### PR TITLE
ARXIVNG-1376 a simple sendmail-based method for sending e-mail 

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -24,18 +24,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:63cd957ba663f5c10ff48ed904575eaa701314f79f18dbc59bd050311cd5f809",
-                "sha256:d1338582bc58741f54bd6b43488de6097a82ea45cebed0a3fd936981eadbb3a5"
+                "sha256:287a82e15c072ea8415d743e25092c73c58b41b00d76e0cfffdac0369a2e7116",
+                "sha256:443cc11e751081de7e380b2ce8d43811367b7ad3dfbbbd43b27e4a25c0ea20bf"
             ],
             "index": "pypi",
-            "version": "==1.9.86"
+            "version": "==1.9.97"
         },
         "botocore": {
             "hashes": [
-                "sha256:24444e7580f0114c3e9fff5d2032c6f0cfbf88691b1be3ba27c6922507a902ec",
-                "sha256:5b01a16f02c3da55068b3aacfa1c37dd8e17141551e1702424b38dd21fa1c792"
+                "sha256:c850967310e9ec37b8a9859da091b761dd55d7085fb6604f5fdf19430bc1c7a5",
+                "sha256:f326778f4b6e1b668625478ef062d173d1ed69ff39c0f4d326d4faaf87b2d010"
             ],
-            "version": "==1.12.86"
+            "version": "==1.12.97"
         },
         "click": {
             "hashes": [
@@ -136,11 +136,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==2.7.5"
+            "version": "==2.8.0"
         },
         "pytz": {
             "hashes": [
@@ -152,10 +152,10 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1",
-                "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"
+                "sha256:7b9ad3213bff7d357f888e0fab5101b56fa1a0548ee77d121c3a3dbfbef4cb2e",
+                "sha256:f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021"
             ],
-            "version": "==0.1.13"
+            "version": "==0.2.0"
         },
         "six": {
             "hashes": [
@@ -174,10 +174,10 @@
         },
         "uwsgi": {
             "hashes": [
-                "sha256:d2318235c74665a60021a4fc7770e9c2756f9fc07de7b8c22805efe85b5ab277"
+                "sha256:4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583"
             ],
             "index": "pypi",
-            "version": "==2.0.17.1"
+            "version": "==2.0.18"
         },
         "webencodings": {
             "hashes": [
@@ -301,12 +301,12 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:39392110c30270593fe3b9e6128727dd4429a09111c8ba5c9d0b64dd5127bc1a",
-                "sha256:b1a2d3c386dc20f9a7cb78aab5b326d0e951f0da4851b8e7da7f42b62ee40eb7",
-                "sha256:d82782f444650dacd8e628b69c5df147a120586d0c91e54b8b07a8a4c55c82b1"
+                "sha256:15e2efc9ea4e667c2410aef80da2e7c42f7b9f130daa595767dad25a468318cc",
+                "sha256:73131d16c8b765db9a84d79c5dfa300678c9243d061c9e2df9ebf8c1c809054f",
+                "sha256:9417e3510560dc221b3567010a1f0e4a90c29eb464b6f988610665d6b29f49d3"
             ],
             "index": "pypi",
-            "version": "==4.4.3"
+            "version": "==4.6.0"
         },
         "idna": {
             "hashes": [
@@ -413,11 +413,11 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:986a7f97808a865405c5fd98fae5ebfa963c31520a56c783df159e9a81e41b3e",
-                "sha256:cc5df73cc11d35655a8c364f45d07b13c8db82c000def4bd7721be13356533b4"
+                "sha256:308c274eb8482fbf16006f549137ddc0d69e5a589465e37b99c4564414363ca7",
+                "sha256:e80fd6af34614a0e898a57f14296d0dacb584648f0339c2e000ddbf0f4cc2f8d"
             ],
             "index": "pypi",
-            "version": "==0.660"
+            "version": "==0.670"
         },
         "mypy-extensions": {
             "hashes": [
@@ -502,11 +502,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:429e3172466df289f0f742471d7e30ba3ee11f3b5aecd9a840480d03f14bcfe5",
-                "sha256:c4cb17ba44acffae3d3209646b6baec1e215cad3065e852c68cc569d4df1b9f8"
+                "sha256:b53904fa7cb4b06a39409a492b949193a1b68cc7241a1a8ce9974f86f0d24287",
+                "sha256:c1c00fc4f6e8b101a0d037065043460dffc2d507257f2f11acaed71fd2b0c83c"
             ],
             "index": "pypi",
-            "version": "==1.8.3"
+            "version": "==1.8.4"
         },
         "sphinx-autodoc-typehints": {
             "hashes": [
@@ -526,29 +526,27 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:023625bfa9359e29bd6e24cac2a4503495b49761d48a5f1e38333fc4ac4d93fe",
-                "sha256:07591f7a5fdff50e2e566c4c1e9df545c75d21e27d98d18cb405727ed0ef329c",
-                "sha256:153e526b0f4ffbfada72d0bb5ffe8574ba02803d2f3a9c605c8cf99dfedd72a2",
-                "sha256:3ad2bdcd46a4a1518d7376e9f5016d17718a9ed3c6a3f09203d832f6c165de4a",
-                "sha256:3ea98c84df53ada97ee1c5159bb3bc784bd734231235a1ede14c8ae0775049f7",
-                "sha256:51a7141ccd076fa561af107cfb7a8b6d06a008d92451a1ac7e73149d18e9a827",
-                "sha256:52c93cd10e6c24e7ac97e8615da9f224fd75c61770515cb323316c30830ddb33",
-                "sha256:6344c84baeda3d7b33e157f0b292e4dd53d05ddb57a63f738178c01cac4635c9",
-                "sha256:64699ca1b3bd5070bdeb043e6d43bc1d0cebe08008548f4a6bee782b0ecce032",
-                "sha256:74903f2e56bbffe29282ef8a5487d207d10be0f8513b41aff787d954a4cf91c9",
-                "sha256:7891710dba83c29ee2bd51ecaa82f60f6bede40271af781110c08be134207bf2",
-                "sha256:91976c56224e26c256a0de0f76d2004ab885a29423737684b4f7ebdd2f46dde2",
-                "sha256:9bad678a576ecc71f25eba9f1e3fd8d01c28c12a2834850b458428b3e855f062",
-                "sha256:b4726339a4c180a8b6ad9d8b50d2b6dc247e1b79b38fe2290549c98e82e4fd15",
-                "sha256:ba36f6aa3f8933edf94ea35826daf92cbb3ec248b89eccdc053d4a815d285357",
-                "sha256:bbc96bde544fd19e9ef168e4dfa5c3dfe704bfa78128fa76f361d64d6b0f731a",
-                "sha256:c0c927f1e44469056f7f2dada266c79b577da378bbde3f6d2ada726d131e4824",
-                "sha256:c0f9a3708008aa59f560fa1bd22385e05b79b8e38e0721a15a8402b089243442",
-                "sha256:f0bf6f36ff9c5643004171f11d2fdc745aa3953c5aacf2536a0685db9ceb3fb1",
-                "sha256:f5be39a0146be663cbf210a4d95c3c58b2d7df7b043c9047c5448e358f0550a2",
-                "sha256:fcd198bf19d9213e5cbf2cde2b9ef20a9856e716f76f9476157f90ae6de06cc6"
+                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
+                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
+                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
+                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
+                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
+                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
+                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
+                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
+                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
+                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
+                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
+                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
+                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
+                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
+                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
+                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
+                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
+                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
+                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
             ],
-            "version": "==1.2.0"
+            "version": "==1.3.1"
         },
         "urllib3": {
             "hashes": [

--- a/arxiv/mail/__init__.py
+++ b/arxiv/mail/__init__.py
@@ -1,0 +1,3 @@
+"""Support for sending e-mails."""
+
+from .mail import send

--- a/arxiv/mail/mail.py
+++ b/arxiv/mail/mail.py
@@ -1,0 +1,72 @@
+from typing import Optional, Dict, List
+from email.message import EmailMessage
+import smtplib
+from arxiv.base.globals import get_application_config
+
+NOREPLY = 'noreply@arxiv.org'
+
+
+def send(recipient: str, subject: str, text_body: str,
+         html_body: Optional[str] = None, sender: Optional[str] = None,
+         headers: Dict[str, str] = {}, cc_recipients: List[str] = [],
+         bcc_recipients: List[str] = []) -> None:
+    """
+    Send an e-mail.
+
+    If both ``text_body`` and ``html_body`` are provided, the e-mail will be
+    sent as ``multipart/alternative``.
+
+    Parameters
+    ----------
+    recipient : str
+        The e-mail address of the recipient.
+    subject : str
+        The subject line.
+    text_body : str
+        Plain text content of the e-mail.
+    html_body : str
+        HTML content of the e-mail.
+    sender : str or None
+        The e-mail address of the sender. If ``None`` (default), the default
+        sender will be loaded from the current config.
+    headers : dict
+        Extra headers to add to the e-mail.
+    cc_recipients : list
+        E-mail addresses that should be CC recipients.
+    bcc_recipients : list
+        E-mail addresses that should be BCC recipients.
+
+    """
+    _send(_write(recipient, subject, text_body, html_body=html_body,
+                 sender=sender, headers=headers, cc_recipients=cc_recipients,
+                 bcc_recipients=bcc_recipients))
+
+
+def _write(recipient: str, subject: str, text_body: str,
+           html_body: Optional[str] = None, sender: Optional[str] = None,
+           headers: Dict[str, str] = {}, cc_recipients: List[str] = [],
+           bcc_recipients: List[str] = []) -> EmailMessage:
+    if sender is None:
+        sender = _get_default_sender()
+    message = EmailMessage()
+    message['Subject'] = subject
+    message['From'] = sender
+    message['To'] = recipient
+    if cc_recipients:
+        message['CC'] = ', '.join(cc_recipients)
+    if bcc_recipients:
+        message['BCC'] = ', '.join(bcc_recipients)
+    message.set_content(text_body)
+    if html_body:
+        message.add_alternative(html_body, subtype='html')
+    return message
+
+
+def _send(message: EmailMessage, host: str = 'localhost', port: int = 0,
+          local_hostname: Optional[str] = None) -> None:
+    with smtplib.SMTP(host, port, local_hostname) as s:
+        s.send_message(message)
+
+
+def _get_default_sender() -> str:
+    return get_application_config().get('DEFAULT_SENDER', NOREPLY)

--- a/arxiv/mail/mail.py
+++ b/arxiv/mail/mail.py
@@ -1,3 +1,5 @@
+"""Dern simple support for sending multipart/alternative e-mails."""
+
 from typing import Optional, Dict, List
 from email.message import EmailMessage
 import smtplib

--- a/arxiv/mail/mail.py
+++ b/arxiv/mail/mail.py
@@ -42,7 +42,9 @@ def send(recipient: str, subject: str, text_body: str,
     smtp_params = {
         'host': _get_smtp_hostname(),
         'port': _get_smtp_port(),
-        'local_hostname': _get_local_hostname()
+        'local_hostname': _get_local_hostname(),
+        'username': _get_smtp_username(),
+        'password': _get_smtp_password()
     }
     _send(_write(recipient, subject, text_body, html_body=html_body,
                  sender=sender, headers=headers, cc_recipients=cc_recipients,
@@ -70,8 +72,12 @@ def _write(recipient: str, subject: str, text_body: str,
 
 
 def _send(message: EmailMessage, host: str = 'localhost', port: int = 0,
-          local_hostname: Optional[str] = None) -> None:
+          local_hostname: Optional[str] = None,
+          username: Optional[str] = None,
+          password: Optional[str] = None) -> None:
     with smtplib.SMTP(host, port, local_hostname) as s:
+        if username and password:
+            s.login(username, password)
         s.send_message(message)
 
 
@@ -81,6 +87,14 @@ def _get_default_sender() -> str:
 
 def _get_smtp_hostname() -> str:
     return get_application_config().get('SMTP_HOSTNAME', 'localhost')
+
+
+def _get_smtp_username() -> str:
+    return get_application_config().get('SMTP_USERNAME', 'foouser')
+
+
+def _get_smtp_password() -> str:
+    return get_application_config().get('SMTP_PASSWORD', 'foopass')
 
 
 def _get_smtp_port() -> int:

--- a/arxiv/mail/mail.py
+++ b/arxiv/mail/mail.py
@@ -39,9 +39,14 @@ def send(recipient: str, subject: str, text_body: str,
         E-mail addresses that should be BCC recipients.
 
     """
+    smtp_params = {
+        'hostname': _get_smtp_hostname(),
+        'port': _get_smtp_port(),
+        'local_hostname': _get_local_hostname()
+    }
     _send(_write(recipient, subject, text_body, html_body=html_body,
                  sender=sender, headers=headers, cc_recipients=cc_recipients,
-                 bcc_recipients=bcc_recipients))
+                 bcc_recipients=bcc_recipients), **smtp_params)
 
 
 def _write(recipient: str, subject: str, text_body: str,
@@ -72,3 +77,15 @@ def _send(message: EmailMessage, host: str = 'localhost', port: int = 0,
 
 def _get_default_sender() -> str:
     return get_application_config().get('DEFAULT_SENDER', NOREPLY)
+
+
+def _get_smtp_hostname() -> str:
+    return get_application_config().get('SMTP_HOSTNAME', 'localhost')
+
+
+def _get_smtp_port() -> int:
+    return int(get_application_config().get('SMTP_PORT', '0'))
+
+
+def _get_local_hostname() -> Optional[str]:
+    return get_application_config().get('SMTP_LOCAL_HOSTNAME', None)

--- a/arxiv/mail/mail.py
+++ b/arxiv/mail/mail.py
@@ -40,7 +40,7 @@ def send(recipient: str, subject: str, text_body: str,
 
     """
     smtp_params = {
-        'hostname': _get_smtp_hostname(),
+        'host': _get_smtp_hostname(),
         'port': _get_smtp_port(),
         'local_hostname': _get_local_hostname()
     }

--- a/arxiv/mail/tests/__init__.py
+++ b/arxiv/mail/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for :mod:`arxiv.mail`."""

--- a/arxiv/mail/tests/test_mail.py
+++ b/arxiv/mail/tests/test_mail.py
@@ -1,0 +1,79 @@
+"""Test sending email."""
+
+from unittest import TestCase, mock
+from .. import mail
+
+
+class TestSendEmail(TestCase):
+    """Tests for :func:`mail.send`."""
+
+    @mock.patch(f'{mail.__name__}.smtplib.SMTP')
+    def test_send_text(self, mock_SMTP):
+        """Send a text-only e-mail."""
+        mock_SMTP_instance = mock.MagicMock()
+        mock_SMTP.return_value.__enter__.return_value = mock_SMTP_instance
+        mail.send("erick.peirson@gmail.com", "Subject!", "Hi there.")
+        expected = (
+            'Subject: Subject!\n'
+            'From: noreply@arxiv.org\n'
+            'To: erick.peirson@gmail.com\n'
+            'Content-Type: text/plain; charset="utf-8"\n'
+            'Content-Transfer-Encoding: 7bit\n'
+            'MIME-Version: 1.0\n\n'
+            'Hi there.\n'
+        )
+        self.assertEqual(str(mock_SMTP_instance.send_message.call_args[0][0]),
+                         expected)
+
+    @mock.patch(f'{mail.__name__}.smtplib.SMTP')
+    def test_send_text_with_cc_and_bcc(self, mock_SMTP):
+        """Send a text-only e-mail."""
+        mock_SMTP_instance = mock.MagicMock()
+        mock_SMTP.return_value.__enter__.return_value = mock_SMTP_instance
+        mail.send("erick.peirson@gmail.com", "Subject!", "Hi there.",
+                  cc_recipients=['foo@somewhere.edu', 'baz@somewhere.edu'],
+                  bcc_recipients=['bar@elsewhere.edu'])
+        expected = (
+            'Subject: Subject!\n'
+            'From: noreply@arxiv.org\n'
+            'To: erick.peirson@gmail.com\n'
+            'CC: foo@somewhere.edu, baz@somewhere.edu\n'
+            'BCC: bar@elsewhere.edu\n'
+            'Content-Type: text/plain; charset="utf-8"\n'
+            'Content-Transfer-Encoding: 7bit\n'
+            'MIME-Version: 1.0\n\n'
+            'Hi there.\n'
+        )
+        self.assertEqual(str(mock_SMTP_instance.send_message.call_args[0][0]),
+                         expected)
+
+    @mock.patch(f'{mail.__name__}.smtplib.SMTP')
+    def test_send_text_and_html(self, mock_SMTP):
+        """Send an email with text and HTML."""
+        mock_SMTP_instance = mock.MagicMock()
+        mock_SMTP.return_value.__enter__.return_value = mock_SMTP_instance
+        html_body = "<html><body><h1>Hi</h1><p>there!</p></body></html>"
+        mail.send("erick.peirson@gmail.com", "Subject!", "Hi there.",
+                  html_body=html_body)
+        sent_message = str(mock_SMTP_instance.send_message.call_args[0][0])
+        expected_headers = (
+            'Subject: Subject!\n'
+            'From: noreply@arxiv.org\n'
+            'To: erick.peirson@gmail.com\n'
+            'MIME-Version: 1.0\n'
+            'Content-Type: multipart/alternative;\n'
+        )
+        text_part = (
+            'Content-Type: text/plain; charset="utf-8"\n'
+            'Content-Transfer-Encoding: 7bit\n\n'
+            'Hi there.\n'
+        )
+        html_part = (
+            'Content-Type: text/html; charset="utf-8"\n'
+            'Content-Transfer-Encoding: 7bit\n'
+            'MIME-Version: 1.0\n\n'
+            '<html><body><h1>Hi</h1><p>there!</p></body></html>\n'
+        )
+        self.assertIn(expected_headers, sent_message)
+        self.assertIn(text_part, sent_message)
+        self.assertIn(html_part, sent_message)

--- a/arxiv/mail/tests/test_mail.py
+++ b/arxiv/mail/tests/test_mail.py
@@ -27,7 +27,7 @@ class TestSendEmail(TestCase):
 
     @mock.patch(f'{mail.__name__}.smtplib.SMTP')
     def test_send_text_with_cc_and_bcc(self, mock_SMTP):
-        """Send a text-only e-mail."""
+        """Send a text-only e-mail with CC and BCC recipients."""
         mock_SMTP_instance = mock.MagicMock()
         mock_SMTP.return_value.__enter__.return_value = mock_SMTP_instance
         mail.send("erick.peirson@gmail.com", "Subject!", "Hi there.",


### PR DESCRIPTION
That's pretty much it. Looking at arXiv-Lib, that's pretty much the core of what we're doing (without wonderful HTML). On top of this we can add convenience functions for rendering templates...but basically all you need is:

```python
from flask import render_template
from arxiv import mail

mail.send("foo@user.edu", "Some arXiv for you", 
          render_template("my/template.txt", **context), 
          html_body=render_template("my/template.html", **context))
```