### PR TITLE
DOI linking regression 

### DIFF
--- a/arxiv/base/filters.py
+++ b/arxiv/base/filters.py
@@ -10,8 +10,7 @@ from typing import Union
 from flask import Flask
 from jinja2 import Markup, escape
 
-from arxiv.base.urls import urlize, url_for_doi, canonical_url, \
-    clickthrough_url
+from arxiv.base.urls import urlizer, canonical_url, clickthrough_url
 from arxiv.util.tex2utf import tex2utf
 from arxiv.taxonomy import get_category_display, get_archive_display, \
     get_group_display
@@ -98,7 +97,7 @@ def register_filters(app: Flask) -> None:
 
     """
     app.template_filter('abstract_lf_to_br')(abstract_lf_to_br)
-    app.template_filter('urlize')(urlize)
+    app.template_filter('urlize')(urlizer)
     app.template_filter('tex2utf')(partial(f_tex2utf, letters=True))
     app.template_filter('tex2utf_no_symbols')(partial(f_tex2utf, letters=False))
     app.template_filter('canonical_url')(canonical_url)
@@ -109,3 +108,4 @@ def register_filters(app: Flask) -> None:
     app.template_filter('embed_content')(embed_content)
     app.template_filter('tidy_filesize')(tidy_filesize)
     app.template_filter('as_eastern')(as_eastern)
+    app.template_filter('abs_doi_to_urls')(urlizer('doi_field'))

--- a/arxiv/base/filters.py
+++ b/arxiv/base/filters.py
@@ -97,7 +97,7 @@ def register_filters(app: Flask) -> None:
 
     """
     app.template_filter('abstract_lf_to_br')(abstract_lf_to_br)
-    app.template_filter('urlize')(urlizer)
+    app.template_filter('urlize')(urlizer())
     app.template_filter('tex2utf')(partial(f_tex2utf, letters=True))
     app.template_filter('tex2utf_no_symbols')(partial(f_tex2utf, letters=False))
     app.template_filter('canonical_url')(canonical_url)
@@ -108,4 +108,4 @@ def register_filters(app: Flask) -> None:
     app.template_filter('embed_content')(embed_content)
     app.template_filter('tidy_filesize')(tidy_filesize)
     app.template_filter('as_eastern')(as_eastern)
-    app.template_filter('abs_doi_to_urls')(urlizer('doi_field'))
+    app.template_filter('abs_doi_to_urls')(urlizer(['doi_field']))

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -176,7 +176,7 @@
         {%- if doi %}
         <tr>
           <td class="tablecell label"><abbr title="Digital Object Identifier">DOI</abbr>:</td>
-          <td class="tablecell msc_classes"><a href="{{ doi|urlize }}">{{ doi }}</a></td>
+          <td class="tablecell msc_classes">{{ doi|abs_doi_to_urls }}</td>
         </tr>
         {% endif -%}
         {%- if report_num %}

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -176,7 +176,7 @@
         {%- if doi %}
         <tr>
           <td class="tablecell label"><abbr title="Digital Object Identifier">DOI</abbr>:</td>
-          <td class="tablecell msc_classes">{{ doi|abs_doi_to_urls }}</td>
+          <td class="tablecell msc_classes">{{ doi|escape|abs_doi_to_urls|safe }}</td>
         </tr>
         {% endif -%}
         {%- if report_num %}

--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -312,7 +312,7 @@ def urlizer(kinds: List[str] = DEFAULT_KINDS) -> Callable_Linker:
     """Generate a function to convert tokens to links.
 
     If the urlizing funciton is going to be reused, this is more
-    efficent than urlize because this will only call _get_linker()
+    efficient than urlize because this will only call _get_linker()
     once. urlize() will call _get_linker() on each call to urlize(txt)
 
     Parameters

--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -311,7 +311,7 @@ def urlize(text: str, kinds: List[str] = DEFAULT_KINDS) -> str:
 def urlizer(kinds: List[str] = DEFAULT_KINDS) -> Callable_Linker:
     """Generate a function to convert tokens to links.
 
-    If the urlizing funciton is going to be reused, this is more
+    If the urlizing function is going to be reused, this is more
     efficient than urlize because this will only call _get_linker()
     once. urlize() will call _get_linker() on each call to urlize(txt)
 

--- a/arxiv/base/urls/tests/test_urlize.py
+++ b/arxiv/base/urls/tests/test_urlize.py
@@ -1,8 +1,7 @@
 import unittest
 from unittest import mock
-import re
 
-from jinja2 import Markup, escape
+from jinja2 import escape
 from .. import links
 
 
@@ -15,7 +14,7 @@ def mock_url_for(endpoint, **kwargs):
 class Id_Patterns_Test(unittest.TestCase):
     def test_arxiv_ids(self):
         def find_match(txt):
-            ptn = links._get_pattern(links.SUPPORTED_KINDS)
+            ptn = links._get_pattern(links.DEFAULT_KINDS)
             return ptn.search(txt)
 
         self.assertIsNotNone(find_match('math/9901123'))
@@ -33,7 +32,7 @@ class Id_Patterns_Test(unittest.TestCase):
 
     def test_find_match(self):
         def find_match(txt):
-            ptn = links._get_pattern(links.SUPPORTED_KINDS)
+            ptn = links._get_pattern(links.DEFAULT_KINDS)
             return ptn.search(txt)
 
         self.assertIsNone(find_match('junk'))
@@ -55,9 +54,10 @@ class TestURLize(unittest.TestCase):
     @mock.patch(f'{links.__name__}.clickthrough')
     def test_doi(self, mock_clickthrough):
         mock_clickthrough.clickthrough_url = lambda url: f'http://arxiv.org/clickthrough?url={url}'
+        self.maxDiff = 3000
         self.assertEqual(
             links.urlize('here is a rando doi doi:10.1109/5.771073 that needs a link'),
-            'here is a rando doi doi:<a class="link-http" data-doi="10.1109/5.771073" href="http://arxiv.org/clickthrough?url=https://dx.doi.org/10.1109/5.771073">10.1109/5.771073</a> that needs a link'
+            'here is a rando doi doi:<a class="link-http link-external" data-doi="10.1109/5.771073" href="http://arxiv.org/clickthrough?url=https://dx.doi.org/10.1109/5.771073" rel="external noopener nofollow">10.1109/5.771073</a> that needs a link'
         )
 
     def test_transform_token(self):
@@ -271,3 +271,45 @@ class TestURLize(unittest.TestCase):
                          'Should handle two DOIs in a row correctly')
 
 
+    @mock.patch(f'{links.__name__}.clickthrough')
+    def test_broad_doi(self, mock_clickthrough):
+        mock_clickthrough.clickthrough_url = lambda x: x
+
+        broad_doi_fn = links.urlizer(['doi_field'])
+        
+        self.assertRegex(broad_doi_fn('10.1088/1475-7516/2018/07/009'),
+                         r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
+
+        self.assertRegex(broad_doi_fn('10.1088/1475-7516/2019/02/E02/meta'),
+                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
+        self.assertRegex(broad_doi_fn('10.1088/1475-7516/2019/02/E02/META'),
+                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
+        self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2018/07/009'),
+                         r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
+
+        self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2019/02/E02/meta'),
+                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
+        self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2019/02/E02/META'),
+                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
+        
+        txt = broad_doi_fn('10.1088/1475-7516/2018/07/009 10.1088/1475-7516/2019/02/E02/meta' )
+        self.assertNotRegex(txt, r'this.*URL',
+                            'DOIs should not get the generic "this https URL" they should have the DOI text')
+        self.assertRegex(txt, r'<a.*>10.1088/1475-7516/2018/07/009</a> <a.*>10.1088/1475-7516/2019/02/E02/meta</a>',
+                         'Should handle two DOIs in a row correctly')
+
+        urlized_doi = broad_doi_fn('10.1175/1520-0469(1996)053<0946:ASTFHH>2.0.CO;2')
+
+        self.assertNotIn('href="http://2.0.CO"',
+                         urlized_doi,
+                         "Should not have odd second <A> tag for DOI urlize for ao-sci/9503001 see ARXIVNG-2049")
+
+        leg_rx = r'<a .* href="https://dx.doi.org/10.1175/1520-0469%281996%29053%3C0946%3AASTFHH%3E2.0.CO%3B2".*'
+        self.assertRegex(urlized_doi, leg_rx,
+                         "Should handle Complex DOI for ao-sci/9503001 see ARXIVNG-2049")
+
+        # in legacy:
+        # <a href="/ct?url=https%3A%2F%2Fdx.doi.org%2F10.1175%252F1520-0469%25281996%2529053%253C0946%253AASTFHH%253E2.0.CO%253B2&amp;v=34a1af05">10.1175/1520-0469(1996)053&lt;0946:ASTFHH&gt;2.0.CO;2</a>
+
+        # Post clickthrough on legacy goes to :
+        # https://dx.doi.org/10.1175%2F1520-0469%281996%29053%3C0946%3AASTFHH%3E2.0.CO%3B2


### PR DESCRIPTION
Fixes regression with DOIs in base by adding a specialized urlizer kind for the abs DOI field.

This will be needed for browse 0.2.1

https://arxiv-org.atlassian.net/browse/ARXIVNG-2049