### PR TITLE
Sorting /abs secondaries by ID

### DIFF
--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -152,7 +152,7 @@
           <td class="tablecell label">Subjects:</td>
           <td class="tablecell subjects">
             <span class="primary-subject">{{ primary_category|get_category_display }}</span>
-            {%- for category in secondary_categories -%}; {{ category|get_category_display }}{%- endfor -%}
+            {%- for category in secondary_categories|sort(attribute='id') -%}; {{ category|get_category_display }}{%- endfor -%}
           </td>
         </tr>
         {%- if msc_class %}
@@ -229,7 +229,7 @@ Date: {{ (submitted_date|as_eastern).strftime("%a, %-d %b %Y %H:%M:%S ET") }}   
 
 Title: {{ title }}
 Authors: {{ authors }}
-Categories: {{ primary_category }}{%- for category in secondary_categories -%} {{ category }}{%- endfor %}
+Categories: {{ primary_category }}{%- for category in secondary_categories|sort(attribute='id') -%} {{ category }}{%- endfor %}
 {% if comments -%}{{ ("Comments: " + comments)|wordwrap(77, wrapstring="\n  ") }}{%- endif %}
 {% if msc_class -%}MSC classes: {{ msc_class }}{%- endif %}
 {% if acm_class -%}ACM classes: {{ acm_class }}{%- endif %}


### PR DESCRIPTION
The crosses are in a different order for https://beta.arxiv.org/abs/0906.3421 compared to https://beta.arxiv.org/abs_classic/0906.3421 

Classic: Statistical Mechanics (cond-mat.stat-mech); Mathematical Physics (math-ph) 
NG: Mathematical Physics (math-ph); Statistical Mechanics (cond-mat.stat-mech) 

This fixes the order of the secondaries. 

https://arxiv-org.atlassian.net/browse/ARXIVNG-2066

This will need to be in a release of base for use in browse-0.2.1.
