### PR TITLE
ARXIVNG-1719: Add missing URLs and filter fixes

### DIFF
--- a/arxiv/base/config.py
+++ b/arxiv/base/config.py
@@ -40,7 +40,10 @@ URLS = [
     ("submit", "/submit", BASE_SERVER),
     ("about", "/about", BASE_SERVER),
     ("team", "/about/people/leadership_team", BASE_SERVER),
-    ("privacy_policy", "/help/policies/privacy_policy", BASE_SERVER)
+    ("privacy_policy", "/help/policies/privacy_policy", BASE_SERVER),
+    ("abs", "/abs/<arxiv:paper_id>v<string:version>", BASE_SERVER),
+    ("abs_by_id", "/abs/<arxiv:paper_id>", BASE_SERVER),
+    ("clickthrough", "/ct", BASE_SERVER)
 ]
 """
 URLs for external services, for use with :func:`flask.url_for`.

--- a/arxiv/base/filters.py
+++ b/arxiv/base/filters.py
@@ -1,12 +1,38 @@
 """Template filters."""
 
+import re
 from functools import partial
+from typing import Union
 from flask import Flask
+from jinja2 import Markup, escape
 from arxiv.base.urls import urlize, url_for_doi, canonical_url, \
     clickthrough_url
 from arxiv.util.tex2utf import tex2utf
 from arxiv.taxonomy import get_category_display, get_archive_display, \
     get_group_display
+
+JinjaFilterInput = Union[Markup, str]
+"""
+   Jinja filters will receive their text input as either
+   a Markup object or a str. It is critical for proper escaping to
+   to ensure that str is correctly HTML escaped.
+
+   Markup is decoded from str so this type is redundant but
+   the hope is to make it clear what is going on to arXiv developers.
+"""
+
+
+def abstract_lf_to_br(text: JinjaFilterInput) -> Markup:
+    """Lines that start with two spaces should be broken."""
+    if hasattr(text, '__html__'):
+        etxt = text
+    else:
+        etxt = Markup(escape(text))
+
+    # if line starts with spaces, replace the white space with <br />
+    br = re.sub(r'((?<!^)\n +)', '\n<br />', etxt)
+    dedup = re.sub(r'\n\n', '\n', br)  # skip if blank
+    return Markup(dedup)
 
 
 def register_filters(app: Flask) -> None:
@@ -18,6 +44,7 @@ def register_filters(app: Flask) -> None:
     app : :class:`Flask`
 
     """
+    app.template_filter('abstract_lf_to_br')(abstract_lf_to_br)
     app.template_filter('urlize')(urlize)
     app.template_filter('tex2utf')(partial(tex2utf, letters=True))
     app.template_filter('tex2utf_no_symbols')(partial(tex2utf, letters=False))

--- a/arxiv/base/filters.py
+++ b/arxiv/base/filters.py
@@ -24,7 +24,7 @@ JinjaFilterInput = Union[Markup, str]
 
 def abstract_lf_to_br(text: JinjaFilterInput) -> Markup:
     """Lines that start with two spaces should be broken."""
-    if hasattr(text, '__html__'):
+    if isinstance(text, Markup):
         etxt = text
     else:
         etxt = Markup(escape(text))
@@ -38,8 +38,8 @@ def abstract_lf_to_br(text: JinjaFilterInput) -> Markup:
 def f_tex2utf(text: JinjaFilterInput,
               letters: bool = True) -> Markup:
     """Return output of tex2utf function as escaped Markup."""
-    if hasattr(text, '__html__'):
-        return Markup(escape(tex2utf(text.unescape(), letters=letters)))
+    if isinstance(text, Markup):
+        return escape(tex2utf(text.unescape(), letters=letters))
     else:
         return Markup(escape(tex2utf(text, letters=letters)))
 

--- a/arxiv/base/filters.py
+++ b/arxiv/base/filters.py
@@ -35,6 +35,15 @@ def abstract_lf_to_br(text: JinjaFilterInput) -> Markup:
     return Markup(dedup)
 
 
+def f_tex2utf(text: JinjaFilterInput,
+              letters: bool = True) -> Markup:
+    """Return output of tex2utf function as escaped Markup."""
+    if hasattr(text, '__html__'):
+        return Markup(escape(tex2utf(text.unescape(), letters=letters)))
+    else:
+        return Markup(escape(tex2utf(text, letters=letters)))
+
+
 def register_filters(app: Flask) -> None:
     """
     Register base template filters on a Flask app.
@@ -46,8 +55,8 @@ def register_filters(app: Flask) -> None:
     """
     app.template_filter('abstract_lf_to_br')(abstract_lf_to_br)
     app.template_filter('urlize')(urlize)
-    app.template_filter('tex2utf')(partial(tex2utf, letters=True))
-    app.template_filter('tex2utf_no_symbols')(partial(tex2utf, letters=False))
+    app.template_filter('tex2utf')(partial(f_tex2utf, letters=True))
+    app.template_filter('tex2utf_no_symbols')(partial(f_tex2utf, letters=False))
     app.template_filter('canonical_url')(canonical_url)
     app.template_filter('url_for_doi')(url_for_doi)
     app.template_filter('clickthrough_url')(clickthrough_url)

--- a/arxiv/base/filters.py
+++ b/arxiv/base/filters.py
@@ -1,5 +1,6 @@
 """Template filters."""
 
+from functools import partial
 from flask import Flask
 from arxiv.base.urls import urlize, url_for_doi, canonical_url, \
     clickthrough_url
@@ -18,7 +19,8 @@ def register_filters(app: Flask) -> None:
 
     """
     app.template_filter('urlize')(urlize)
-    app.template_filter('tex2utf')(tex2utf)
+    app.template_filter('tex2utf')(partial(tex2utf, letters=True))
+    app.template_filter('tex2utf_no_symbols')(partial(tex2utf, letters=False))
     app.template_filter('canonical_url')(canonical_url)
     app.template_filter('url_for_doi')(url_for_doi)
     app.template_filter('clickthrough_url')(clickthrough_url)

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -134,7 +134,7 @@
     <div class="dateline">{{ abs_date_line(arxiv_id, submitted_date, version, submission_history) }}</div>
     {#- TODO: the 'replace' call may not behave in the same way as line_feed_to_br filter in arxiv-browse -#}
     {#- TODO: arxiv-base filters may need to be Markup aware so that filters can be ordered arbitrarily and explicit escape is not needed -#}
-    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|escape|urlize|replace('\n\n', '<br />')|safe }}</blockquote>
+    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|escape|urlize|abstract_lf_to_br|safe }}</blockquote>
     <!--CONTEXT-->
     <div class="metatable">
       <table summary="Additional metadata">

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -133,7 +133,7 @@
     <div class="authors"><span class="descriptor">Authors:</span>{{ authors }}</div>
     <div class="dateline">{{ abs_date_line(arxiv_id, submitted_date, version, submission_history) }}</div>
 
-    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|urlize|replace('\n\n', '<br />')|safe }}</blockquote>
+    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|escape|tex2utf_no_symbols|urlize|replace('\n\n', '<br/>')|safe }}</blockquote>
     <!--CONTEXT-->
     <div class="metatable">
       <table summary="Additional metadata">

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -129,12 +129,12 @@
 <div id="content">
   <div id="abs">
 
-    <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ title|tex2utf|escape|urlize|safe }}</h1>
+    <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ title|tex2utf|urlize|safe }}</h1>
     <div class="authors"><span class="descriptor">Authors:</span>{{ authors }}</div>
     <div class="dateline">{{ abs_date_line(arxiv_id, submitted_date, version, submission_history) }}</div>
     {#- TODO: the 'replace' call may not behave in the same way as line_feed_to_br filter in arxiv-browse -#}
     {#- TODO: arxiv-base filters may need to be Markup aware so that filters can be ordered arbitrarily and explicit escape is not needed -#}
-    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|escape|urlize|abstract_lf_to_br|safe }}</blockquote>
+    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|abstract_lf_to_br|urlize|safe }}</blockquote>
     <!--CONTEXT-->
     <div class="metatable">
       <table summary="Additional metadata">

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -133,7 +133,7 @@
     <div class="authors"><span class="descriptor">Authors:</span>{{ authors }}</div>
     <div class="dateline">{{ abs_date_line(arxiv_id, submitted_date, version, submission_history) }}</div>
 
-    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf|urlize|replace('\n\n', '<br />')|safe }}</blockquote>
+    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|urlize|replace('\n\n', '<br />')|safe }}</blockquote>
     <!--CONTEXT-->
     <div class="metatable">
       <table summary="Additional metadata">

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -132,8 +132,6 @@
     <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ title|tex2utf|urlize|safe }}</h1>
     <div class="authors"><span class="descriptor">Authors:</span>{{ authors }}</div>
     <div class="dateline">{{ abs_date_line(arxiv_id, submitted_date, version, submission_history) }}</div>
-    {#- TODO: the 'replace' call may not behave in the same way as line_feed_to_br filter in arxiv-browse -#}
-    {#- TODO: arxiv-base filters may need to be Markup aware so that filters can be ordered arbitrarily and explicit escape is not needed -#}
     <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|abstract_lf_to_br|urlize|safe }}</blockquote>
     <!--CONTEXT-->
     <div class="metatable">

--- a/arxiv/util/tests/test_tex2utf.py
+++ b/arxiv/util/tests/test_tex2utf.py
@@ -11,15 +11,30 @@ class TextTex2Utf(TestCase):
         utf_out = tex2utf(test_str)
         self.assertEqual(utf_out, test_str)
 
+        utf_out = tex2utf(test_str, letters=False)
+        self.assertEqual(utf_out, test_str)
+
         test_str = "\\'e"
         utf_out = tex2utf(test_str)
         self.assertEqual(utf_out, chr(0xe9))
-        #<test><args>\'e</args><func>tex2UTF</func><out>&#xe9;</out></test>
 
         test_str = "\\'E"
         utf_out = tex2utf(test_str)
         self.assertEqual(utf_out, chr(
             0xc9))
+
+        test_str = "\\'E"
+        utf_out = tex2utf(test_str, letters=True)
+        self.assertEqual(utf_out, chr(
+            0xc9))
+
+        test_str = "\\'E"
+        utf_out = tex2utf(test_str, letters=False)
+        self.assertEqual(utf_out, chr(0xc9))
+
+        test_str = "\\'E"
+        utf_out = tex2utf(test_str, False)
+        self.assertEqual(utf_out, chr(0xc9))
 
         # single textsymbol
         test_str = '\\OE'
@@ -53,6 +68,15 @@ class TextTex2Utf(TestCase):
         utf_out = tex2utf(test_str)
         self.assertEqual(utf_out, chr(
             0x03b1))
+
+        test_str = '\\alpha'
+        utf_out = tex2utf(test_str, True)
+        self.assertEqual(utf_out, chr(
+            0x03b1))
+
+        test_str = '\\alpha'
+        utf_out = tex2utf(test_str, False)
+        self.assertEqual(utf_out, r'\alpha')
 
         # simple test_string of greek
         test_str = '\\alpha\\beta\gamma'
@@ -116,7 +140,8 @@ class TextTex2Utf(TestCase):
         # textlet followed by underscore (for subscript)
         test_str = 'foo \\alpha_\\beta_\\gamma_7'
         utf_out = tex2utf(test_str)
-        self.assertEqual(utf_out, 'foo ' + chr(0x03b1) + '_' + chr(0x03b2) + '_' + chr(0x03b3) + '_7')
+        self.assertEqual(utf_out, 'foo ' + chr(0x03b1) + '_' +
+                         chr(0x03b2) + '_' + chr(0x03b3) + '_7')
 
     # <test><args>\'E</args><func>tex2UTF</func><out>&#xc9;</out></test>
     def test_tex2utf_curly(self):
@@ -125,8 +150,8 @@ class TextTex2Utf(TestCase):
         self.assertEqual(utf_out, chr(
             0xe9))
 
-        #<test><args>\'{e}</args><func>tex2UTF</func><out>&#xe9;</out></test>
-        #<test><args>{\'e}</args><func>tex2UTF</func><out>{&#xe9;}</out></test>
+        # <test><args>\'{e}</args><func>tex2UTF</func><out>&#xe9;</out></test>
+        # <test><args>{\'e}</args><func>tex2UTF</func><out>{&#xe9;}</out></test>
 
     def test_ARXIVDEV2322fixes(self):
         test_str = "ARXIVDEV-2322 \\u{A} fix"

--- a/arxiv/util/tex2utf.py
+++ b/arxiv/util/tex2utf.py
@@ -85,8 +85,9 @@ textlet = {
     'nu': 0x03bd, 'xi': 0x03be, 'omicron': 0x03bf,
     'pi': 0x03c0, 'rho': 0x03c1, 'varsigma': 0x03c2,
     'sigma': 0x03c3, 'tau': 0x03c4, 'upsion': 0x03c5,
-    'phi': 0x03c6, 'chi': 0x03c7, 'psi': 0x03c8,
-    'omega': 0x03c9,
+    'varphi': 0x03C6,  # φ
+    'phi':  0x03D5,  # ϕ
+    'chi': 0x03c7, 'psi': 0x03c8, 'omega': 0x03c9,
 }
 
 
@@ -117,8 +118,7 @@ def _textsym_sub(match: Match) -> str:
 
 
 def texch2UTF(acc: str) -> str:
-    """
-    Convert single character TeX accents to UTF-8.
+    """Convert single character TeX accents to UTF-8.
 
     Strip non-whitepsace characters from any sequence not recognized (hence
     could return an empty string if there are no word characters in the input
@@ -132,25 +132,25 @@ def texch2UTF(acc: str) -> str:
         return re.sub(r'[^\w]+', '', acc, flags=re.IGNORECASE)
 
 
-#   my ($acc)=@_;
-#   #warn "acc = $acc\n";
-#   return(chr($accents{$acc})) if (defined($accents{$acc}));
-#   #warn "Unknown accent '$acc'\n";
-#   $acc=~s/[^\w]+//ig;
-#   return($acc);
-# }
-#
+def tex2utf(tex: str, letters: bool = True) -> str:
+    r"""Convert some TeX accents and greek symbols to UTF-8 characters.
 
-def tex2utf(tex: str) -> str:
-    """Converts some accents and greek TeX to utf8."""
-    # This is Legacy stuff and might not be needed if we move toward all utf8
+    :param tex: Text to filter.
 
+    :param letters: If False, do not convert greek letters or
+    ligatures.  Greek symbols can cause problems. Ex. \phi is not
+    suppose to look like φ. φ looks like \varphi.  See ARXIVNG-1612
+
+    :returns: string, possibly with some TeX replaced with UTF8
+
+    """
     # Do dotless i,j -> plain i,j where they are part of an accented i or j
     utf = re.sub(r"/(\\['`\^\"\~\=\.uvH])\{\\([ij])\}", r"\g<1>\{\g<2>\}", tex)
-    # $utf =~ s/(\\['`\^"\~\=\.uvH])\{\\([ij])\}/$1\{$2\}/g; #'
 
     # Now work on the Tex sequences, first those with letters only match
-    utf = textlet_pattern.sub(_textlet_sub, utf)
+    if letters:
+        utf = textlet_pattern.sub(_textlet_sub, utf)
+
     utf = textsym_pattern.sub(_textsym_sub, utf)
 
     utf = re.sub(r'\{\\j\}|\\j\s', 'j', utf)  # not in Unicode?
@@ -158,26 +158,21 @@ def tex2utf(tex: str) -> str:
     # reduce {{x}}, {{{x}}}, ... down to {x}
     while re.search(r'\{\{([^\}]*)\}\}', utf):
         utf = re.sub(r'\{\{([^\}]*)\}\}', r'{\g<1>}', utf)
-        # $utf =~ s/\{\{([^\}]*)\}\}/{$1}/g;
 
     # Accents which have a non-letter prefix in TeX, first \'e
-    # $utf =~ s/\\(['`\^"\~\=\.][a-zA-Z])/&texch2UTF($1)/eg; #'
     utf = re.sub(r'\\([\'`^"~=.][a-zA-Z])',
                  lambda m: texch2UTF(m.group(1)), utf)
 
     # then \'{e} form:
-    # $utf =~ s/\\(['`\^"\~\=\.])\{([a-zA-Z])\}/&texch2UTF("$1$2")/eg; #'
     utf = re.sub(r'\\([\'`^"~=.])\{([a-zA-Z])\}',
                  lambda m: texch2UTF(m.group(1) + m.group(2)), utf)
 
     # Accents which have a letter prefix in TeX
     #  \u{x} u above (breve), \v{x}   v above (caron), \H{x}   double accute...
-    # $utf =~ s/\\([Hckoruv])\{([a-zA-Z])\}/&texch2UTF("$1$2")/eg;
     utf = re.sub(r'\\([Hckoruv])\{([a-zA-Z])\}',
                  lambda m: texch2UTF(m.group(1) + m.group(2)), utf)
 
     # Don't do \t{oo} yet,
-    # $utf =~ s/\\t\{([^\}])\}/$2/g;
     utf = re.sub(r'\\t{([^\}])\}', r'\g<1>', utf)
 
     # bdc34: commented out in original Perl

--- a/arxiv/util/tex2utf.py
+++ b/arxiv/util/tex2utf.py
@@ -2,12 +2,6 @@
 import re
 from typing import Pattern, Dict, Match
 
-# Hash to lookup tex markup and convert to Unicode
-#
-# macron is line above character (overbar \= in Tex)
-# caron is v-shape above (\v{ } in Tex)
-# See: http://www.unicode.org/charts/
-
 accents = {
     # first accents with non-letter prefix, e.g. \'A
     "'A": 0x00c1, "'C": 0x0106, "'E": 0x00c9, "'I": 0x00cd,
@@ -63,6 +57,14 @@ accents = {
     'vr': 0x0159, 'vs': 0x0161, 'vt': 0x0165, 'vu': 0x01d4,
     'vz': 0x017e
 }
+r"""
+Hash to lookup tex markup and convert to Unicode.
+
+macron: a line above character (overbar \={} in TeX)
+caron: v-shape above character (\v{ } in TeX)
+See: http://www.unicode.org/charts/
+
+"""
 
 textlet = {
     'AA': 0x00c5, 'AE': 0x00c6, 'DH': 0x00d0, 'DJ': 0x0110,


### PR DESCRIPTION
This adds some missing URL definitions that went missing:
* `abs`
* `abs_by_id`
* `clickthrough`

There are also some minor fixes to filters and the `abs` macro:
* add `abstract_lf_to_br` filter
* add Markup awareness to tex2utf filter
* proper escaping

With this branch activated on browse, all tests pass. A separate PR for browse is forthcoming.
