### PR TITLE
ARXIVNG-1015 set up coherent URL strategy for static files, including S3 integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
 - pipenv install ./
 - pipenv run nose2 -s arxiv --with-coverage
 - "./tests/lintstats.sh"
-- pipenv run nose2 -s tests/run_app_tests.py
+- pipenv run python tests/run_app_tests.py
 after_success:
 - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
 - pipenv install ./
 - pipenv run nose2 -s arxiv --with-coverage
 - "./tests/lintstats.sh"
+- pipenv run nose2 -s tests/run_app_tests.py
 after_success:
 - coveralls
 deploy:

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ uwsgi = "*"
 wtforms = "*"
 "e1839a8" = {path = "."}
 bleach = "*"
+"flask-s3" = "*"
 
 [dev-packages]
 pydocstyle = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1092b19475dfe494d65dfc1237108d9d20a95c09ef93956f632e89a24ce89888"
+            "sha256": "60d82c615522b94e8bc61bd6b42c61fbc3da00059c95da8cd19054fc9d361b1d"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -24,18 +24,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:122603b00f8c458236d1bd09850bdea56fc45f271e75ca38e66dbce37f72cada",
-                "sha256:99ec19dc4f0aa8a8354db7baebe1ff57bd18aeb6a539b28693b2e8ca8dc3d85b"
+                "sha256:63cd957ba663f5c10ff48ed904575eaa701314f79f18dbc59bd050311cd5f809",
+                "sha256:d1338582bc58741f54bd6b43488de6097a82ea45cebed0a3fd936981eadbb3a5"
             ],
             "index": "pypi",
-            "version": "==1.9.80"
+            "version": "==1.9.86"
         },
         "botocore": {
             "hashes": [
-                "sha256:76a2969278250e010253ddf514f4b54eaa7d2b1430f682874c3c2ab92f25a96d",
-                "sha256:8c579bac9abeaff1270a7a25964b01d3db1367f42fa5f826e1303ec8a4b13cef"
+                "sha256:24444e7580f0114c3e9fff5d2032c6f0cfbf88691b1be3ba27c6922507a902ec",
+                "sha256:5b01a16f02c3da55068b3aacfa1c37dd8e17141551e1702424b38dd21fa1c792"
             ],
-            "version": "==1.12.80"
+            "version": "==1.12.86"
         },
         "click": {
             "hashes": [
@@ -62,6 +62,15 @@
             ],
             "index": "pypi",
             "version": "==1.0.2"
+        },
+        "flask-s3": {
+            "hashes": [
+                "sha256:1d49061d4b78759df763358a901f4ed32bb43f672c9f8e1ec7226793f6ae0fd2",
+                "sha256:23cbbb1db4c29c313455dbe16f25be078d6318f0a11abcbb610f99e116945b62",
+                "sha256:d6e1fc3834f0be74c17e26bb8d0f506f711eb888775ab6af9164c0abb6f4c97c"
+            ],
+            "index": "pypi",
+            "version": "==0.3.3"
         },
         "itsdangerous": {
             "hashes": [
@@ -292,12 +301,12 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:77cfa1e9e83f79766c782dd20c7dea122c3a6999c6053f1734f07db9b100165c",
-                "sha256:954c60a7c43e15bac4ec1eb9efa1e752442a88c699529497b4fe14893ea554cc",
-                "sha256:dce74cd793af2f981b34702435259cb2fe43268ab3f73a345da1c39b8a9ab175"
+                "sha256:39392110c30270593fe3b9e6128727dd4429a09111c8ba5c9d0b64dd5127bc1a",
+                "sha256:b1a2d3c386dc20f9a7cb78aab5b326d0e951f0da4851b8e7da7f42b62ee40eb7",
+                "sha256:d82782f444650dacd8e628b69c5df147a120586d0c91e54b8b07a8a4c55c82b1"
             ],
             "index": "pypi",
-            "version": "==4.0.1"
+            "version": "==4.4.3"
         },
         "idna": {
             "hashes": [
@@ -426,10 +435,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:0886227f54515e592aaa2e5a553332c73962917f2831f1b0f9b9f4380a4b9807",
-                "sha256:f95a1e147590f204328170981833854229bb2912ac3d5f89e2a8ccd2834800c9"
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
             ],
-            "version": "==18.0"
+            "version": "==19.0"
         },
         "pydocstyle": {
             "hashes": [
@@ -551,9 +560,9 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:e03f19f64d81d0a3099518ca26b04550026f131eced2e76ced7b85c6b8d32128"
+                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
             ],
-            "version": "==1.11.0"
+            "version": "==1.11.1"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -125,6 +125,27 @@ above) to ``/static/[app name]/[ app version ]``. It will also rewrite blueprint
 [``static_url_path``](http://flask.pocoo.org/docs/1.0/api/#flask.Blueprint.static_url_path)
 to ``/static/[app name]/[ app version ]/[ blueprint name]``.
 
+### Serving static files on S3
+
+We use [Flask-S3](https://flask-s3.readthedocs.io/en/latest/) to serve static
+files via S3. Given the URL strategy above, following the instructions for
+Flask-S3 should just work.
+
+Be sure to initialize the integration after  instantiating ``Base`` and
+registering your blueprints. For example:
+
+```python
+def create_web_app() -> Flask:
+    """Initialize and configure the application."""
+
+    app = Flask('coolapp')
+    app.config.from_object(config)
+    Base(app)    # Gives us access to the base UI templates and resources.
+    app.register_blueprint(routes.blueprint)
+    s3.init_app(app)    # <- Down here!
+    return app
+```
+
 ## App tests
 
 Some tests to check app configuration and pattern compliance are provided in

--- a/README.md
+++ b/README.md
@@ -72,7 +72,14 @@ pipenv uninstall arxiv-base
 pipenv install git+https://github.com/cul-it/arxiv-base.git@task/ARXIVNG-1010#egg=arxiv-base
 ```
 
-In your application factory, instantiate the BaseUI blueprint. This makes
+In your ``config.py``, be sure to set ``APP_VERSION`` to the current semantic
+version of the app. For example:
+
+```python
+APP_VERSION = "1.4.2rc5"
+```
+
+In your application factory, instantiate the Base component. This makes
 templates and static files available to you. For example, in your
 ``factory.py`` module:
 
@@ -107,15 +114,31 @@ And use static files in your templates, e.g.:
 {{ url_for('base.static', filename='images/CUL-reduced-white-SMALL.svg') }}
 ```
 
+## Static files and paths
+
+Base does a little bit of work for you to keep static files from different
+apps and versions sorted. The ``Base`` component will automatically set  your
+app's
+[``static_url_path``](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.static_url_path)
+using the name of the app and the value of  ``APP VERSION`` in your config (see
+above) to ``/static/[app name]/[ app version ]``. It will also rewrite blueprint
+[``static_url_path``](http://flask.pocoo.org/docs/1.0/api/#flask.Blueprint.static_url_path)
+to ``/static/[app name]/[ app version ]/[ blueprint name]``.
+
+## App tests
+
+Some tests to check app configuration and pattern compliance are provided in
+``arxiv.base.app_tests``. See that module for usage.
+
 ## Editing and compiling sass
 
 The file arxivstyle.css should never be edited directly. It is compiled from
 arxivstyle.sass with this command from project directory root:
-```sass arxiv/base/static/sass/arxivstyle.sass:arxiv/base/static/css/arxivstyle.css```
+``sass arxiv/base/static/sass/arxivstyle.sass:arxiv/base/static/css/arxivstyle.css``
 
 or you can use the ``--watch`` option to autocompile on any changed file:
 
-```sass --watch arxiv/base/static/sass/arxivstyle.sass:arxiv/base/static/css/arxivstyle.css```
+``sass --watch arxiv/base/static/sass/arxivstyle.sass:arxiv/base/static/css/arxivstyle.css``
 
 Bulma source files are included in the ``static/sass`` directory so that
 variables can be overridden directly during compile. The ``arxivstyle.sass``

--- a/arxiv/base/__init__.py
+++ b/arxiv/base/__init__.py
@@ -25,12 +25,13 @@ Intended for use in an application factory. For example:
 
 
 """
-
+import types
 from typing import Optional, Any, Dict
 from flask import Blueprint, Flask, Blueprint
 from werkzeug.exceptions import NotFound
 
 from . import exceptions, urls, alerts, context_processors, filters
+from . import config as base_config
 from .converter import ArXivConverter
 
 
@@ -47,13 +48,43 @@ class Base(object):
         # Attach the arXiv identifier converter for URLs with IDs.
         app.url_map.converters['arxiv'] = ArXivConverter
 
-        # The base blueprint attaches static assets and templates.
+        # Set the static url path.
+        app_version = app.config.get("APP_VERSION", "null")
+        app_static_path = f'/static/{app.name}/{app_version}'
+        app.static_url_path = app_static_path
+
+        # 2019-01-31 - Erick P.:
+        #
+        # We need to able able to set the static URL for blueprints, so that
+        # we can ensure a consistent URL strategy. Changing the static URL for
+        # a blueprint after it is registered won't work, because the blueprint
+        # will have already set up its internal machinery via
+        # Blueprint.register(), which is called by Flask.register_blueprint().
+        # In order to intercept and modify the blueprint before
+        # Blueprint.register() is called, we swap out the app's
+        # register_blueprint() method for a closure (below) that alters the
+        # static URL path.
+        def register_blueprint(self: Flask, blueprint: Blueprint,
+                               **options: Any) -> None:
+            blueprint.static_url_path = f'{app_static_path}/{blueprint.name}'
+            self._register_blueprint(blueprint, **options)
+
+        app._register_blueprint = app.register_blueprint
+        app.register_blueprint = types.MethodType(register_blueprint, app)
+
+        # The base blueprint attaches static assets and templates. These are
+        # used by many different apps.
+        #
+        # We include the version of this package in the static path, so that
+        # apps can run slightly different versions of this package without
+        # clobbering each other.
+        static_path = f'/static/base/{base_config.BASE_VERSION}'
         blueprint = Blueprint(
             'base',
             __name__,
             template_folder='templates',
             static_folder='static',
-            static_url_path=app.static_url_path + '/base'
+            static_url_path=static_path
         )
         app.register_blueprint(blueprint)
 
@@ -64,6 +95,6 @@ class Base(object):
         # Attach the external URL handler as a fallback for failed calls to
         # url_for().
         app.url_build_error_handlers.append(urls.external_url_handler)
-        
+
         filters.register_filters(app)
         context_processors.register_context_processors(app)

--- a/arxiv/base/app_tests.py
+++ b/arxiv/base/app_tests.py
@@ -1,0 +1,87 @@
+"""
+These tests check for possible problems with apps that use this package.
+
+Usage
+-----
+You can import all of the tests in this module, and run them with the built in
+test runner. E.g.
+
+.. code-block:: python
+
+   # my_app_tests.py
+   import unittest
+
+   from my_app.factory import create_web_app
+   from arxiv.base.app_tests import *
+
+   app = create_web_app()
+
+   if __name__ == '__main__':
+       with app.app_context():
+           unittest.main()
+
+
+And run with:
+
+.. code-block:: bash
+
+   pipenv run python my_app_tests.py
+
+
+"""
+
+from flask import Flask, current_app
+from unittest import TestCase
+
+
+class TestConfig(TestCase):
+    """Look for common problems with the app config."""
+
+    def test_server_name(self):
+        """SERVER_NAME should be None (or unset)."""
+        self.assertIsNone(current_app.config.get('SERVER_NAME'),
+                          "SERVER_NAME should be None (or unset)")
+
+
+class TestStaticFiles(TestCase):
+    """Make sure that static files are configured safely on an app."""
+
+    def test_static_url_paths(self) -> None:
+        """Check for possible issues with the static URL path."""
+        self.assertTrue(current_app.static_url_path.startswith('/static'),
+                        "The static url path for the app should start with"
+                        " /static")
+        self.assertIn(
+            f'/{current_app.name}', current_app.static_url_path,
+            f"The static_url_path should include the name of the app"
+        )
+        self.assertIn(
+            f'/{current_app.config.get("APP_VERSION")}',
+            current_app.static_url_path,
+            f"The static_url_path should include the version of the app"
+            " (config.APP_VERSION)"
+        )
+
+        for key, blueprint in current_app.blueprints.items():
+            self.assertIsNotNone(
+                blueprint.static_url_path,
+                f"The static_url_path should be set on blueprint `{key}`"
+            )
+            self.assertTrue(current_app.static_url_path.startswith('/static'),
+                            "The static url path for the app should start with"
+                            " /static")
+            self.assertIn(
+                f'/{current_app.name}', blueprint.static_url_path,
+                f"The static_url_path should include the name of the app"
+            )
+            self.assertIn(
+                f'/{current_app.config.get("APP_VERSION")}',
+                blueprint.static_url_path,
+                f"The static_url_path should include the version of the app"
+                " (config.APP_VERSION)"
+            )
+            self.assertIn(
+                key, blueprint.static_url_path,
+                f"The static_url_path for blueprint `{key}` should include"
+                " the name of the blueprint"
+            )

--- a/arxiv/base/config.py
+++ b/arxiv/base/config.py
@@ -62,3 +62,25 @@ for key, value in os.environ.items():
             URLS[i] = (endpoint, o.path, o.netloc)
 
 ARXIV_BUSINESS_TZ = os.environ.get("ARXIV_BUSINESS_TZ", "US/Eastern")
+
+BASE_VERSION = "0.14.1"
+"""The version of the arxiv-base package."""
+
+APP_VERSION = "0.14.1"
+"""The version of the base test app."""
+
+"""
+Flask-S3 plugin settings.
+
+See `<https://flask-s3.readthedocs.io/en/latest/>`_.
+"""
+FLASKS3_BUCKET_NAME = os.environ.get('FLASKS3_BUCKET_NAME', 'some_bucket')
+# FLASKS3_CDN_DOMAIN = os.environ.get('FLASKS3_CDN_DOMAIN', 'static.arxiv.org')
+FLASKS3_USE_HTTPS = os.environ.get('FLASKS3_USE_HTTPS', 1)
+FLASKS3_FORCE_MIMETYPE = os.environ.get('FLASKS3_FORCE_MIMETYPE', 1)
+FLASKS3_ACTIVE = bool(int(os.environ.get('FLASKS3_ACTIVE', 0)))
+
+# AWS credentials.
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', 'nope')
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', 'nope')
+AWS_REGION = os.environ.get('AWS_REGION', 'us-east-1')

--- a/arxiv/base/factory.py
+++ b/arxiv/base/factory.py
@@ -11,16 +11,14 @@ from . import config
 
 s3 = FlaskS3()
 
+
 def create_web_app() -> Flask:
     """Initialize and configure the base application."""
-
     app = Flask('base_test')
-    basedir, _ = os.path.split(os.path.abspath(__file__))
     app.config.from_object(config)
 
     Base(app)    # Gives us access to the base UI templates and resources.
     app.register_blueprint(routes.blueprint)
 
     s3.init_app(app)
-
     return app

--- a/arxiv/base/factory.py
+++ b/arxiv/base/factory.py
@@ -3,15 +3,24 @@
 import logging
 import os
 from flask import Flask
+from flask_s3 import FlaskS3
+
 from arxiv.base import Base, routes
 
+from . import config
+
+s3 = FlaskS3()
 
 def create_web_app() -> Flask:
     """Initialize and configure the base application."""
-    app = Flask('base')
+
+    app = Flask('base_test')
     basedir, _ = os.path.split(os.path.abspath(__file__))
-    app.config.from_pyfile(os.path.join(basedir, 'config.py'))
+    app.config.from_object(config)
+
     Base(app)    # Gives us access to the base UI templates and resources.
     app.register_blueprint(routes.blueprint)
+
+    s3.init_app(app)
 
     return app

--- a/arxiv/base/routes.py
+++ b/arxiv/base/routes.py
@@ -16,7 +16,8 @@ from arxiv.base.exceptions import NotFound, Forbidden, Unauthorized, \
 
 from . import alerts
 
-blueprint = Blueprint('ui', __name__, url_prefix='')
+blueprint = Blueprint('ui', __name__, url_prefix='',
+                      static_folder='./static_test')
 
 
 @blueprint.route('/styleguide', methods=['GET'])
@@ -28,8 +29,8 @@ def test_page() -> Response:
     # Demonstrate flash alerts. To see these alerts, reload the page.
     help_url = url_for('help')
     alerts.flash_warning(f'This is a warning, see <a href="{help_url}">the'
-                           f' docs</a> for more information',
-                           title='Warning title', safe=True)
+                         f' docs</a> for more information',
+                         title='Warning title', safe=True)
     alerts.flash_info('This is some info', title='Info title')
     alerts.flash_failure('This is a failure', title='Failure title')
     alerts.flash_success('This is a success', title='Success title')

--- a/arxiv/base/static_test/test.md
+++ b/arxiv/base/static_test/test.md
@@ -1,0 +1,3 @@
+# This is a test
+
+Of the app static files.

--- a/arxiv/taxonomy/category.py
+++ b/arxiv/taxonomy/category.py
@@ -46,7 +46,7 @@ class Category(str):
             (archive, _) = parts
             if archive in ARCHIVES:
                 archive_name = ARCHIVES[archive]['name']
-                return f'{archive_name} ({self})'
+                return f'{archive_name} ({archive})'
         return self
 
     def unalias(self) -> 'Category':

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
         'jsonschema',
         'pytz',
         'uwsgi',
-        'boto3'
+        'boto3',
+        'bleach==3.1.0'
     ],
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-base',
-    version='0.13',
+    version='0.14.1',
     packages=[f'arxiv.{package}' for package
               in find_packages('arxiv', exclude=['*test*'])],
     zip_safe=False,

--- a/tests/run_app_tests.py
+++ b/tests/run_app_tests.py
@@ -1,0 +1,10 @@
+import unittest
+
+from arxiv.base.factory import create_web_app
+from arxiv.base.app_tests import *
+
+app = create_web_app()
+
+if __name__ == '__main__':
+    with app.app_context():
+        unittest.main()

--- a/upload_static_assets.py
+++ b/upload_static_assets.py
@@ -1,0 +1,8 @@
+"""Use this to upload static content to S3."""
+
+import flask_s3
+from arxiv.base.factory import create_web_app
+
+app = create_web_app()
+with app.app_context():
+    flask_s3.create_all(app)


### PR DESCRIPTION
This sets up a coherent URL strategy for serving static files. Goals:

- Be able to use multiple versions of base in different apps without clobbering shared static files
- Keep app and blueprint static files separate in S3
- Make sure the Flask-S3 integration works

From README.md:

...
In your ``config.py``, be sure to set ``APP_VERSION`` to the current semantic
version of the app. For example:

```python
APP_VERSION = "1.4.2rc5"
```
...

## Static files and paths

Base does a little bit of work for you to keep static files from different apps and versions sorted. The ``Base`` component will automatically set  your app's [``static_url_path``](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.static_url_path) using the name of the app and the value of  ``APP VERSION`` in your config (see above) to ``/static/[app name]/[ app version ]``. It will also rewrite blueprint [``static_url_path``](http://flask.pocoo.org/docs/1.0/api/#flask.Blueprint.static_url_path) to ``/static/[app name]/[ app version ]/[ blueprint name]``.

### Serving static files on S3

We use [Flask-S3](https://flask-s3.readthedocs.io/en/latest/) to serve static files via S3. Given the URL strategy above, following the instructions for Flask-S3 should just work.

Be sure to initialize the integration after  instantiating ``Base`` and registering your blueprints. For example:

```python
def create_web_app() -> Flask:
    """Initialize and configure the application."""

    app = Flask('coolapp')
    app.config.from_object(config)
    Base(app)    # Gives us access to the base UI templates and resources.
    app.register_blueprint(routes.blueprint)
    s3.init_app(app)    # <- Down here!
    return app
```