### PR TITLE
ARXIVNG-2042 Make retry behavior in base Kinesis consumer easier to modify

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ wtforms = "*"
 bleach = "*"
 "flask-s3" = "*"
 "backports-datetime-fromisoformat" = "==1.0.0"
+retry = "*"
 
 [dev-packages]
 pydocstyle = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3818600507b94947fa0933d18577e03ca9f40cd2f6a064e3d7aabab4a3ddbe7c"
+            "sha256": "635d921092e1cfaeb59e64635dc1e7fcddc8f9a21b60ea43952075d32704f908"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -46,10 +46,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:3b5968fc897b590c2b57fd6105b52ba8bdf5eb2100b7e181d4c17c7c05a2f83a",
-                "sha256:cc270cc2c282b2679f44bd1de011a270c4d8b5364afc2f705152ca187821d4eb"
+                "sha256:5c4d9ea1b0fbb1dc98b6a06ed8780096fca981a1c3599bf8f03f338e6aa389ae",
+                "sha256:c59a74539eb081f4b3a307fc5c3d69d8459e30bfaf4b94aa78e74a9a05583764"
             ],
-            "version": "==1.12.133"
+            "version": "==1.12.134"
         },
         "click": {
             "hashes": [
@@ -57,6 +57,13 @@
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
+        },
+        "decorator": {
+            "hashes": [
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+            ],
+            "version": "==4.4.0"
         },
         "docutils": {
             "hashes": [
@@ -144,6 +151,13 @@
             ],
             "version": "==1.1.1"
         },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "version": "==1.8.0"
+        },
         "pyrsistent": {
             "hashes": [
                 "sha256:3ca82748918eb65e2d89f222b702277099aca77e34843c5eb9d52451173970e2"
@@ -165,6 +179,14 @@
             ],
             "index": "pypi",
             "version": "==2019.1"
+        },
+        "retry": {
+            "hashes": [
+                "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606",
+                "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4"
+            ],
+            "index": "pypi",
+            "version": "==0.9.2"
         },
         "s3transfer": {
             "hashes": [
@@ -306,12 +328,12 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:4801b8175e2047abc8034fa1d4bce1a686225aefcfa3e0011d6c08f0324a807d",
-                "sha256:db7d64776d7c0fd04c874c5ab7d32d1b45c7d5d434fd130ce7746ec30c64bfc2",
-                "sha256:e86040269da16622fcc2771a211f93ce93e10fc8fb1f6f622dcd4507ae5670a4"
+                "sha256:4a0ef713f71c49379f1bfb92784063b5cd32899924506b70a86a95625a7e3891",
+                "sha256:c691d1479e2b45b028696b63cebde22dd8607dca53b948407e345391782e32a5",
+                "sha256:f3ca26da5535fc4467793080e35f5be670d28cb618a55a419a6bee3ff856134e"
             ],
             "index": "pypi",
-            "version": "==4.17.1"
+            "version": "==4.17.2"
         },
         "idna": {
             "hashes": [

--- a/arxiv/base/logging.py
+++ b/arxiv/base/logging.py
@@ -49,7 +49,7 @@ def getLogger(name: str, stream: IO = sys.stderr) -> logging.Logger:
     :class:`logging.Logger`
     """
     logger = logging.getLogger(name)
-    logger.propagate = False
+    # logger.propagate = False
     config = get_application_config()
 
     # Set the log level from the Flask app configuration.

--- a/arxiv/integration/kinesis/consumer/__init__.py
+++ b/arxiv/integration/kinesis/consumer/__init__.py
@@ -189,7 +189,7 @@ class BaseConsumer(object):
             'delay': delay,
             'max_delay': max_delay,
             'backoff': backoff,
-            'jitter': jitter
+            'jitter': jitter  #  extra seconds added to delay between retry attempts.
         }
 
         if not self.stream_name or not self.shard_id:

--- a/arxiv/integration/kinesis/consumer/__init__.py
+++ b/arxiv/integration/kinesis/consumer/__init__.py
@@ -227,9 +227,9 @@ class BaseConsumer(object):
 
     def new_client(self) -> boto3.client:
         """Generate a new Kinesis client."""
-        params = {'region_name': self.region,
-                  'aws_access_key_id': self._access_key,
-                  'aws_secret_access_key': self._secret_key}
+        params: Dict[str, Any] = {'region_name': self.region,
+                                  'aws_access_key_id': self._access_key,
+                                  'aws_secret_access_key': self._secret_key}
         if self.endpoint:
             params['endpoint_url'] = self.endpoint
         if self.verify is False:

--- a/arxiv/integration/kinesis/consumer/__init__.py
+++ b/arxiv/integration/kinesis/consumer/__init__.py
@@ -79,7 +79,7 @@ import json
 from pytz import UTC
 from datetime import datetime, timedelta
 import os
-from typing import Any, Optional, Tuple, Generator, Callable, Dict, Union
+from typing import Any, Optional, Tuple, Generator, Callable, Dict, Union, Any
 from contextlib import contextmanager
 import signal
 import warnings
@@ -162,7 +162,7 @@ class BaseConsumer(object):
                  start_type: str = 'AT_TIMESTAMP',
                  start_at: str = NOW, tries: int = 5, delay: int = 5,
                  max_delay: Optional[int] = None, backoff: int = 1,
-                 jitter: Union[int, Tuple[int, int]] = 0, **extra) -> None:
+                 jitter: Union[int, Tuple[int, int]] = 0, **extra: Any) -> None:
         """Initialize a new stream consumer."""
         logger.info(f'New consumer for {stream_name} ({shard_id})')
         self.stream_name = stream_name
@@ -207,6 +207,7 @@ class BaseConsumer(object):
         logger.info('Ready to start')
 
     def get_or_create_stream(self) -> None:
+        """Wait for the stream, and create it if it doesn't exist."""
         logger.info(f'Waiting for {self.stream_name} to be available')
         try:
             self.wait_for_stream(tries=1)
@@ -432,7 +433,7 @@ class BaseConsumer(object):
 def process_stream(Consumer: type, config: dict,
                    checkpointmanager: Optional[Any] = None,
                    duration: Optional[int] = None,
-                   **extra) -> None:
+                   **extra: Any) -> None:
     """
     Configure and run an agent (Kinesis consumer).
 

--- a/arxiv/integration/kinesis/consumer/__init__.py
+++ b/arxiv/integration/kinesis/consumer/__init__.py
@@ -171,7 +171,7 @@ class BaseConsumer(object):
         else:
             self.position = None
         self.duration = duration
-        self.start_time = None
+        self.start_time: Optional[float] = None
         self.back_off = back_off
         self.batch_size = batch_size
         self.sleep_time = 5
@@ -221,7 +221,7 @@ class BaseConsumer(object):
                 ShardCount=1
             )
             logger.info(f'Created; waiting for {self.stream_name} again')
-            self.wait_for_stream(**self.retry_params)
+            self.wait_for_stream(**self.retry_params)   # type: ignore
 
         # Intercept SIGINT and SIGTERM so that we can checkpoint before exit.
         self.exit = False
@@ -358,7 +358,7 @@ class BaseConsumer(object):
         processed = 0
         try:
             time.sleep(self.sleep_time)   # Don't get carried away.
-            next_start, response = self.get_records(start, self.batch_size,
+            next_start, response = self.get_records(start, self.batch_size,   # type: ignore
                                                     **self.retry_params)
         except Exception as e:
             self._checkpoint()

--- a/arxiv/integration/kinesis/consumer/exceptions.py
+++ b/arxiv/integration/kinesis/consumer/exceptions.py
@@ -19,3 +19,7 @@ class StopProcessing(RuntimeError):
 
 class ConfigurationError(RuntimeError):
     """There was a problem with the configuration."""
+
+
+class RestartProcessing(RuntimeError):
+    """Something happened that requires a restart."""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-base',
-    version='0.15.7rc1',
+    version='0.15.7rc8',
     packages=[f'arxiv.{package}' for package
               in find_packages('arxiv', exclude=['*test*'])],
     zip_safe=False,


### PR DESCRIPTION
The Kinesis consumer has some retry handling, e.g. when waiting for the stream to be available. https://github.com/arXiv/arxiv-base/tree/feature/ARXIVNG-1970/arxiv/integration/kinesis 

This is currently not configurable; it should be easy to alter this in a subclass without overriding whole methods. 

This PR eliminates the simple ``retry`` decorator in that module, and uses [``retry``](https://pypi.org/project/retry/) instead. Parameters for retry can be passed to the ``BaseConsumer`` constructor, and are stored in the public attribute ``retry_params``. So the retry behavior can be configured via the app config (``KINESIS_RETRY_x`` params), or a subclass can easily intervene on  ``retry_params``. 

Not perfect. But an improvement. 