### PR TITLE
ARXIVNG-1673 Initial draft of email templates

### DIFF
--- a/arxiv/mail/templates/html-sample.html
+++ b/arxiv/mail/templates/html-sample.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Submission Received</title>
+    <!--[if mso]>
+        <style>
+            * {
+                font-family: sans-serif !important;
+            }
+        </style>
+    <![endif]-->
+
+    <!--[if !mso]>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,700' rel='stylesheet' type='text/css'>
+    <![endif]-->
+    <style>
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+            table[class=body] ul,
+            table[class=body] ol,
+            table[class=body] td,
+            table[class=body] span,
+            table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+            table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+    }
+
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+
+      .apple-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+      }
+    }
+
+    /* Type styles for all clients */
+    h1 {
+     font-family: Roboto, Helvetica, Arial, sans-serif;
+    }
+
+    /* Type styles for WebKit clients */
+    @media screen and (-webkit-min-device-pixel-ratio:0) {
+      h1 {
+        font-family: Roboto, Helvetica, Arial, sans-serif !important;
+      }
+    }
+    </style>
+
+  </head>
+  <body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+    <center style="width: 100%; background-color: #222222;">
+    <!--[if mso | IE]>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: #222222;">
+    <tr>
+    <td>
+    <![endif]-->
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;">
+      <tr>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; margin: 0 auto; max-width: 580px; padding: 10px; width: 580px;">
+          <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px;">
+
+            <!-- START CENTERED WHITE CONTAINER -->
+            <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">This is preheader text. Some clients will show this text as a preview.</span>
+            <table role="presentation" class="main" border="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff;">
+              <!-- START LOGO AND BANNER AREA -->
+              <tr>
+                <td class="wrapper" style="font-family: Roboto, Helvetica, Arial, sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 0;">
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-bottom: 3px solid #B31B1B;" width="100%">
+                    <tr>
+                      <td bgcolor="#B31B1B" align="center" valign="center" width="100px" style="padding: 10px 20px 10px 20px; color: #FFFFFF; font-family: sans-serif; font-weight: bold; font-size: 28px; line-height: 1.1;">
+                        <img src="https://static.arxiv.org/static/base/0.14.1/images/arxiv-logo-web.svg" alt="arXiv" aria-label="logo" width="85" height="25" style="display: block;" />
+                      </td>
+                      <td style="font-size: 0; line-height: 0;" height="20">
+                        &nbsp;
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-family: Roboto, Helvetica, Arial, sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 20px;">
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                    <tr>
+                      <td style="font-family: Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-weight:normal; vertical-align: top;">
+                        <h1 style="font-size: 16px; font-weight: bold; margin: 0; margin-bottom: 15px;">We have received your submission to arXiv.</h1>
+                        <p style="margin: 0; margin-bottom: 15px;">Your temporary submission identifier is: <b>[% subm.sub_id %]</b><br />
+                        You may update your submission at: <a href="" style="color: #0068ac; text-decoration: underline;"><font color="#0068ac">[% submit_url %]</font></a></p>
+
+                        <p style="margin: 0; margin-bottom: 15px;">Your article is scheduled to be announced at [% subm.publish_time_string %]. The abstract will appear in the subsequent mailing as displayed below, except that the submission identifier will be replaced by the official arXiv identifier. Updates before [% subm.freeze_time_string %] will not delay announcement.</p>
+
+                        <p style="margin: 0; margin-bottom: 15px;">A paper password will be emailed to you when the article is announced. You should share this with co-authors to allow them to claim ownership. If you have a problem that you are not able to resolve through the web interface, contact <a href="" style="color: #0068ac; text-decoration: underline;"><font color="#0068ac">[% www_admin %]</font></a> with a description of the issue and reference the submission identifier.</p>
+
+                        <p style="margin: 0; margin-bottom: 15px;">- arXiv admin</p>
+
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+            <!-- START FOOTER -->
+            <div class="footer" style="clear: both; text-align: center; width: 100%;">
+              <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-top: 1px solid #D8D8D8;">
+                <tr>
+                  <td class="content-block" style="font-family: Roboto, Helvetica, Arial, sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; color: #5E5E5E; text-align: center;">
+                    <span class="apple-link" style="color: #5E5E5E; font-size: 12px; text-align: center;">arXiv, Cornell University, Ithaca NY 14853 USA<br />
+                    You are receiving this email because you initiated a process at arXiv.org. <br />
+                    If this doesn't sound right, <a href="mailto:support@arxiv.org" style="text-decoration: underline; color: #5E5E5E;"><font color="#5E5E5E">let us know</font>.</a></span>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <!-- END FOOTER -->
+
+          <!-- END CENTERED WHITE CONTAINER -->
+          </div>
+        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </center>
+  </body>
+</html>

--- a/arxiv/mail/templates/license.txt
+++ b/arxiv/mail/templates/license.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) [2013] [Lee Munroe]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/arxiv/mail/templates/plaintext-sample.txt
+++ b/arxiv/mail/templates/plaintext-sample.txt
@@ -1,0 +1,18 @@
+We have received your submission to arXiv.
+
+Your temporary submission identifier is: [% subm.sub_id %].
+You may update your submission at: [% submit_url %]
+
+Your article is scheduled to be announced at [% subm.publish_time_string %].
+The abstract will appear in the subsequent mailing as displayed below,
+except that the submission identifier will be replaced by
+the official arXiv identifier. Updates before [% subm.freeze_time_string %] will
+not delay announcement.
+
+A paper password will be emailed to you when the article is announced.
+You should share this with co-authors to allow them to claim ownership.
+If you have a problem that you are not able to resolve through the web
+interface, contact [% www_admin %] with a description of the issue and
+reference the submission identifier.
+
+- arXiv admin

--- a/arxiv/mail/templates/readme.md
+++ b/arxiv/mail/templates/readme.md
@@ -1,0 +1,27 @@
+# arXiv Email Templates
+
+This set of templates is based heavily on Lee Munroe's [Really Simple Free
+Responsive Email Template] (https://github.com/leemunroe/responsive-html-email-template)
+with additional enhancements from Ted Goas's [Cerberus](https://tedgoas.github.io/Cerberus/).
+We are using templates with pre-coded inline styling to prevent the need for a
+separate tool to do the inlining. The original Munroe template was inlined, the
+rest is intended to be style-edited by hand. Our emails are not all that
+complicated from a design and layout perspective.
+
+## HTML Email - Coding Circa 1999
+
+- All styles should be explicitly defined and inline.
+- Some CSS in the <head> is included for email clients that can use it.
+- All layout needs to be done with tables.
+- HTML4 only.
+- Keep markup as simple as possible.
+- When in doubt, consult a reliable reference.
+- Test, test, test on every platform possible. Use [Putsmail](https://putsmail.com/).
+- Include a plaintext version with every email.
+
+## References
+
+- https://tedgoas.github.io/Cerberus/
+- https://github.com/leemunroe/responsive-html-email-template
+- https://www.smashingmagazine.com/2017/01/introduction-building-sending-html-email-for-web-developers/
+- https://webdesign.tutsplus.com/articles/build-an-html-email-template-from-scratch--webdesign-12770


### PR DESCRIPTION
Not yet Jinja-ized, wanted to get your look at this first and make sure I was 100% going in the right direction.

One can spend far too much time trying to capture whether all the test cases have been met - finally I decided to pick a boilerplate, add in some useful things from another boilerplate, and call it good enough until we test it.

Need to do: add a PNG version of the arXiv logo to static files so that it can be referenced in the email template. SVG renders nicely in browsers and some email clients, but is sketchily supported in others.

## Screenshot, mobile:
<img width="396" alt="screen shot 2019-02-18 at 4 42 53 pm" src="https://user-images.githubusercontent.com/17456668/52977850-e156fd00-339c-11e9-8bf8-8c765aced9aa.png">

## Screenshot, desktop:
<img width="632" alt="screen shot 2019-02-18 at 4 42 44 pm" src="https://user-images.githubusercontent.com/17456668/52977852-e156fd00-339c-11e9-8071-2d1d5552affb.png">

## Screenshot, Gmail browser version (for realsies, not simulated):
<img width="1056" alt="screen shot 2019-02-18 at 4 48 17 pm" src="https://user-images.githubusercontent.com/17456668/52977895-15cab900-339d-11e9-96b7-cb7349169d97.png">
