### PR TITLE
ARXIVNG-971 added ISO8601JSONEncoder and ISO8601JSONDecoder

### DIFF
--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -120,9 +120,12 @@
     report_num = None,
     version = 1,
     submission_history = [],
-    secondary_categories = []) -%}
+    secondary_categories = [],
+    include_stylesheet = 1) -%}
 
+{% if include_stylesheet %}
 <link rel="stylesheet" type="text/css" href="{{ url_for('base.static', filename='css/abs.css') }}">
+{% endif %}
 <div id="content">
   <div id="abs">
 

--- a/arxiv/util/serialize.py
+++ b/arxiv/util/serialize.py
@@ -1,0 +1,59 @@
+"""Tools for encoding/serializing data."""
+
+from typing import Any, Union, List
+import json
+from datetime import datetime, date
+import dateutil.parser
+
+
+class ISO8601JSONEncoder(json.JSONEncoder):
+    """Renders date and datetime objects as ISO8601 datetime strings."""
+
+    def default(self, obj: Any) -> Union[str, List[Any]]:
+        """Overriden to render date(time)s in isoformat."""
+        try:
+            if isinstance(obj, (date, datetime)):
+                return obj.isoformat()
+            iterable = iter(obj)
+        except TypeError:
+            pass
+        else:
+            return list(iterable)
+        return json.JSONEncoder.default(self, obj)  # type: ignore
+
+
+class ISO8601JSONDecoder(json.JSONDecoder):
+    """Attempts to parse ISO8601 strings as datetime objects."""
+
+    def __init__(self, *args, **kwargs):
+        """Pass :func:`object_hook` to the base constructor."""
+        super(ISO8601JSONDecoder, self).__init__(object_hook=self.object_hook,
+                                                 *args, **kwargs)
+
+    def _try_isoparse(self, value: Any) -> Any:
+        """Attempt to parse a value as an ISO8601 datetime."""
+        if type(value) is not str:
+            return value
+        try:
+            return dateutil.parser.isoparse(value)
+        except ValueError as e:
+            return value
+
+    def object_hook(self, data: dict, **extra) -> Any:
+        """Intercept and coerce ISO8601 strings to datetimes."""
+        for key, value in data.items():
+            if type(value) is list:
+                data[key] = [self._try_isoparse(v) for v in value]
+            else:
+                data[key] = self._try_isoparse(value)
+        return data
+
+
+def dumps(obj: Any) -> str:
+    """Generate JSON from a Python object."""
+    return json.dumps(obj, cls=ISO8601JSONEncoder)
+
+
+def loads(data: str) -> Any:
+    """Load a Python object from JSON."""
+    return json.loads(data, cls=ISO8601JSONDecoder)

--- a/arxiv/util/serialize.py
+++ b/arxiv/util/serialize.py
@@ -25,21 +25,21 @@ class ISO8601JSONEncoder(json.JSONEncoder):
 class ISO8601JSONDecoder(json.JSONDecoder):
     """Attempts to parse ISO8601 strings as datetime objects."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Pass :func:`object_hook` to the base constructor."""
-        super(ISO8601JSONDecoder, self).__init__(object_hook=self.object_hook,
-                                                 *args, **kwargs)
+        kwargs['object_hook'] = kwargs.get('object_hook', self.object_hook)
+        super(ISO8601JSONDecoder, self).__init__(*args, **kwargs)
 
     def _try_isoparse(self, value: Any) -> Any:
         """Attempt to parse a value as an ISO8601 datetime."""
         if type(value) is not str:
             return value
         try:
-            return dateutil.parser.isoparse(value)
+            return dateutil.parser.isoparse(value)  # type: ignore
         except ValueError as e:
             return value
 
-    def object_hook(self, data: dict, **extra) -> Any:
+    def object_hook(self, data: dict, **extra: Any) -> Any:
         """Intercept and coerce ISO8601 strings to datetimes."""
         for key, value in data.items():
             if type(value) is list:

--- a/arxiv/util/tests/test_serialize.py
+++ b/arxiv/util/tests/test_serialize.py
@@ -1,0 +1,128 @@
+"""Tests for :mod:`.serialize`."""
+
+from unittest import TestCase, mock
+from datetime import datetime, date
+from pytz import UTC, timezone
+from .. import serialize
+
+ET = timezone('US/Eastern')
+
+
+class TestISO8601JSONEncoder(TestCase):
+    """
+    Tests :func:`.serialize.dumps` and :class:`.serialize.ISO8601JSONEncoder`.
+    """
+
+    def test_encode_with_date(self):
+        """Encode JSON with a :class:`.date` object."""
+        self.assertEqual(
+            serialize.dumps(date(year=1993, month=11, day=3)),
+            '"1993-11-03"'
+        )
+        self.assertEqual(
+            serialize.dumps({"date": date(year=1993, month=11, day=3)}),
+            '{"date": "1993-11-03"}'
+        )
+        self.assertEqual(
+            serialize.dumps([{"date": date(year=1993, month=11, day=3)}]),
+            '[{"date": "1993-11-03"}]'
+        )
+        self.assertEqual(
+            serialize.dumps([{"date": [date(year=1993, month=11, day=3)]}]),
+            '[{"date": ["1993-11-03"]}]'
+        )
+
+    def test_encode_with_datetime(self):
+        """Encode JSON with a :class:`.datetime` object."""
+        self.assertEqual(
+            serialize.dumps(datetime(year=1993, month=11, day=3)),
+            '"1993-11-03T00:00:00"'
+        )
+        self.assertEqual(
+            serialize.dumps({"date": datetime(year=1993, month=11, day=3)}),
+            '{"date": "1993-11-03T00:00:00"}'
+        )
+        self.assertEqual(
+            serialize.dumps([{"date": datetime(year=1993, month=11, day=3)}]),
+            '[{"date": "1993-11-03T00:00:00"}]'
+        )
+        self.assertEqual(
+            serialize.dumps([{"date": [datetime(year=1993, month=11, day=3)]}]),
+            '[{"date": ["1993-11-03T00:00:00"]}]'
+        )
+
+    def test_encode_with_datetime_tz(self):
+        """Encode JSON with a TZ-aware :class:`.datetime` object."""
+        self.assertEqual(
+            serialize.dumps(datetime(year=1993, month=11, day=3, tzinfo=ET)),
+            '"1993-11-03T00:00:00-04:56"'
+        )
+        self.assertEqual(
+            serialize.dumps({
+                "date": datetime(year=1993, month=11, day=3, tzinfo=ET)
+            }),
+            '{"date": "1993-11-03T00:00:00-04:56"}'
+        )
+        self.assertEqual(
+            serialize.dumps([
+                {"date": datetime(year=1993, month=11, day=3, tzinfo=ET)}
+            ]),
+            '[{"date": "1993-11-03T00:00:00-04:56"}]'
+        )
+        self.assertEqual(
+            serialize.dumps([
+                {"date": [datetime(year=1993, month=11, day=3, tzinfo=ET)]}
+            ]),
+            '[{"date": ["1993-11-03T00:00:00-04:56"]}]'
+        )
+
+
+class TestISO8601JSONDecoder(TestCase):
+    """
+    Tests :func:`.serialize.loads` and :class:`.serialize.ISO8601JSONDecoder`.
+    """
+
+    def test_decode_with_date(self):
+        """Decode JSON with a date value."""
+        self.assertEqual(
+            {"date": datetime(year=1993, month=11, day=3)},
+            serialize.loads('{"date": "1993-11-03"}')
+        )
+        self.assertEqual(
+            [{"date": datetime(year=1993, month=11, day=3)}],
+            serialize.loads('[{"date": "1993-11-03"}]')
+        )
+        self.assertEqual(
+            [{"date": [datetime(year=1993, month=11, day=3)]}],
+            serialize.loads('[{"date": ["1993-11-03"]}]')
+        )
+
+    def test_decode_with_datetime(self):
+        """Decode JSON with a datetime value."""
+        self.assertEqual(
+            {"date": datetime(year=1993, month=11, day=3)},
+            serialize.loads('{"date": "1993-11-03T00:00:00"}')
+        )
+        self.assertEqual(
+            [{"date": datetime(year=1993, month=11, day=3)}],
+            serialize.loads('[{"date": "1993-11-03T00:00:00"}]')
+        )
+        self.assertEqual(
+            [{"date": [datetime(year=1993, month=11, day=3)]}],
+            serialize.loads('[{"date": ["1993-11-03T00:00:00"]}]')
+        )
+
+    def test_encode_with_datetime_tz(self):
+        """Decode JSON with a datetime value."""
+        self.assertEqual(
+            {"date": datetime(year=1993, month=11, day=3, tzinfo=ET)},
+            serialize.loads('{"date": "1993-11-03T00:00:00-04:56"}')
+        )
+        self.assertEqual(
+            [{"date": datetime(year=1993, month=11, day=3, tzinfo=ET)}],
+            serialize.loads('[{"date": "1993-11-03T00:00:00-04:56"}]')
+        )
+        self.assertEqual(
+            [{"date": [datetime(year=1993, month=11, day=3, tzinfo=ET)]}],
+            serialize.loads('[{"date": ["1993-11-03T00:00:00-04:56"]}]')
+        )


### PR DESCRIPTION
Adds ``arxiv.util.serialize.ISO8601JSONEncoder`` and ``.ISO8601JSONDecoder``, and convenience functions ``.loads`` and ``.dumps``.  For background on JSON encoders/decoders, see https://docs.python.org/3/library/json.html#encoders-and-decoders. 