### PR TITLE
ARXIVNG-250 Linkification in abs view should not choke on parentheses

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ uwsgi = "*"
 "boto3" = "*"
 wtforms = "*"
 "e1839a8" = {path = "."}
+bleach = "*"
 
 [dev-packages]
 pydocstyle = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f93094719c81d6aecd570ac0150c6cfacd57b92b9615f315b890ccccabdcd251"
+            "sha256": "1092b19475dfe494d65dfc1237108d9d20a95c09ef93956f632e89a24ce89888"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,20 +14,28 @@
         ]
     },
     "default": {
-        "boto3": {
+        "bleach": {
             "hashes": [
-                "sha256:0aef5adf904638bf9bc053efaf182d8dc8647d72d9d7974173b77eab29f67254",
-                "sha256:90911996038f88f90eef8d55689c4c4843daec94a48b56aba4b3399306dd4f2a"
+                "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
+                "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"
             ],
             "index": "pypi",
-            "version": "==1.9.66"
+            "version": "==3.1.0"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:122603b00f8c458236d1bd09850bdea56fc45f271e75ca38e66dbce37f72cada",
+                "sha256:99ec19dc4f0aa8a8354db7baebe1ff57bd18aeb6a539b28693b2e8ca8dc3d85b"
+            ],
+            "index": "pypi",
+            "version": "==1.9.80"
         },
         "botocore": {
             "hashes": [
-                "sha256:25c39ecc71356287cf79d66981ec77deca374e28043b19b2f818d48aa34272a1",
-                "sha256:419e1a6a1829c49c7aad30efc1e4a9435ad36573ca6a14d94940e7f302aa234a"
+                "sha256:76a2969278250e010253ddf514f4b54eaa7d2b1430f682874c3c2ab92f25a96d",
+                "sha256:8c579bac9abeaff1270a7a25964b01d3db1367f42fa5f826e1303ec8a4b13cef"
             ],
-            "version": "==1.12.66"
+            "version": "==1.12.80"
         },
         "click": {
             "hashes": [
@@ -127,11 +135,11 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
-                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
             ],
             "index": "pypi",
-            "version": "==2018.7"
+            "version": "==2018.9"
         },
         "s3transfer": {
             "hashes": [
@@ -161,6 +169,13 @@
             ],
             "index": "pypi",
             "version": "==2.0.17.1"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
         },
         "werkzeug": {
             "hashes": [
@@ -277,12 +292,12 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:0dc026a7b2861a8c02764a0a1f33e7d1fc2f6a5cd395285fde0baf10d3dc3b24",
-                "sha256:2f73a9e4974acbbe1530a662e55c77fb368a240590f468c3a0cea61669143b37",
-                "sha256:fbca61297dcb454af7ea1b7e32ca5438562e9eba6b5ab7dda4ce4bed7d354fc3"
+                "sha256:77cfa1e9e83f79766c782dd20c7dea122c3a6999c6053f1734f07db9b100165c",
+                "sha256:954c60a7c43e15bac4ec1eb9efa1e752442a88c699529497b4fe14893ea554cc",
+                "sha256:dce74cd793af2f981b34702435259cb2fe43268ab3f73a345da1c39b8a9ab175"
             ],
             "index": "pypi",
-            "version": "==3.83.2"
+            "version": "==4.0.1"
         },
         "idna": {
             "hashes": [
@@ -389,11 +404,11 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:12d965c9c4e8a625673aec493162cf390e66de12ef176b1f4821ac00d55f3ab3",
-                "sha256:38d5b5f835a81817dcc0af8d155bce4e9aefa03794fe32ed154d6612e83feafa"
+                "sha256:986a7f97808a865405c5fd98fae5ebfa963c31520a56c783df159e9a81e41b3e",
+                "sha256:cc5df73cc11d35655a8c364f45d07b13c8db82c000def4bd7721be13356533b4"
             ],
             "index": "pypi",
-            "version": "==0.650"
+            "version": "==0.660"
         },
         "mypy-extensions": {
             "hashes": [
@@ -442,18 +457,18 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b",
-                "sha256:f353aab21fd474459d97b709e527b5571314ee5f067441dc9f88e33eecd96592"
+                "sha256:66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a",
+                "sha256:f6c5ef0d7480ad048c054c37632c67fca55299990fff127850181659eea33fc3"
             ],
-            "version": "==2.3.0"
+            "version": "==2.3.1"
         },
         "pytz": {
             "hashes": [
-                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
-                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
             ],
             "index": "pypi",
-            "version": "==2018.7"
+            "version": "==2018.9"
         },
         "requests": {
             "hashes": [
@@ -478,19 +493,19 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:120732cbddb1b2364471c3d9f8bfd4b0c5b550862f99a65736c77f970b142aea",
-                "sha256:b348790776490894e0424101af9c8413f2a86831524bd55c5f379d3e3e12ca64"
+                "sha256:429e3172466df289f0f742471d7e30ba3ee11f3b5aecd9a840480d03f14bcfe5",
+                "sha256:c4cb17ba44acffae3d3209646b6baec1e215cad3065e852c68cc569d4df1b9f8"
             ],
             "index": "pypi",
-            "version": "==1.8.2"
+            "version": "==1.8.3"
         },
         "sphinx-autodoc-typehints": {
             "hashes": [
-                "sha256:9f546fa18ee6bfb17f5cf937805d3c8afea48b976050db0bd14bb463eee97888",
-                "sha256:adfa4712e77c795522574ce644e084cded2f6e796a59d37e7f1cb98287687100"
+                "sha256:19fe0b426b7c008181f67f816060da7f046bd8a42723f67a685d26d875bcefd7",
+                "sha256:f9c06acfec80766fe8f542a6d6a042e751fcf6ce2e2711a7dc00d8b6daf8aa36"
             ],
             "index": "pypi",
-            "version": "==1.5.2"
+            "version": "==1.6.0"
         },
         "sphinxcontrib-websupport": {
             "hashes": [
@@ -502,32 +517,29 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:0948004fa228ae071054f5208840a1e88747a357ec1101c17217bfe99b299d58",
-                "sha256:10703d3cec8dcd9eef5a630a04056bbc898abc19bac5691612acba7d1325b66d",
-                "sha256:1f6c4bd0bdc0f14246fd41262df7dfc018d65bb05f6e16390b7ea26ca454a291",
-                "sha256:25d8feefe27eb0303b73545416b13d108c6067b846b543738a25ff304824ed9a",
-                "sha256:29464a177d56e4e055b5f7b629935af7f49c196be47528cc94e0a7bf83fbc2b9",
-                "sha256:2e214b72168ea0275efd6c884b114ab42e316de3ffa125b267e732ed2abda892",
-                "sha256:3e0d5e48e3a23e9a4d1a9f698e32a542a4a288c871d33ed8df1b092a40f3a0f9",
-                "sha256:519425deca5c2b2bdac49f77b2c5625781abbaf9a809d727d3a5596b30bb4ded",
-                "sha256:57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa",
-                "sha256:668d0cec391d9aed1c6a388b0d5b97cd22e6073eaa5fbaa6d2946603b4871efe",
-                "sha256:68ba70684990f59497680ff90d18e756a47bf4863c604098f10de9716b2c0bdd",
-                "sha256:6de012d2b166fe7a4cdf505eee3aaa12192f7ba365beeefaca4ec10e31241a85",
-                "sha256:79b91ebe5a28d349b6d0d323023350133e927b4de5b651a8aa2db69c761420c6",
-                "sha256:8550177fa5d4c1f09b5e5f524411c44633c80ec69b24e0e98906dd761941ca46",
-                "sha256:898f818399cafcdb93cbbe15fc83a33d05f18e29fb498ddc09b0214cdfc7cd51",
-                "sha256:94b091dc0f19291adcb279a108f5d38de2430411068b219f41b343c03b28fb1f",
-                "sha256:a26863198902cda15ab4503991e8cf1ca874219e0118cbf07c126bce7c4db129",
-                "sha256:a8034021801bc0440f2e027c354b4eafd95891b573e12ff0418dec385c76785c",
-                "sha256:bc978ac17468fe868ee589c795d06777f75496b1ed576d308002c8a5756fb9ea",
-                "sha256:c05b41bc1deade9f90ddc5d988fe506208019ebba9f2578c622516fd201f5863",
-                "sha256:c9b060bd1e5a26ab6e8267fd46fc9e02b54eb15fffb16d112d4c7b1c12987559",
-                "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
-                "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
+                "sha256:023625bfa9359e29bd6e24cac2a4503495b49761d48a5f1e38333fc4ac4d93fe",
+                "sha256:07591f7a5fdff50e2e566c4c1e9df545c75d21e27d98d18cb405727ed0ef329c",
+                "sha256:153e526b0f4ffbfada72d0bb5ffe8574ba02803d2f3a9c605c8cf99dfedd72a2",
+                "sha256:3ad2bdcd46a4a1518d7376e9f5016d17718a9ed3c6a3f09203d832f6c165de4a",
+                "sha256:3ea98c84df53ada97ee1c5159bb3bc784bd734231235a1ede14c8ae0775049f7",
+                "sha256:51a7141ccd076fa561af107cfb7a8b6d06a008d92451a1ac7e73149d18e9a827",
+                "sha256:52c93cd10e6c24e7ac97e8615da9f224fd75c61770515cb323316c30830ddb33",
+                "sha256:6344c84baeda3d7b33e157f0b292e4dd53d05ddb57a63f738178c01cac4635c9",
+                "sha256:64699ca1b3bd5070bdeb043e6d43bc1d0cebe08008548f4a6bee782b0ecce032",
+                "sha256:74903f2e56bbffe29282ef8a5487d207d10be0f8513b41aff787d954a4cf91c9",
+                "sha256:7891710dba83c29ee2bd51ecaa82f60f6bede40271af781110c08be134207bf2",
+                "sha256:91976c56224e26c256a0de0f76d2004ab885a29423737684b4f7ebdd2f46dde2",
+                "sha256:9bad678a576ecc71f25eba9f1e3fd8d01c28c12a2834850b458428b3e855f062",
+                "sha256:b4726339a4c180a8b6ad9d8b50d2b6dc247e1b79b38fe2290549c98e82e4fd15",
+                "sha256:ba36f6aa3f8933edf94ea35826daf92cbb3ec248b89eccdc053d4a815d285357",
+                "sha256:bbc96bde544fd19e9ef168e4dfa5c3dfe704bfa78128fa76f361d64d6b0f731a",
+                "sha256:c0c927f1e44469056f7f2dada266c79b577da378bbde3f6d2ada726d131e4824",
+                "sha256:c0f9a3708008aa59f560fa1bd22385e05b79b8e38e0721a15a8402b089243442",
+                "sha256:f0bf6f36ff9c5643004171f11d2fdc745aa3953c5aacf2536a0685db9ceb3fb1",
+                "sha256:f5be39a0146be663cbf210a4d95c3c58b2d7df7b043c9047c5448e358f0550a2",
+                "sha256:fcd198bf19d9213e5cbf2cde2b9ef20a9856e716f76f9476157f90ae6de06cc6"
             ],
-            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
-            "version": "==1.1.0"
+            "version": "==1.2.0"
         },
         "urllib3": {
             "hashes": [
@@ -539,9 +551,9 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:d4d560d479f2c21e1b5443bbd15fe7ec4b37fe7e53d335d3b9b0a7b1226fe3c6"
+                "sha256:e03f19f64d81d0a3099518ca26b04550026f131eced2e76ced7b85c6b8d32128"
             ],
-            "version": "==1.10.11"
+            "version": "==1.11.0"
         }
     }
 }

--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -135,7 +135,8 @@ def _add_rel_external(attrs: Mapping, new: bool = False) -> Mapping:
         attrs[(None, 'rel')] = 'external'
         attrs['_text'] = f'this {o.scheme} URL'    # Replaces the link text.
         _extend_class_attr(attrs, 'link-external')
-    elif (None, 'data-arxiv') not in attrs and (None, 'data-doi') not in attrs:
+    elif (None, 'data-arxiv-id') not in attrs \
+            and (None, 'data-doi') not in attrs:
         attrs['_text'] = f'this {o.scheme} URL'    # Replaces the link text.
         _extend_class_attr(attrs, 'link-internal')
     return attrs
@@ -170,7 +171,7 @@ def _handle_arxiv_url(attrs: Mapping, new: bool = False) -> Mapping:
     if ARXIV_ID.match(target):
         attrs[(None, 'href')] = arxiv_id_to_url(target)
         attrs['_text'] = f'{prefix}{target}'
-        attrs[(None, 'data-arxiv')] = target     # Add arxiv="<arxiv id>"
+        attrs[(None, 'data-arxiv-id')] = target     # Add arxiv="<arxiv id>"
     return attrs
 
 

--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -1,16 +1,12 @@
 r"""
 Patterns and functions to detect arXiv ids and Urls in text.
 
-Functions to detech arXiv ids, URLs and DOI in text.
+Functions to detect arXiv ids, URLs and DOI in text.
 Functions to transform them to <a> tags.
 
 These were originally jinja filters but became a little too big
 for that so they were split out and made more general so they didn't
 rely on the Flask context.
-
-These all use expect input of Markup or non-markup text and return
-Markup objects. This is because the <a> that get added need to avoid
-double escaping.
 
 There are several classes of patterns we want to match but there is
 some overlap in these patterns. To avoid looking for and parsing HTML in each
@@ -28,6 +24,11 @@ interupting once one is found.
 
 We should probably match DOIs first because they are the source of a
 lot of false positives for arxiv matches.
+
+Updated 18 January, 2019: refactored to combine arXiv + DOI regexes with URL
+matching and link generation provided by `bleach
+<https://bleach.readthedocs.io>`_. The bleach URL regex is extended a bit to
+handle FTP addresses.
 """
 from typing import Optional, List, Pattern, Match, Tuple, Callable, \
     NamedTuple, Dict, Union, Mapping
@@ -42,31 +43,15 @@ import bleach
 from arxiv import identifier
 from . import clickthrough
 
-
-class Matchable(NamedTuple):
-    """Class for paterns."""
-
-    examples: List[str]
-    pattern: Pattern
+Callback = Callable[[Mapping, bool], Mapping]
 
 
-Izer = Callable[[str], str]
-Substituter = Callable[[Match, Izer],
-                       Tuple[Union[Markup, str], Union[Markup, str]]]
-URLType = Tuple[List[Matchable], Substituter, Izer]
-
-
-def _identity(x: str) -> str:
-    """Identity funciton for default in some places."""
-    return x
-
-
-DOI = re.compile(r'(?P<doi>10.\d{4,9}/[-._;()/:A-Z0-9]+)', re.I)
-doi_patterns = [
-    Matchable(['10.1145/0001234.1234567'], DOI)
-]
+DOI = re.compile(   # '10.1145/0001234.1234567'
+    r'(?P<doi>10.\d{4,9}/[-._;()/:A-Z0-9]+)',
+    re.I
+)
 """
-List of Matchable for DOIs in text.
+Pattern for matching DOIs.
 
 We should probably match DOIs first because they are the source of a
 lot of false positives for arxiv matches.
@@ -75,187 +60,45 @@ Only using the most general express from
 https://www.crossref.org/blog/dois-and-matching-regular-expressions/
 """
 
-basic_arxiv_id_patterns = [
-    Matchable(['math/0501233', 'hep-ph/0611734', 'gr-qc/0112123'],
-              identifier.OLD_STYLE_WITH_ARCHIVE),
-    Matchable(['math.GR/0601136v3', 'math.GR/0601136'],
-              identifier.OLD_STYLE_WITH_CATEGORY),
-    Matchable(['1609.05068', '1207.1234v1', '1207.1234', '1807.12345',
-               '1807.12345v1', '1807.12345v12'],
-              identifier.STANDARD)
+ARXIV_PATTERNS = [
+    identifier.OLD_STYLE_WITH_ARCHIVE,  # math/0501233 hep-ph/0611734
+    identifier.OLD_STYLE_WITH_CATEGORY,  # math.GR/0601136v3 math.GR/0601136
+    identifier.STANDARD  # 1609.05068 1207.1234v1 1207.1234 1807.12345v12
 ]
 ARXIV_ID = re.compile(
-    rf"""(?:{identifier.OLD_STYLE_WITH_ARCHIVE.pattern})
-            | (?:{identifier.OLD_STYLE_WITH_CATEGORY.pattern})
-            | (?:{identifier.STANDARD.pattern})""",
+    "|".join([rf"(?:{pattern.pattern})" for pattern in ARXIV_PATTERNS]),
     re.IGNORECASE | re.VERBOSE | re.UNICODE
 )
 
 OKCHARS = r'([a-z0-9,_.\-+~:]|%[a-f0-9]*)'
 """Chacters that are acceptable during PATH, QUERY and ANCHOR parts"""
 
-HOST_NAME = r'(?:[a-z0-9][a-z0-9\-.:]+[a-z0-9])'
-"""Regex used to match host names in arXiv urlize.
-
-This is not a perfect regex for a host name, It accepts only a sub-set
-of hostnames to meet the needs of arxiv.
-
-HOST_NAME must end with a simplified character to avoid capturing a
-period.
-"""
-
 PATH = rf'(?P<PATH>(/{OKCHARS}*)+)?'
 """Regex for path part of URLs for use in urlize"""
-
-QUERY = rf'(?P<QUERY>\?(&?({OKCHARS}*(={OKCHARS}*)?))*)?'
-"""Regex for query part of URLs for use in urlize"""
-
-ANCHOR = rf'(?P<ANCHOR>#({OKCHARS}|/)*)?'
-"""Regex for anchor part of URLs for use in urlize"""
-
-URLINTEXT_PAT = re.compile(r'(?P<url>(?:https?://)'
-                           f'{HOST_NAME}{PATH}{QUERY}{ANCHOR})',
-                           re.I)
-"""Regex to match URLs in text."""
 
 FTP = re.compile(rf'(?P<url>(?:ftp://)({OKCHARS}|(@))*{PATH})', re.I)
 """Regex to match FTP URLs in text."""
 
-basic_url_patterns = [
-    Matchable(['http://something.com/bla'], URLINTEXT_PAT),
-    Matchable(['ftp://something.com/bla'], FTP)
-]
-"""List of Matchable to use when finding URLs in text"""
+IP_ADDRESS = (r'(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}'
+              r'(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)')
+"""Regex to match an IP address."""
 
-bad_arxiv_id_patterns = [
-    re.compile('vixra', re.I),  # don't need to link to vixra
-]
-"""List of Regex patterns that will cause matching to be skipped for
-the token."""
-
-dois_ids_and_urls = basic_url_patterns + doi_patterns + basic_arxiv_id_patterns
-"""
-List of Matchable to use when finding DOIs, arXiv IDs, and URLs.
-
-URLs are first because some URLs contain DOIs or arXiv IDS.
-
-DOI are before arXiv ids because many DOIs are falsely matched by the
-arxiv_id patterns.
-"""
-
-
-_bad_endings = ['.', ',', ':', ';', '&', '(', '[', '{']
-"""These should not appear at the end of URLs because they are likely
-part of the surrounding text"""
-
-
-def _find_match(patterns: List[Matchable], token: str) \
-        -> Optional[Tuple[Match, Matchable]]:
-    """Find first in patterns that is found in txt."""
-    for chgMtch in patterns:
-        if chgMtch.pattern.flags:
-            fnd = re.search(chgMtch.pattern, token)
-        else:
-            fnd = re.search(chgMtch.pattern, token, re.I)
-        if fnd is not None:
-            return (fnd, chgMtch)
-    return None
-
-
-def _transform_token(targets: Tuple[str, List[str], Substituter, Izer],
-                     bad_patterns: List[Pattern], token: str) -> str:
-    """
-    Transform a token from text to one of the Matchables.
-
-    This only transforms against the first of Matchable matched.
-    Matching on this token will be skipped if any of the bad_patterns
-    match the token (that is re.search).
-    """
-    for pattern in bad_patterns:
-        if re.search(pattern, token):
-            return token
-
-    patterns = [p for _, ptns, _, _ in targets for p in ptns]    # type: ignore
-    mtch = _find_match(patterns, token)
-    if mtch is None:
-        return token
-
-    (match, _) = mtch
-    keys = match.groupdict().keys()
-    target_match = False
-    for target_type, _, substituter, izer in targets:   # type: ignore
-        if target_type in keys:
-            (front, back) = substituter(match, izer)
-            target_match = True
-            break
-    # If no substituters apply, there is nothing more to do.
-    if not target_match:    # But this would be an odd case...
-        return token
-
-    if back:
-        t_back = _transform_token(targets, bad_patterns, back)
-        return front + Markup(t_back)   # type: ignore
-    else:
-        return front       # type: ignore
-
-
-def id_substituter(match: Match, id_to_url: Izer) -> Tuple[Markup, str]:
-    """Return match.string transformed for a arxiv id match."""
-    aid = match.group('arxiv_id')
-    prefix = 'arXiv:' if match.group('arxiv_prefix') else ''
-
-    if aid[-1] in _bad_endings:
-        arxiv_url = id_to_url(aid)[:-1]
-        anchor = aid[:-1]
-        back = aid[-1] + match.string[match.end():]
-    else:
-        arxiv_url = id_to_url(aid)
-        anchor = prefix + aid
-        back = match.string[match.end():]
-
-    front = match.string[0:match.start()]
-    return (Markup(f'{front}<a href="{arxiv_url}">{anchor}</a>'), back)
-
-
-def doi_substituter(match: Match, url_for_doi: Izer) -> Tuple[Markup, str]:
-    """Return match.string transformed for a DOI match."""
-    doi = match.group('doi')
-    if(doi[-1] in _bad_endings):
-        back = match.string[match.end():] + doi[-1]
-        doi = doi[:-1]
-    else:
-        back = match.string[match.end():]
-
-    doi_url = url_for_doi(doi)
-
-    anchor = escape(doi)
-    front = match.string[0:match.start()]
-    return (Markup(f'{front}<a href="{doi_url}">{anchor}</a>'), back)
-
-
-_word_split_re = re.compile(r'(\s+)')
-"""Regex to split to tokens during _to_tags.
-
-Capturing group causes the splitting spaces to be included
-in the returned list.
-"""
-
-
-def _to_tags(targets: Tuple[str, List[str], Substituter, Izer],
-             bad_patterns: List[Pattern], text: str)-> str:
-    """Split text to tokens, do _transform_token for each, return results."""
-    transform_token = partial(_transform_token, targets, bad_patterns)
-
-    if not hasattr(text, '__html__'):
-        text = Markup(escape(text))
-
-    words = _word_split_re.split(text)
-    for i, token in enumerate(words):
-        token_2 = transform_token(token)
-        if token_2 != token:
-            words[i] = token_2
-    result = u''.join(words)
-    return Markup(result)
+TLDS = '|'.join(bleach.linkifier.TLDS)
+PROTOCOLS = '|'.join(bleach.linkifier.html5lib_shim.allowed_protocols)
+URL = re.compile(
+    rf"""(?:{FTP.pattern})|
+    (?:\(*  # Match any opening parentheses.
+    \b(?<![@/])(?:(?:{PROTOCOLS}):/{{0,3}}(?:(?:\w+:)?\w+@)?)?  # http://
+    (?:
+        (?:([\w-]+\.)+(?:{TLDS}))   # Conventional URL
+        |(?:{IP_ADDRESS})           # IP address
+    )(?:\:[0-9]+)?(?!\.\w)\b        # Port
+    (?:[/?][^\s\{{\}}\|\\\^\[\]`<>"]*)?)
+        # /path/zz (excluding "unsafe" chars from RFC 1738,
+        # except for # and ~, which happen in practice)
+    """,
+    re.IGNORECASE | re.VERBOSE | re.UNICODE
+)
 
 
 def arxiv_id_to_url(arxiv_id: str) -> str:
@@ -275,33 +118,33 @@ def clickthrough_url_for_doi(doi: str) -> str:
     return clickthrough.clickthrough_url(url_for_doi(doi))
 
 
-def extend_class_attr(attrs: Mapping, new_class: str) -> Mapping:
+def _extend_class_attr(attrs: Mapping, new_class: str) -> Mapping:
     if (None, 'class') not in attrs:
         attrs[(None, 'class')] = ''
     attrs[(None, 'class')] = (attrs[(None, 'class')] + f' {new_class}').strip()
 
 
-def add_rel_external(attrs: Mapping, new: bool = False) -> Mapping:
+def _add_rel_external(attrs: Mapping, new: bool = False) -> Mapping:
     o = urlparse(attrs[(None, 'href')])
     if not o.netloc.split(':')[0].endswith('arxiv.org'):   # External link?
         attrs[(None, 'rel')] = 'external'
         attrs['_text'] = f'this {o.scheme} URL'    # Replaces the link text.
-        extend_class_attr(attrs, 'link-external')
+        _extend_class_attr(attrs, 'link-external')
     elif (None, 'arxiv') not in attrs and (None, 'doi') not in attrs:
         attrs['_text'] = f'this {o.scheme} URL'    # Replaces the link text.
-        extend_class_attr(attrs, 'link-internal')
+        _extend_class_attr(attrs, 'link-internal')
     return attrs
 
 
-def add_scheme_info(attrs: Mapping, new: bool = False) -> Mapping:
+def _add_scheme_info(attrs: Mapping, new: bool = False) -> Mapping:
     o = urlparse(attrs[(None, 'href')])
     if (None, 'class') not in attrs:
         attrs[(None, 'class')] = ''
-    extend_class_attr(attrs, f'link-{o.scheme}')
+    _extend_class_attr(attrs, f'link-{o.scheme}')
     return attrs
 
 
-def handle_arxiv_url(attrs: Mapping, new: bool = False) -> Mapping:
+def _handle_arxiv_url(attrs: Mapping, new: bool = False) -> Mapping:
     """
     Screen for reference to an arXiv e-print, and generate URL.
 
@@ -326,9 +169,9 @@ def handle_arxiv_url(attrs: Mapping, new: bool = False) -> Mapping:
     return attrs
 
 
-def handle_doi_url(attrs: Mapping, new: bool = False) -> Mapping:
+def _handle_doi_url(attrs: Mapping, new: bool = False) -> Mapping:
     """
-    Screen for reference to an DOIs, and generate URL.
+    Screen for reference to a DOI, and generate a URL.
 
     If the :ref:`.DOI` pattern is used, it will generate a link with the
     doi as a the target. We need to intercept these links, and generate
@@ -344,42 +187,12 @@ def handle_doi_url(attrs: Mapping, new: bool = False) -> Mapping:
     else:
         target = href
         prefix = ''
-    print(target, DOI.match(target), DOI.search(target))
     if DOI.match(target):
         attrs[(None, 'href')] = clickthrough_url_for_doi(target)
         attrs['_text'] = f'{prefix}{target}'
         attrs[(None, 'doi')] = target     # Add arxiv="<arxiv id>"
     return attrs
 
-
-
-REGEX_URL_KINDS: Dict[str, URLType] = {
-    # 'url': (basic_url_patterns, url_substituter, _identity),
-    'arxiv_id': (basic_arxiv_id_patterns, id_substituter, arxiv_id_to_url),
-    'doi': (doi_patterns, doi_substituter, clickthrough_url_for_doi),
-}
-
-IP_ADDRESS = r'[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
-
-
-# TODO: incorporate DOI into this regex, optionally; use callbacks to detect
-# things that need clickthrough URLs. Consider even doing arXiv IDs this way.
-TLDS = '|'.join(bleach.linkifier.TLDS)
-PROTOCOLS = '|'.join(bleach.linkifier.html5lib_shim.allowed_protocols)
-URL = re.compile(
-    rf"""(?:{FTP.pattern})|
-    (?:\(*  # Match any opening parentheses.
-    \b(?<![@/])(?:(?:{PROTOCOLS}):/{{0,3}}(?:(?:\w+:)?\w+@)?)?  # http://
-    (?:
-        (?:([\w-]+\.)+(?:{TLDS}))   # Conventional URL
-        |(?:{IP_ADDRESS})           # IP address
-    )(?:\:[0-9]+)?(?!\.\w)\b        # Port
-    (?:[/?][^\s\{{\}}\|\\\^\[\]`<>"]*)?)
-        # /path/zz (excluding "unsafe" chars from RFC 1738,
-        # except for # and ~, which happen in practice)
-    """,
-    re.IGNORECASE | re.VERBOSE | re.UNICODE
-)
 
 PATTERNS = {
     'doi': DOI,
@@ -388,6 +201,14 @@ PATTERNS = {
 }
 ORDER = ['arxiv_id', 'doi', 'url']
 SUPPORTED_KINDS = ORDER
+"""Identifier types that we can currently match and convert to to URLs."""
+
+DEFAULT_CALLBACKS = [
+    _handle_doi_url,
+    _handle_arxiv_url,
+    _add_rel_external,
+    _add_scheme_info
+]
 
 
 def _get_pattern(kinds: List[str]) -> Pattern:
@@ -398,18 +219,51 @@ def _get_pattern(kinds: List[str]) -> Pattern:
     )
 
 
-def _get_linker(kinds: List[str]) -> Callable[[str], str]:
+def _get_linker(kinds: List[str],
+                callbacks: List[Callback] = DEFAULT_CALLBACKS) \
+        -> Callable[[str], str]:
     return bleach.linkifier.Linker(
-        callbacks=[handle_doi_url, handle_arxiv_url, add_rel_external, add_scheme_info],
+        callbacks=callbacks,
         skip_tags=['a'],
         url_re=_get_pattern(kinds)
     ).linkify
 
 
 def urlize(text: str, kinds: List[str] = SUPPORTED_KINDS) -> str:
-    """Convert URLs and certain identifiers to links."""
+    """
+    Convert URLs and certain identifiers to HTML links.
+
+    Parameters
+    ----------
+    text : str
+        Some text containing identifiers and/or URLs.
+    kinds : list
+        Names (from :ref:`SUPPORTED_KINDS`) of identifiers to match.
+
+    Returns
+    -------
+    str
+        The passed text, with identifiers and/or URLs converted to HTML links.
+
+    """
     return _get_linker(kinds)(text)
 
 
-def urlizer(kinds: List[str] = SUPPORTED_KINDS):
+def urlizer(kinds: List[str] = SUPPORTED_KINDS) -> Callable[[str], str]:
+    """
+    Generate a function to convert tokens to links.
+
+    Parameters
+    ----------
+    kinds : list
+        Names (from :ref:`SUPPORTED_KINDS`) of identifiers to match and
+        convert.
+
+    Returns
+    -------
+    callable
+        A function with signature ``(str) -> str`` that converts identifiers
+        to HTML links.
+
+    """
     return _get_linker(kinds)

--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -135,7 +135,7 @@ def _add_rel_external(attrs: Mapping, new: bool = False) -> Mapping:
         attrs[(None, 'rel')] = 'external'
         attrs['_text'] = f'this {o.scheme} URL'    # Replaces the link text.
         _extend_class_attr(attrs, 'link-external')
-    elif (None, 'arxiv') not in attrs and (None, 'doi') not in attrs:
+    elif (None, 'data-arxiv') not in attrs and (None, 'data-doi') not in attrs:
         attrs['_text'] = f'this {o.scheme} URL'    # Replaces the link text.
         _extend_class_attr(attrs, 'link-internal')
     return attrs
@@ -170,7 +170,7 @@ def _handle_arxiv_url(attrs: Mapping, new: bool = False) -> Mapping:
     if ARXIV_ID.match(target):
         attrs[(None, 'href')] = arxiv_id_to_url(target)
         attrs['_text'] = f'{prefix}{target}'
-        attrs[(None, 'arxiv')] = target     # Add arxiv="<arxiv id>"
+        attrs[(None, 'data-arxiv')] = target     # Add arxiv="<arxiv id>"
     return attrs
 
 
@@ -195,7 +195,7 @@ def _handle_doi_url(attrs: Mapping, new: bool = False) -> Mapping:
     if DOI.match(target):
         attrs[(None, 'href')] = clickthrough_url_for_doi(target)
         attrs['_text'] = f'{prefix}{target}'
-        attrs[(None, 'doi')] = target     # Add arxiv="<arxiv id>"
+        attrs[(None, 'data-doi')] = target     # Add arxiv="<arxiv id>"
     return attrs
 
 

--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -46,6 +46,10 @@ from . import clickthrough
 Callback = Callable[[Mapping, bool], Mapping]
 
 
+def _without_group_names(pattern: Pattern) -> str:
+    return re.sub(r'\(\?P<[^>\!]+>', '(?:', pattern.pattern)
+
+
 DOI = re.compile(   # '10.1145/0001234.1234567'
     r'(?P<doi>10.\d{4,9}/[-._;()/:A-Z0-9]+)',
     re.I
@@ -66,7 +70,8 @@ ARXIV_PATTERNS = [
     identifier.STANDARD  # 1609.05068 1207.1234v1 1207.1234 1807.12345v12
 ]
 ARXIV_ID = re.compile(
-    "|".join([rf"(?:{pattern.pattern})" for pattern in ARXIV_PATTERNS]),
+    "|".join([rf"(?:{_without_group_names(pattern)})"
+              for pattern in ARXIV_PATTERNS]),
     re.IGNORECASE | re.VERBOSE | re.UNICODE
 )
 

--- a/arxiv/base/urls/tests/test_urlize.py
+++ b/arxiv/base/urls/tests/test_urlize.py
@@ -60,14 +60,6 @@ class TestURLize(unittest.TestCase):
             'here is a rando doi doi:<a class="link-http" doi="10.1109/5.771073" href="http://arxiv.org/clickthrough?url=https://dx.doi.org/10.1109/5.771073">10.1109/5.771073</a> that needs a link'
         )
 
-    @mock.patch(f'{links.__name__}.clickthrough')
-    def test_interesting_doi(self, mock_clickthrough):
-        mock_clickthrough.clickthrough_url = lambda url: f'http://arxiv.org/clickthrough?url={url}'
-        self.assertEqual(
-            links.urlize('here is a doi that we didn not expect 1721.1/107045'),
-            'here is a doi that we didn not expect <a class="link-http" doi="1721.1/107045" href="http://arxiv.org/clickthrough?url=https://dx.doi.org/1721.1/107045">1721.1/107045</a>'
-        )
-
     def test_transform_token(self):
         # def doi_id_url_transform_token(tkn,fn):
         #     return doi_id_url_transform_token(fn, tkn)

--- a/arxiv/base/urls/tests/test_urlize.py
+++ b/arxiv/base/urls/tests/test_urlize.py
@@ -57,7 +57,7 @@ class TestURLize(unittest.TestCase):
         mock_clickthrough.clickthrough_url = lambda url: f'http://arxiv.org/clickthrough?url={url}'
         self.assertEqual(
             links.urlize('here is a rando doi doi:10.1109/5.771073 that needs a link'),
-            'here is a rando doi doi:<a class="link-http" doi="10.1109/5.771073" href="http://arxiv.org/clickthrough?url=https://dx.doi.org/10.1109/5.771073">10.1109/5.771073</a> that needs a link'
+            'here is a rando doi doi:<a class="link-http" data-doi="10.1109/5.771073" href="http://arxiv.org/clickthrough?url=https://dx.doi.org/10.1109/5.771073">10.1109/5.771073</a> that needs a link'
         )
 
     def test_transform_token(self):
@@ -138,7 +138,7 @@ class TestURLize(unittest.TestCase):
 
         self.assertEqual(
             links.urlize('cond-mat/97063007'),
-            '<a arxiv="cond-mat/9706300" class="link-https" href="https://arxiv.org/abs/cond-mat/9706300">cond-mat/9706300</a>7',
+            '<a class="link-https" data-arxiv="cond-mat/9706300" href="https://arxiv.org/abs/cond-mat/9706300">cond-mat/9706300</a>7',
             'urlize (should match) 7/9')
 
         self.assertEqual(
@@ -189,7 +189,7 @@ class TestURLize(unittest.TestCase):
     def test_category_id(self):
         self.assertEqual(
             links.urlize('version of arXiv.math.GR/0512484 (2011).', ['arxiv_id']),
-            'version of arXiv.<a arxiv="math.GR/0512484" class="link-https" href="https://arxiv.org/abs/math.GR/0512484">math.GR/0512484</a> (2011).'
+            'version of arXiv.<a class="link-https" data-arxiv="math.GR/0512484" href="https://arxiv.org/abs/math.GR/0512484">math.GR/0512484</a> (2011).'
         )
 
     @mock.patch(f'{links.__name__}.url_for', mock_url_for)
@@ -239,5 +239,5 @@ class TestURLize(unittest.TestCase):
     def test_arxiv_prefix(self):
         self.assertEqual(
             links.urlize("see arxiv:1201.12345"),
-            'see <a arxiv="1201.12345" class="link-https" href="https://arxiv.org/abs/1201.12345">arXiv:1201.12345</a>'
+            'see <a class="link-https" data-arxiv="1201.12345" href="https://arxiv.org/abs/1201.12345">arXiv:1201.12345</a>'
         )

--- a/arxiv/base/urls/tests/test_urlize.py
+++ b/arxiv/base/urls/tests/test_urlize.py
@@ -138,7 +138,7 @@ class TestURLize(unittest.TestCase):
 
         self.assertEqual(
             links.urlize('cond-mat/97063007'),
-            '<a class="link-https" data-arxiv="cond-mat/9706300" href="https://arxiv.org/abs/cond-mat/9706300">cond-mat/9706300</a>7',
+            '<a class="link-https" data-arxiv-id="cond-mat/9706300" href="https://arxiv.org/abs/cond-mat/9706300">cond-mat/9706300</a>7',
             'urlize (should match) 7/9')
 
         self.assertEqual(
@@ -189,7 +189,7 @@ class TestURLize(unittest.TestCase):
     def test_category_id(self):
         self.assertEqual(
             links.urlize('version of arXiv.math.GR/0512484 (2011).', ['arxiv_id']),
-            'version of arXiv.<a class="link-https" data-arxiv="math.GR/0512484" href="https://arxiv.org/abs/math.GR/0512484">math.GR/0512484</a> (2011).'
+            'version of arXiv.<a class="link-https" data-arxiv-id="math.GR/0512484" href="https://arxiv.org/abs/math.GR/0512484">math.GR/0512484</a> (2011).'
         )
 
     @mock.patch(f'{links.__name__}.url_for', mock_url_for)
@@ -239,5 +239,5 @@ class TestURLize(unittest.TestCase):
     def test_arxiv_prefix(self):
         self.assertEqual(
             links.urlize("see arxiv:1201.12345"),
-            'see <a class="link-https" data-arxiv="1201.12345" href="https://arxiv.org/abs/1201.12345">arXiv:1201.12345</a>'
+            'see <a class="link-https" data-arxiv-id="1201.12345" href="https://arxiv.org/abs/1201.12345">arXiv:1201.12345</a>'
         )

--- a/arxiv/base/urls/tests/test_urlize.py
+++ b/arxiv/base/urls/tests/test_urlize.py
@@ -218,6 +218,13 @@ class Id_Patterns_Test(unittest.TestCase):
         )
 
     @mock.patch(f'{links.__name__}.url_for', mock_url_for)
+    def test_parens(self):
+        self.assertEqual(
+            links.urlize('http://www-nuclear.univer.kharkov.ua/lib/1017_3(55)_12_p28-59.pdf'),
+            '<a href=\"http://www-nuclear.univer.kharkov.ua/lib/1017_3(55)_12_p28-59.pdf\">this http URL</a>'
+        )
+
+    @mock.patch(f'{links.__name__}.url_for', mock_url_for)
     def test_hosts(self):
         self.assertEqual(
             links.urlize('can be downloaded from http://rwcc.bao.ac.cn:8001'

--- a/arxiv/identifier/__init__.py
+++ b/arxiv/identifier/__init__.py
@@ -11,7 +11,7 @@ _archive = '|'.join([re.escape(key) for key in taxonomy.ARCHIVES.keys()])
 
 _category = '|'.join([re.escape(key) for key in taxonomy.CATEGORIES.keys()])
 
-_prefix = r'ar[xX]iv:'
+_prefix = r'(?P<arxiv_prefix>ar[xX]iv:)'
 """
 Attempt to catch the arxiv prefix in front of arxiv ids.
 
@@ -25,23 +25,23 @@ ARXIV_REGEX = (
 )
 
 OLD_STYLE_WITH_ARCHIVE = re.compile(
-    r'(?:%s)?(%s)\/\d{2}[01]\d{4}(v\d*)?' % (_prefix, _archive),
+    r'(?:%s)?(?P<arxiv_id>(%s)\/\d{2}[01]\d{4}(v\d*)?)' % (_prefix, _archive),
     re.I
 )
 
 OLD_STYLE_WITH_CATEGORY = re.compile(
-    r'(?:%s)?(%s)\/\d{2}[01]\d{4}(v\d*)?' % (_prefix, _category),
+    r'(?:%s)?(?P<arxiv_id>(%s)\/\d{2}[01]\d{4}(v\d*)?)' % (_prefix, _category),
     re.I
 )
 
 OLD_STYLE = re.compile(
-    r'(?:%s)?(%s)\/\d{2}[01]\d{4}(v\d*)?'
+    r'(?:%s)?(?P<arxiv_id>(%s)\/\d{2}[01]\d{4}(v\d*)?)'
     % (_prefix, f'{_archive}|{_category}'),
     re.I
 )
 
 STANDARD = re.compile(
-    r'(?<![\d=\.])(?:%s)?\d{4}\.\d{4,5}(v\d*)?'
+    r'(?<![\d=\.])(?:%s)?(?P<arxiv_id>\d{4}\.\d{4,5}(v\d*)?)'
     % (_prefix),
     re.I
 )

--- a/arxiv/identifier/__init__.py
+++ b/arxiv/identifier/__init__.py
@@ -11,7 +11,7 @@ _archive = '|'.join([re.escape(key) for key in taxonomy.ARCHIVES.keys()])
 
 _category = '|'.join([re.escape(key) for key in taxonomy.CATEGORIES.keys()])
 
-_prefix = r'(?P<arxiv_prefix>ar[xX]iv:)?'
+_prefix = r'ar[xX]iv:'
 """
 Attempt to catch the arxiv prefix in front of arxiv ids.
 
@@ -25,23 +25,24 @@ ARXIV_REGEX = (
 )
 
 OLD_STYLE_WITH_ARCHIVE = re.compile(
-    r'%s(?P<arxiv_id>(%s)\/\d{2}[01]\d{4}(v\d*)?)' % (_prefix, _archive),
+    r'(?:%s)?(%s)\/\d{2}[01]\d{4}(v\d*)?' % (_prefix, _archive),
     re.I
 )
 
 OLD_STYLE_WITH_CATEGORY = re.compile(
-    r'%s(?P<arxiv_id>(%s)\/\d{2}[01]\d{4}(v\d*)?)' % (_prefix, _category),
+    r'(?:%s)?(%s)\/\d{2}[01]\d{4}(v\d*)?' % (_prefix, _category),
     re.I
 )
 
 OLD_STYLE = re.compile(
-    r'%s(?P<arxiv_id>(%s)\/\d{2}[01]\d{4}(v\d*)?)'
+    r'(?:%s)?(%s)\/\d{2}[01]\d{4}(v\d*)?'
     % (_prefix, f'{_archive}|{_category}'),
     re.I
 )
 
 STANDARD = re.compile(
-    r'(?<![\d=\.])%s(?P<arxiv_id>\d{4}\.\d{4,5}(v\d*)?)' % _prefix,
+    r'(?<![\d=\.])(?:%s)?\d{4}\.\d{4,5}(v\d*)?'
+    % (_prefix),
     re.I
 )
 

--- a/arxiv/identifier/__init__.py
+++ b/arxiv/identifier/__init__.py
@@ -41,7 +41,7 @@ OLD_STYLE = re.compile(
 )
 
 STANDARD = re.compile(
-    r'(?<![\d=])%s(?P<arxiv_id>\d{4}\.\d{4,5}(v\d*)?)' % _prefix,
+    r'(?<![\d=\.])%s(?P<arxiv_id>\d{4}\.\d{4,5}(v\d*)?)' % _prefix,
     re.I
 )
 

--- a/arxiv/identifier/tests.py
+++ b/arxiv/identifier/tests.py
@@ -1,0 +1,41 @@
+"""Tests for :mod:`arxiv.identifier`."""
+
+from unittest import TestCase
+
+from . import parse_arxiv_id
+
+
+class TestParseArXivID(TestCase):
+    """Tests for :func:`parse_arxiv_id`."""
+
+    def test_old_style_with_archive(self):
+        """Parse old-style arXiv IDs with archive names."""
+        self.assertIsNotNone(parse_arxiv_id('math/9901123'))
+        self.assertIsNotNone(parse_arxiv_id('hep-ex/9901123'))
+        self.assertIsNotNone(parse_arxiv_id('gr-qc/9901123'))
+
+    def test_old_style_with_category(self):
+        """Parse old-style arXiv IDs with category names."""
+        self.assertIsNotNone(parse_arxiv_id('math.NA/9901123'))
+        self.assertIsNotNone(parse_arxiv_id('cs.DB/9901123'))
+
+    def test_old_style_with_version(self):
+        """Parse old-style arXiv IDs with version numbers."""
+        self.assertIsNotNone(parse_arxiv_id('gr-qc/9901123v3'))
+
+    def test_odd_mashup(self):
+        """Parse identifer that combines old- and new-style."""
+        self.assertIsNotNone(parse_arxiv_id('hep-ph/1203.12345v12'))
+
+    def test_new_style(self):
+        """Parse new-style identifiers."""
+        self.assertIsNotNone(parse_arxiv_id('1202.1234'))
+        self.assertIsNotNone(parse_arxiv_id('1203.12345'))
+
+    def test_new_style_with_version(self):
+        """Parse new-style with version numbers."""
+        self.assertIsNotNone(parse_arxiv_id('1202.1234v1'))
+        self.assertIsNotNone(parse_arxiv_id('1203.12345v1'))
+        self.assertIsNotNone(parse_arxiv_id('1203.12345v12'))
+
+    # slightly odd but seen in comments


### PR DESCRIPTION
I refactored ``arxiv.base.urls.links`` to use the [``bleach``](https://bleach.readthedocs.io/en/latest/) package from Mozilla. It is a little more user-friendly than maintaining our own core code for matching/replacing identifiers and/or URLs. I combined the regex that was already there for DOIs, arXiv IDs, and URL cases not already handled by bleach with the core bleach URL regex. I then wrote some [callbacks](https://bleach.readthedocs.io/en/latest/linkify.html?highlight=callbacks#callbacks-for-adjusting-attributes-callbacks) to alter link text, add CSS classes (new), add ``rel`` attribute, generate URLs for arXiv IDs and callback URLs for DOIs, etc.

The tests are basically the same, I just updated them to reflect the classes, rel, and other attributes. But the matching/replacing behavior is just as before, with the improvement that (ARXIVNG-250) parentheses are now supported in URLs.

Whew!