### PR TITLE
ARXIVNG-2085 addressing memory leak in production

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ wtforms = "*"
 bleach = "*"
 "flask-s3" = "*"
 "backports-datetime-fromisoformat" = "==1.0.0"
+arxiv-base = {path = "."}
 
 [dev-packages]
 pydocstyle = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,6 @@ wtforms = "*"
 bleach = "*"
 "flask-s3" = "*"
 "backports-datetime-fromisoformat" = "==1.0.0"
-arxiv-base = {path = "."}
 
 [dev-packages]
 pydocstyle = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0ea0094d0488a8c74c01da3bc37b7b164f37a0f652ad50636bb78b501b59db12"
+            "sha256": "3818600507b94947fa0933d18577e03ca9f40cd2f6a064e3d7aabab4a3ddbe7c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,9 +14,6 @@
         ]
     },
     "default": {
-        "arxiv-base": {
-            "path": "."
-        },
         "attrs": {
             "hashes": [
                 "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d110bbdfa41cd2a4a22e644be24c7c8f2c42590ee5dd7904ed7808e3ae3d7c6a"
+            "sha256": "0ea0094d0488a8c74c01da3bc37b7b164f37a0f652ad50636bb78b501b59db12"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -49,10 +49,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:691a6fb8ef0edbe2aebe2c1b2707cac9b3f120a87f1c70af014e02542cf398a0",
-                "sha256:a0275f9b7cab4cab3a701ce53c8711c1a45b77bf1d719b9af9ed232f4abee99a"
+                "sha256:3b5968fc897b590c2b57fd6105b52ba8bdf5eb2100b7e181d4c17c7c05a2f83a",
+                "sha256:cc270cc2c282b2679f44bd1de011a270c4d8b5364afc2f705152ca187821d4eb"
             ],
-            "version": "==1.12.131"
+            "version": "==1.12.133"
         },
         "click": {
             "hashes": [
@@ -68,9 +68,6 @@
                 "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
             ],
             "version": "==0.14"
-        },
-        "e1839a8": {
-            "path": "."
         },
         "flask": {
             "hashes": [
@@ -188,11 +185,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "uwsgi": {
             "hashes": [
@@ -579,35 +576,36 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
-                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
-                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
-                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
-                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
-                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
-                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
-                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
-                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
-                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
-                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
-                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
-                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
-                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
-                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
-                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
-                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
-                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
-                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
+                "sha256:04894d268ba6eab7e093d43107869ad49e7b5ef40d1a94243ea49b352061b200",
+                "sha256:16616ece19daddc586e499a3d2f560302c11f122b9c692bc216e821ae32aa0d0",
+                "sha256:252fdae740964b2d3cdfb3f84dcb4d6247a48a6abe2579e8029ab3be3cdc026c",
+                "sha256:2af80a373af123d0b9f44941a46df67ef0ff7a60f95872412a145f4500a7fc99",
+                "sha256:2c88d0a913229a06282b285f42a31e063c3bf9071ff65c5ea4c12acb6977c6a7",
+                "sha256:2ea99c029ebd4b5a308d915cc7fb95b8e1201d60b065450d5d26deb65d3f2bc1",
+                "sha256:3d2e3ab175fc097d2a51c7a0d3fda442f35ebcc93bb1d7bd9b95ad893e44c04d",
+                "sha256:4766dd695548a15ee766927bf883fb90c6ac8321be5a60c141f18628fb7f8da8",
+                "sha256:56b6978798502ef66625a2e0f80cf923da64e328da8bbe16c1ff928c70c873de",
+                "sha256:5cddb6f8bce14325b2863f9d5ac5c51e07b71b462361fd815d1d7706d3a9d682",
+                "sha256:644ee788222d81555af543b70a1098f2025db38eaa99226f3a75a6854924d4db",
+                "sha256:64cf762049fc4775efe6b27161467e76d0ba145862802a65eefc8879086fc6f8",
+                "sha256:68c362848d9fb71d3c3e5f43c09974a0ae319144634e7a47db62f0f2a54a7fa7",
+                "sha256:6c1f3c6f6635e611d58e467bf4371883568f0de9ccc4606f17048142dec14a1f",
+                "sha256:b213d4a02eec4ddf622f4d2fbc539f062af3788d1f332f028a2e19c42da53f15",
+                "sha256:bb27d4e7805a7de0e35bd0cb1411bc85f807968b2b0539597a49a23b00a622ae",
+                "sha256:c9d414512eaa417aadae7758bc118868cd2396b0e6138c1dd4fda96679c079d3",
+                "sha256:f0937165d1e25477b01081c4763d2d9cdc3b18af69cb259dd4f640c9b900fe5e",
+                "sha256:fb96a6e2c11059ecf84e6741a319f93f683e440e341d4489c9b161eca251cf2a",
+                "sha256:fc71d2d6ae56a091a8d94f33ec9d0f2001d1cb1db423d8b4355debfe9ce689b7"
             ],
-            "version": "==1.3.1"
+            "version": "==1.3.4"
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "wrapt": {
             "hashes": [

--- a/arxiv/base/__init__.py
+++ b/arxiv/base/__init__.py
@@ -106,6 +106,7 @@ class Base(object):
 
         # Attach the external URL handler as a fallback for failed calls to
         # url_for().
+        app.external_url_adapter = urls.build_adapter(app)
         app.url_build_error_handlers.append(urls.external_url_handler)
 
         filters.register_filters(app)

--- a/arxiv/base/__init__.py
+++ b/arxiv/base/__init__.py
@@ -106,8 +106,7 @@ class Base(object):
 
         # Attach the external URL handler as a fallback for failed calls to
         # url_for().
-        app.external_url_adapter = urls.build_adapter(app)
-        app.url_build_error_handlers.append(urls.external_url_handler)
+        urls.register_external_urls(app)
 
         filters.register_filters(app)
         context_processors.register_context_processors(app)

--- a/arxiv/base/config.py
+++ b/arxiv/base/config.py
@@ -70,10 +70,10 @@ for key, value in os.environ.items():
 
 ARXIV_BUSINESS_TZ = os.environ.get("ARXIV_BUSINESS_TZ", "US/Eastern")
 
-BASE_VERSION = "0.15.5"
+BASE_VERSION = "0.15.6"
 """The version of the arxiv-base package."""
 
-APP_VERSION = "0.15.4"
+APP_VERSION = "0.15.6"
 """The version of the base test app."""
 
 """

--- a/arxiv/base/urls/__init__.py
+++ b/arxiv/base/urls/__init__.py
@@ -104,8 +104,9 @@ def external_url_handler(err: BuildError, endpoint: str, values: Dict) -> str:
     """
     values.pop('_external')
     try:
-        url = current_app.external_url_adapter.build(endpoint, values=values,
-                                                     force_external=True)
+        url: str = current_app.external_url_adapter.build(endpoint,
+                                                          values=values,
+                                                          force_external=True)
     except BuildError:
         # Re-raise the original BuildError, in context of original traceback.
         exc_type, exc_value, tb = sys.exc_info()

--- a/arxiv/base/urls/tests/test_urls.py
+++ b/arxiv/base/urls/tests/test_urls.py
@@ -58,138 +58,59 @@ class TestStaticURLs(TestCase):
 class TestGetURLMap(TestCase):
     """Tests for :func:`arxiv.base.urls.get_url_map`."""
 
-    @mock.patch('arxiv.base.urls._get_base_config')
-    @mock.patch('arxiv.base.urls.current_app')
-    def test_no_urls_configured(self, mock_current_app, mock_base_config):
+    @mock.patch('arxiv.base.urls.base_config', mock.MagicMock(URLS=[]))
+    def test_no_urls_configured(self):
         """No external URLs are defined on the current app nor in base."""
-        mock_current_app.config = {
-            'URLS': []
-        }
-        mock_base_config.return_value = mock.MagicMock(URLS=[])
-        url_map = urls.get_url_map()
-        self.assertEqual(len(url_map._rules), 0, "No URL patterns are loaded")
+        app = mock.MagicMock(config={'URLS': []})
+        adapter = urls.build_adapter(app)
+        self.assertEqual(len(adapter.map._rules), 0,
+                         "No URL patterns are loaded")
 
-    @mock.patch('arxiv.base.urls._get_base_config')
-    @mock.patch('arxiv.base.urls.current_app')
-    def test_base_urls(self, mock_current_app, mock_base_config):
+    @mock.patch('arxiv.base.urls.base_config',
+                mock.MagicMock(URLS=[
+                    ('foo', '/foo', 'foo.org'),
+                    ('bar', '/bar/<string:foo>', 'bar.org'),
+                ]))
+    def test_base_urls(self):
         """Only URLs are defined in base; the current app has none."""
-        mock_current_app.config = {
-            'URLS': []
-        }
-        mock_base_config.return_value = mock.MagicMock(URLS=[
-            ('foo', '/foo', 'foo.org'),
-            ('bar', '/bar/<string:foo>', 'bar.org'),
-        ])
-        url_map = urls.get_url_map()
-        self.assertEqual(len(url_map._rules), 2, "Only base URLs are loaded")
+        app = mock.MagicMock(config={'URLS': []})
+        adapter = urls.build_adapter(app)
+        self.assertEqual(len(adapter.map._rules), 2,
+                         "Only base URLs are loaded")
 
-    @mock.patch('arxiv.base.urls._get_base_config')
-    @mock.patch('arxiv.base.urls.current_app')
-    def test_combined_urls(self, mock_current_app, mock_base_config):
+    @mock.patch('arxiv.base.urls.base_config',
+                mock.MagicMock(URLS=[
+                    ('foo', '/foo', 'foo.org'),
+                    ('bar', '/bar/<string:foo>', 'bar.org'),
+                ]))
+    def test_combined_urls(self):
         """Only non-overlapping URLs are defined in base and the app."""
-        mock_current_app.config = {
+        app = mock.MagicMock(config={
             'URLS': [
                 ('baz', '/baz', 'baz.org'),
                 ('bat', '/bat/<string:foo>', 'bat.org'),
             ]
-        }
-        mock_base_config.return_value = mock.MagicMock(URLS=[
-            ('foo', '/foo', 'foo.org'),
-            ('bar', '/bar/<string:foo>', 'bar.org'),
-        ])
-        url_map = urls.get_url_map()
-        self.assertEqual(len(url_map._rules), 4, "All URLs are loaded")
+        })
+        adapter = urls.build_adapter(app)
+        self.assertEqual(len(adapter.map._rules), 4, "All URLs are loaded")
 
-    @mock.patch('arxiv.base.urls._get_base_config')
-    @mock.patch('arxiv.base.urls.current_app')
-    def test_overlapping_urls(self, mock_current_app, mock_base_config):
+    @mock.patch('arxiv.base.urls.base_config', mock.MagicMock(URLS=[
+                    ('baz', '/foo', 'foo.org'),
+                    ('bar', '/bar/<string:foo>', 'bar.org'),
+                ]))
+    def test_overlapping_urls(self):
         """Overlapping URLs are defined in base and the app."""
-        mock_current_app.config = {
+        app = mock.MagicMock(config={
             'URLS': [
                 ('baz', '/baz', 'baz.org'),
                 ('bat', '/bat/<string:foo>', 'bat.org'),
             ]
-        }
-        mock_base_config.return_value = mock.MagicMock(URLS=[
-            ('baz', '/foo', 'foo.org'),
-            ('bar', '/bar/<string:foo>', 'bar.org'),
-        ])
-        url_map = urls.get_url_map()
-        self.assertEqual(len(url_map._rules), 3, "Duplicate URLs not added")
-        adapter = url_map.bind('nope.com', url_scheme='https')
+        })
+        adapter = urls.build_adapter(app)
+        self.assertEqual(len(adapter.map._rules), 3,
+                         "Duplicate URLs not added")
         self.assertEqual(adapter.build('baz'), 'https://baz.org/baz',
                          "The application config is preferred to base")
-
-
-class TestExternalURLFor(TestCase):
-    """Tests for :func:`arxiv.base.urls.external_url_for`."""
-
-    @mock.patch('arxiv.base.urls._get_base_config')
-    @mock.patch('arxiv.base.urls.current_app')
-    def test_no_urls_configured(self, mock_current_app, mock_base_config):
-        """No external URLs are defined on the current app nor in base."""
-        mock_current_app.config = {
-            'URLS': []
-        }
-        mock_base_config.return_value = mock.MagicMock(URLS=[])
-        with self.assertRaises(BuildError):
-            urls.external_url_for('foo')
-
-    @mock.patch('arxiv.base.urls._get_base_config')
-    @mock.patch('arxiv.base.urls.current_app')
-    def test_base_urls(self, mock_current_app, mock_base_config):
-        """Only URLs are defined in base; the current app has none."""
-        mock_current_app.config = {
-            'URLS': []
-        }
-        mock_base_config.return_value = mock.MagicMock(URLS=[
-            ('foo', '/foo', 'foo.org'),
-            ('bar', '/bar/<string:foo>', 'bar.org'),
-        ])
-        self.assertEqual(urls.external_url_for('foo'), 'https://foo.org/foo')
-        self.assertEqual(urls.external_url_for('bar', foo=1),
-                         'https://bar.org/bar/1')
-
-    @mock.patch('arxiv.base.urls._get_base_config')
-    @mock.patch('arxiv.base.urls.current_app')
-    def test_combined_urls(self, mock_current_app, mock_base_config):
-        """Only non-overlapping URLs are defined in base and the app."""
-        mock_current_app.config = {
-            'URLS': [
-                ('baz', '/baz', 'baz.org'),
-                ('bat', '/bat/<string:foo>', 'bat.org'),
-            ]
-        }
-        mock_base_config.return_value = mock.MagicMock(URLS=[
-            ('foo', '/foo', 'foo.org'),
-            ('bar', '/bar/<string:foo>', 'bar.org'),
-        ])
-        self.assertEqual(urls.external_url_for('foo'), 'https://foo.org/foo')
-        self.assertEqual(urls.external_url_for('baz'), 'https://baz.org/baz')
-        self.assertEqual(urls.external_url_for('bar', foo=1),
-                         'https://bar.org/bar/1')
-        self.assertEqual(urls.external_url_for('bat', foo='yes'),
-                         'https://bat.org/bat/yes')
-
-    @mock.patch('arxiv.base.urls._get_base_config')
-    @mock.patch('arxiv.base.urls.current_app')
-    def test_overlapping_urls(self, mock_current_app, mock_base_config):
-        """Overlapping URLs are defined in base and the app."""
-        mock_current_app.config = {
-            'URLS': [
-                ('baz', '/baz', 'baz.org'),
-                ('bat', '/bat/<string:foo>', 'bat.org'),
-            ]
-        }
-        mock_base_config.return_value = mock.MagicMock(URLS=[
-            ('baz', '/foo', 'foo.org'),
-            ('bar', '/bar/<string:foo>', 'bar.org'),
-        ])
-        self.assertEqual(urls.external_url_for('baz'), 'https://baz.org/baz')
-        self.assertEqual(urls.external_url_for('bar', foo=1),
-                         'https://bar.org/bar/1')
-        self.assertEqual(urls.external_url_for('bat', foo='yes'),
-                         'https://bat.org/bat/yes')
 
 
 class TestExternalURLFallback(TestCase):
@@ -198,7 +119,6 @@ class TestExternalURLFallback(TestCase):
     def setUp(self):
         """Create a Flask app."""
         self.app = Flask('test')
-        Base(self.app)
         self.app.config['URLS'] = [
             ('baz', '/baz', 'baz.org'),
             ('bat', '/bat/<string:foo>', 'bat.org'),
@@ -211,28 +131,30 @@ class TestExternalURLFallback(TestCase):
 
     def test_application_url(self):
         """url_for works as expected for an app-defined URL."""
+        Base(self.app)
         with self.app.app_context():
             self.assertEqual(url_for('something'), 'http://nope.com/something')
 
-    @mock.patch('arxiv.base.urls._get_base_config')
-    def test_url_from_app_config(self, mock_base_config):
+    @mock.patch('arxiv.base.urls.base_config',
+                mock.MagicMock(URLS=[
+                    ('baz', '/foo', 'foo.org'),
+                    ('bar', '/bar/<string:foo>', 'bar.org'),
+                ]))
+    def test_url_from_app_config(self):
         """url_for falls back to URLs from the application config."""
-        mock_base_config.return_value = mock.MagicMock(URLS=[
-            ('baz', '/foo', 'foo.org'),
-            ('bar', '/bar/<string:foo>', 'bar.org'),
-        ])
+        Base(self.app)
         with self.app.app_context():
             self.assertEqual(url_for('bat', foo='yes'),
                              'https://bat.org/bat/yes')
             self.assertEqual(url_for('baz'), 'https://baz.org/baz')
 
-    @mock.patch('arxiv.base.urls._get_base_config')
-    def test_url_from_base_config(self, mock_base_config):
+    @mock.patch('arxiv.base.urls.base_config', mock.MagicMock(URLS=[
+                    ('baz', '/foo', 'foo.org'),
+                    ('bar', '/bar/<string:foo>', 'bar.org'),
+                ]))
+    def test_url_from_base_config(self):
         """url_for falls back to URLs from the application config."""
-        mock_base_config.return_value = mock.MagicMock(URLS=[
-            ('baz', '/foo', 'foo.org'),
-            ('bar', '/bar/<string:foo>', 'bar.org'),
-        ])
+        Base(self.app)
         with self.app.app_context():
             self.assertEqual(url_for('bar', foo=1), 'https://bar.org/bar/1')
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-base',
-    version='0.15.5',
+    version='0.15.6',
     packages=[f'arxiv.{package}' for package
               in find_packages('arxiv', exclude=['*test*'])],
     zip_safe=False,


### PR DESCRIPTION
Earlier versions of this module built Werkzeug routing machinery (Rules, Maps, etc) on the fly. This led to serious memory leaks. As of v0.15.6, :class:`.Base` uses :func:`register_external_urls` to set up external URL handling, which registers a single :class:`.MapAdapter` on a Flask app. This adapter is in turn used by :func:`external_url_handler` on demand.