### PR TITLE
Removes unwanted urlization in title field of /abs

### DIFF
--- a/arxiv/base/filters.py
+++ b/arxiv/base/filters.py
@@ -109,3 +109,4 @@ def register_filters(app: Flask) -> None:
     app.template_filter('tidy_filesize')(tidy_filesize)
     app.template_filter('as_eastern')(as_eastern)
     app.template_filter('abs_doi_to_urls')(urlizer(['doi_field']))
+    app.template_filter('arxiv_id_urlize')(urlizer(['arxiv_id']))

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -135,7 +135,7 @@
 <div id="content">
   <div id="abs">
 
-    <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ title|tex2utf|urlize|safe }}</h1>
+    <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ title|tex2utf|arxiv_id_urlize|safe }}</h1>
     <div class="authors"><span class="descriptor">Authors:</span>{{ authors }}</div>
     <div class="dateline">{{ abs_date_line(arxiv_id, submitted_date, version, submission_history) }}</div>
     <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|abstract_lf_to_br|urlize|safe }}</blockquote>


### PR DESCRIPTION
This changes the /abs page macro so it only does arxiv-id urlization on the title.

I've made tests for this in arxiv-browse.

https://arxiv-org.atlassian.net/browse/ARXIVNG-2109