### PR TITLE
ARXIVNG-2068: Urlize no longer turns category names like math.CO into urls

### DIFF
--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -33,14 +33,12 @@ handle FTP addresses.
 Updated 20 March, 2019: refactored to provide independent bleach attribute
 callbacks for each kind of link.
 """
-from typing import Optional, List, Pattern, Match, Tuple, Callable, \
-    NamedTuple, Dict, Union, Mapping
+from typing import List, Pattern, Tuple, Callable, Dict, Union
 import re
-from functools import partial, reduce
+from functools import reduce
 from urllib.parse import quote, urlparse
 
 from flask import url_for
-from jinja2 import Markup, escape
 import bleach
 
 from arxiv.taxonomy import CATEGORIES
@@ -73,7 +71,7 @@ https://www.crossref.org/blog/dois-and-matching-regular-expressions/
 """
 
 
-BROAD_DOI=re.compile(r'(?P<doi>10\.\d{4,5}\/\S+)', re.I)
+BROAD_DOI = re.compile(r'(?P<doi>10\.\d{4,5}\/\S+)', re.I)
 """
 Very broad pattern for matching DOIs in the abs DOI field.
 
@@ -154,8 +152,9 @@ def _add_rel(attrs: Attrs, new: bool = False) -> Attrs:
     else:
         return _add_rel_internal(attrs, new)
 
+
 def _add_rel_external(attrs: Attrs, new: bool = False) -> Attrs:
-    """Always adds external rel."""
+    """Add an external rel."""
     # noopener for security reasons
     # nofollow to disencentivie arXiv articles for SEO
     # external says that link is away from arxiv
@@ -163,10 +162,12 @@ def _add_rel_external(attrs: Attrs, new: bool = False) -> Attrs:
     _extend_class_attr(attrs, 'link-external')
     return attrs
 
+
 def _add_rel_internal(attrs: Attrs, new: bool = False) -> Attrs:
-    """Always adds interal rel."""
+    """Add an interal rel."""
     _extend_class_attr(attrs, 'link-internal')
     return attrs
+
 
 def _this_url_text(attrs: Attrs, new: bool = False) -> Attrs:
     o = urlparse(attrs[(None, 'href')])
@@ -231,13 +232,17 @@ def _handle_doi_url(attrs: Attrs, new: bool = False) -> Attrs:
         attrs[(None, 'data-doi')] = target     # Add arxiv="<arxiv id>"
     return attrs
 
+
 ENDS_WITH_TLD = r".*\.(" + TLDS + ")$"
 CATEGORIES_THAT_COULD_BE_HOSTNAMES = '|'.join([cat_id for cat_id in CATEGORIES.keys()
-                    if re.search(ENDS_WITH_TLD, cat_id, re.IGNORECASE)])
+                                               if re.search(ENDS_WITH_TLD, cat_id, re.IGNORECASE)])
 DONT_URLIZE_CATS = re.compile(CATEGORIES_THAT_COULD_BE_HOSTNAMES,
-                              re.IGNORECASE|re.UNICODE)
+                              re.IGNORECASE | re.UNICODE)
+
+
 def _dont_urlize_arxiv_categories(attrs: Attrs, new: bool = False) -> Attrs:
-    """Prevents urlizing archive categories that look like hostnames.    
+    """
+    Prevent urlizing archive categories that look like hostnames.
 
     Ex. don't urlize math.CO but do urlize supermath.co
     """
@@ -246,6 +251,7 @@ def _dont_urlize_arxiv_categories(attrs: Attrs, new: bool = False) -> Attrs:
         return None
     else:
         return attrs
+
 
 PATTERNS = {
     'doi': DOI,
@@ -272,7 +278,7 @@ callbacks = {
 def _get_pattern(kinds: List[str]) -> Pattern:
     return re.compile(
         '|'.join([rf'(?:{PATTERNS[kind].pattern})' for kind
-                 in sorted(kinds, key=lambda kind: ORDER.index(kind))]),
+                  in sorted(kinds, key=lambda kind: ORDER.index(kind))]),
         re.IGNORECASE | re.VERBOSE | re.UNICODE
     )
 
@@ -290,7 +296,7 @@ def _get_linker_of_kind(kind: str) -> Callable_Linker:
 
 
 def _compose_list_of_funcs(fv: List[Callable_Linker]) -> Callable_Linker:
-    """Returns function that calls fv functions one after another."""
+    """Return function that calls fv functions one after another."""
     if not fv:
         return lambda x: x
     return reduce(lambda f, g: lambda x: f(g(x)), fv[1:], fv[0])
@@ -298,7 +304,8 @@ def _compose_list_of_funcs(fv: List[Callable_Linker]) -> Callable_Linker:
 
 def _get_linker(kinds: List[str]) -> Callable_Linker:
     if len(kinds) > 1 and 'doi_field' in kinds:
-        raise ValueError('doi_field should not be used in combination with other kinds')
+        raise ValueError(
+            'doi_field should not be used in combination with other kinds')
     ordered_linkers = [_get_linker_of_kind(kind) for kind
                        in sorted(kinds, key=lambda kind: ORDER.index(kind))]
     return _compose_list_of_funcs(ordered_linkers)

--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -248,7 +248,7 @@ def _dont_urlize_arxiv_categories(attrs: Attrs, new: bool = False) -> Attrs:
     """
     url = urlparse(attrs[(None, 'href')])
     if DONT_URLIZE_CATS.match(url.netloc):
-        return None
+        return None  # type: ignore
     else:
         return attrs
 

--- a/arxiv/base/urls/tests/test_urlize.py
+++ b/arxiv/base/urls/tests/test_urlize.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import mock
+import re
 
 from jinja2 import escape
 from .. import links
@@ -51,6 +52,12 @@ class Id_Patterns_Test(unittest.TestCase):
 
 
 class TestURLize(unittest.TestCase):
+            
+    def test_dont_urlize_cats( self ):
+        self.assertGreater(len(links.CATEGORIES_THAT_COULD_BE_HOSTNAMES), 0,
+                           'The links.CATEGORIES_THAT_COULD_BE_HOSTNAMES must not be empty or it will match everything')
+
+        
     @mock.patch(f'{links.__name__}.clickthrough')
     def test_doi(self, mock_clickthrough):
         mock_clickthrough.clickthrough_url = lambda url: f'http://arxiv.org/clickthrough?url={url}'
@@ -313,3 +320,11 @@ class TestURLize(unittest.TestCase):
 
         # Post clickthrough on legacy goes to :
         # https://dx.doi.org/10.1175%2F1520-0469%281996%29053%3C0946%3AASTFHH%3E2.0.CO%3B2
+
+
+    def test_dont_urlize_category_name(self):
+        urlize = links.urlizer()
+        self.assertEqual(urlize('math.CO'), 'math.CO',
+                         'category name math.CO should not get urlized')
+        self.assertIn('href="http://supermath.co', urlize('supermath.co'),
+                      'hostname close to category name should get urlized')


### PR DESCRIPTION
ARXIVNG-2068