### PR TITLE
add new Matomo tracking code

### DIFF
--- a/arxiv/base/templates/base/base.html
+++ b/arxiv/base/templates/base/base.html
@@ -8,7 +8,7 @@
   </head>
   <body>
   {% import "base/macros.html" as macros %}
-  <noscript><img src="//webanalytics.library.cornell.edu/piwik.php?idsite=538&rec=1" style="border:0;" alt="" /></noscript>
+  <noscript><p><img src="https://webstats.arxiv.org/matomo.php?idsite=1&amp;rec=1" style="border:0;" alt="" /></p></noscript>
   <header>
     {% block header %}
     {% include "base/header.html" %}

--- a/arxiv/base/templates/base/head.html
+++ b/arxiv/base/templates/base/head.html
@@ -43,14 +43,20 @@
 <script src='//static.arxiv.org/MathJax-2.7.3/MathJax.js'></script>
 
 <script src="{{ url_for('base.static', filename='js/notification.js') }}"></script>
-<!-- Piwik -->
+<!-- Matomo -->
 <script type="text/javascript">
-var _paq = _paq || [];
-_paq.push(["setDomains", ["*.arxiv.org"]]);
-_paq.push(['trackPageView']);
-_paq.push(['enableLinkTracking']);
-(function()
-{ var u="//webanalytics.library.cornell.edu/"; _paq.push(['setTrackerUrl', u+'piwik.php']); _paq.push(['setSiteId', 538]); var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s); }
-)();
+  var _paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+  _paq.push(["setCookieDomain", "*.arxiv.org"]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://webstats.arxiv.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '1']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
 </script>
-<!-- End Piwik Code -->
+<!-- End Matomo Code -->


### PR DESCRIPTION
Whenever it's time to pull this in -- here is the tracking code for the new Matomo.
I checked with Chris and he said that it is OK to have the new code implemented on some pages and the old code on others if we want to or need to; the log import would cover that. He did say, however, NOT to have both trackers running on the same page so that it doesn't get double counted.

For the donate button tracking, this needs to get implemented for arxiv-docs specifically.
The new Matomo has other options if we need to configure download formats to track or any other custom variables. I tried to just match what we had in the old Piwik for now.