### PR TITLE
Fixes race condition due to multithread use of bleach

### DIFF
--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -313,7 +313,12 @@ def _deferred_thread_local_linker_of_kind(kind: str) -> Callable_Linker:
         # This must not be called while the app is starting up, only
         # when the linkiers are being used in requests. So the
         # function is created/cached at call time.
-        return g.get('linkers',{}).get(kind,_get_linker_of_kind(kind))(instr)
+        if 'linkers' not in g:
+            g.linkers = {}
+        if kind not in g.linkers:
+            g.linkers[kind] = _get_linker_of_kind(kind)
+
+        return g.linkers[kind](instr)
 
     return deferred
 

--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -318,7 +318,7 @@ def _deferred_thread_local_linker_of_kind(kind: str) -> Callable_Linker:
         if kind not in g.linkers:
             g.linkers[kind] = _get_linker_of_kind(kind)
 
-        return g.linkers[kind](instr)
+        return g.linkers[kind](instr) #type: ignore
 
     return deferred
 

--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -325,7 +325,7 @@ def _deferred_thread_local_linker_of_kind(kind: str) -> Callable_Linker:
         if kind not in _t_local_linkers.__dict__:
             _t_local_linkers.__dict__[kind] = _get_linker_of_kind(kind)
 
-        return _t_local_linkers.__dict__[kind](instr)
+        return _t_local_linkers.__dict__[kind](instr)  # type: ignore
 
     return deferred
 

--- a/arxiv/base/urls/tests/test_urlize.py
+++ b/arxiv/base/urls/tests/test_urlize.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 import re
-
+from flask import Flask
 from jinja2 import escape
 from .. import links
 
@@ -13,10 +13,14 @@ def mock_url_for(endpoint, **kwargs):
 
 
 class Id_Patterns_Test(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask('bogus')
+        
     def test_arxiv_ids(self):
         def find_match(txt):
-            ptn = links._get_pattern(links.DEFAULT_KINDS)
-            return ptn.search(txt)
+            with self.app.app_context():
+                ptn = links._get_pattern(links.DEFAULT_KINDS)
+                return ptn.search(txt)
 
         self.assertIsNotNone(find_match('math/9901123'))
         self.assertIsNotNone(find_match('hep-ex/9901123'))
@@ -33,8 +37,9 @@ class Id_Patterns_Test(unittest.TestCase):
 
     def test_find_match(self):
         def find_match(txt):
-            ptn = links._get_pattern(links.DEFAULT_KINDS)
-            return ptn.search(txt)
+            with self.app.app_context():
+                ptn = links._get_pattern(links.DEFAULT_KINDS)
+                return ptn.search(txt)
 
         self.assertIsNone(find_match('junk'))
         self.assertIsNone(find_match(''))
@@ -52,7 +57,9 @@ class Id_Patterns_Test(unittest.TestCase):
 
 
 class TestURLize(unittest.TestCase):
-            
+    def setUp(self):
+        self.app = Flask('bogus')
+        
     def test_dont_urlize_cats( self ):
         self.assertGreater(len(links.CATEGORIES_THAT_COULD_BE_HOSTNAMES), 0,
                            'The links.CATEGORIES_THAT_COULD_BE_HOSTNAMES must not be empty or it will match everything')
@@ -60,271 +67,283 @@ class TestURLize(unittest.TestCase):
         
     @mock.patch(f'{links.__name__}.clickthrough')
     def test_doi(self, mock_clickthrough):
-        mock_clickthrough.clickthrough_url = lambda url: f'http://arxiv.org/clickthrough?url={url}'
-        self.maxDiff = 3000
-        self.assertEqual(
-            links.urlize('here is a rando doi doi:10.1109/5.771073 that needs a link'),
-            'here is a rando doi doi:<a class="link-http link-external" data-doi="10.1109/5.771073" href="http://arxiv.org/clickthrough?url=https://dx.doi.org/10.1109/5.771073" rel="external noopener nofollow">10.1109/5.771073</a> that needs a link'
-        )
+        with self.app.app_context():
+            mock_clickthrough.clickthrough_url = lambda url: f'http://arxiv.org/clickthrough?url={url}'
+            self.maxDiff = 3000
+            self.assertEqual(
+                links.urlize('here is a rando doi doi:10.1109/5.771073 that needs a link'),
+                'here is a rando doi doi:<a class="link-http link-external" data-doi="10.1109/5.771073" href="http://arxiv.org/clickthrough?url=https://dx.doi.org/10.1109/5.771073" rel="external noopener nofollow">10.1109/5.771073</a> that needs a link'
+            )
 
     def test_transform_token(self):
         # def doi_id_url_transform_token(tkn,fn):
         #     return doi_id_url_transform_token(fn, tkn)
+        with self.app.app_context():
+            self.assertEqual(links.urlize('', ['url']), '')
 
-        self.assertEqual(links.urlize('', ['url']), '')
+            self.assertEqual(
+                links.urlize('it is fine, chapter 234 see<xxyx,234>'),
+                escape('it is fine, chapter 234 see<xxyx,234>')
+            )
 
-        self.assertEqual(
-            links.urlize('it is fine, chapter 234 see<xxyx,234>'),
-            escape('it is fine, chapter 234 see<xxyx,234>')
-        )
+            self.assertEqual(links.urlize('http://arxiv.org', ['url']),
+                             '<a class="link-internal link-http" href="http://arxiv.org">this http URL</a>')
 
-        self.assertEqual(links.urlize('http://arxiv.org', ['url']),
-                         '<a class="link-internal link-http" href="http://arxiv.org">this http URL</a>')
+            self.assertEqual(
+                links.urlize('in the front http://arxiv.org oth', ['url']),
+                'in the front <a class="link-internal link-http" href="http://arxiv.org">this http URL</a> oth'
+            )
 
-        self.assertEqual(
-            links.urlize('in the front http://arxiv.org oth', ['url']),
-            'in the front <a class="link-internal link-http" href="http://arxiv.org">this http URL</a> oth'
-        )
+            self.assertEqual(
+                links.urlize('.http://arxiv.org.', ['url']),
+                '.<a class="link-internal link-http" href="http://arxiv.org">this http URL</a>.'
+            )
 
-        self.assertEqual(
-            links.urlize('.http://arxiv.org.', ['url']),
-            '.<a class="link-internal link-http" href="http://arxiv.org">this http URL</a>.'
-        )
-
-        self.assertEqual(
-            links.urlize('"http://arxiv.org"', ['url']),
-            '"<a class="link-internal link-http" href="http://arxiv.org">this http URL</a>"'
-        )
+            self.assertEqual(
+                links.urlize('"http://arxiv.org"', ['url']),
+                '"<a class="link-internal link-http" href="http://arxiv.org">this http URL</a>"'
+            )
 
     @mock.patch(f'{links.__name__}.clickthrough')
     @mock.patch(f'{links.__name__}.url_for', mock_url_for)
     def test_urlize(self, mock_clickthrough):
-        mock_clickthrough.clickthrough_url.return_value = 'foo'
-        self.assertEqual(
-            links.urlize('http://example.com/'),
-            '<a class="link-external link-http" href="http://example.com/" rel="external noopener nofollow">this http URL</a>',
-            'urlize (URL linking) 1/6'
-        )
-        self.assertEqual(
-            links.urlize('https://example.com/'),
-            '<a class="link-external link-https" href="https://example.com/" rel="external noopener nofollow">this https URL</a>',
-            'urlize (URL linking) 2/6'
-        )
-        self.assertEqual(
-            links.urlize('ftp://example.com/'),
-            '<a class="link-external link-ftp" href="ftp://example.com/" rel="external noopener nofollow">this ftp URL</a>',
-            'urlize (URL linking) 3/6'
-        )
+        with self.app.app_context():
+            mock_clickthrough.clickthrough_url.return_value = 'foo'
+            self.assertEqual(
+                links.urlize('http://example.com/'),
+                '<a class="link-external link-http" href="http://example.com/" rel="external noopener nofollow">this http URL</a>',
+                'urlize (URL linking) 1/6'
+            )
+            self.assertEqual(
+                links.urlize('https://example.com/'),
+                '<a class="link-external link-https" href="https://example.com/" rel="external noopener nofollow">this https URL</a>',
+                'urlize (URL linking) 2/6'
+            )
+            self.assertEqual(
+                links.urlize('ftp://example.com/'),
+                '<a class="link-external link-ftp" href="ftp://example.com/" rel="external noopener nofollow">this ftp URL</a>',
+                'urlize (URL linking) 3/6'
+            )
 
-        self.assertEqual(
-            links.urlize('http://projecteuclid.org/euclid.bj/1151525136'),
-            '<a class="link-external link-http" href="http://projecteuclid.org/euclid.bj/1151525136" rel="external noopener nofollow">this http URL</a>',
-            'urlize (URL linking) 6/6'
-        )
+            self.assertEqual(
+                links.urlize('http://projecteuclid.org/euclid.bj/1151525136'),
+                '<a class="link-external link-http" href="http://projecteuclid.org/euclid.bj/1151525136" rel="external noopener nofollow">this http URL</a>',
+                'urlize (URL linking) 6/6'
+            )
 
-        self.assertEqual(links.urlize('2448446.4710(5)'), '2448446.4710(5)',
-                         'urlize (should not match) 1/9')
-        self.assertEqual(links.urlize('HJD=2450274.4156+/-0.0009'),
-                         'HJD=2450274.4156+/-0.0009',
-                         'urlize (should not match) 2/9')
-        self.assertEqual(
-            links.urlize('T_min[HJD]=49238.83662(14)+0.146352739(11)E.'),
-            'T_min[HJD]=49238.83662(14)+0.146352739(11)E.',
-            'urlize (should not match) 3/9'
-        )
-        self.assertEqual(links.urlize('Pspin=1008.3408s'),
-                         'Pspin=1008.3408s',
-                         'urlize (should not match) 4/9')
-        self.assertEqual(
-            links.urlize('2453527.87455^{+0.00085}_{-0.00091}'),
-            '2453527.87455^{+0.00085}_{-0.00091}',
-            'urlize (should not match) 5/9'
-        )
-        self.assertEqual(links.urlize('2451435.4353'), '2451435.4353',
-                         'urlize (should not match) 6/9')
+            self.assertEqual(links.urlize('2448446.4710(5)'), '2448446.4710(5)',
+                             'urlize (should not match) 1/9')
+            self.assertEqual(links.urlize('HJD=2450274.4156+/-0.0009'),
+                             'HJD=2450274.4156+/-0.0009',
+                             'urlize (should not match) 2/9')
+            self.assertEqual(
+                links.urlize('T_min[HJD]=49238.83662(14)+0.146352739(11)E.'),
+                'T_min[HJD]=49238.83662(14)+0.146352739(11)E.',
+                'urlize (should not match) 3/9'
+            )
+            self.assertEqual(links.urlize('Pspin=1008.3408s'),
+                             'Pspin=1008.3408s',
+                             'urlize (should not match) 4/9')
+            self.assertEqual(
+                links.urlize('2453527.87455^{+0.00085}_{-0.00091}'),
+                '2453527.87455^{+0.00085}_{-0.00091}',
+                'urlize (should not match) 5/9'
+            )
+            self.assertEqual(links.urlize('2451435.4353'), '2451435.4353',
+                             'urlize (should not match) 6/9')
 
-        self.assertEqual(
-            links.urlize('cond-mat/97063007'),
-            '<a class="link-https" data-arxiv-id="cond-mat/9706300" href="https://arxiv.org/abs/cond-mat/9706300">cond-mat/9706300</a>7',
-            'urlize (should match) 7/9')
+            self.assertEqual(
+                links.urlize('cond-mat/97063007'),
+                '<a class="link-https" data-arxiv-id="cond-mat/9706300" href="https://arxiv.org/abs/cond-mat/9706300">cond-mat/9706300</a>7',
+                'urlize (should match) 7/9')
 
-        self.assertEqual(
-            links.urlize('[http://onion.com/something-funny-about-arxiv-1234]'),
-            '[<a class="link-external link-http" href="http://onion.com/something-funny-about-arxiv-1234" rel="external noopener nofollow">this http URL</a>]')
+            self.assertEqual(
+                links.urlize('[http://onion.com/something-funny-about-arxiv-1234]'),
+                '[<a class="link-external link-http" href="http://onion.com/something-funny-about-arxiv-1234" rel="external noopener nofollow">this http URL</a>]')
 
-        self.assertEqual(
-            links.urlize(
-                '[http://onion.com/?q=something-funny-about-arxiv.1234]'
-            ),
-            '[<a class="link-external link-http" href="http://onion.com/?q=something-funny-about-arxiv.1234" rel="external noopener nofollow">this http URL</a>]'
-        )
+            self.assertEqual(
+                links.urlize(
+                    '[http://onion.com/?q=something-funny-about-arxiv.1234]'
+                ),
+                '[<a class="link-external link-http" href="http://onion.com/?q=something-funny-about-arxiv.1234" rel="external noopener nofollow">this http URL</a>]'
+            )
 
-        self.assertEqual(
-            links.urlize('http://onion.com/?q=something funny'),
-            '<a class="link-external link-http" href="http://onion.com/?q=something" rel="external noopener nofollow">this http URL</a> funny',
-            'Spaces CANNOT be expected to be part of URLs'
-        )
+            self.assertEqual(
+                links.urlize('http://onion.com/?q=something funny'),
+                '<a class="link-external link-http" href="http://onion.com/?q=something" rel="external noopener nofollow">this http URL</a> funny',
+                'Spaces CANNOT be expected to be part of URLs'
+            )
 
-        self.assertEqual(
-            links.urlize(
-                '"http://onion.com/something-funny-about-arxiv-1234"'
-            ),
-            '"<a class="link-external link-http" href="http://onion.com/something-funny-about-arxiv-1234" rel="external noopener nofollow">this http URL</a>"',
-            'Should handle URL surrounded by double quotes'
-        )
+            self.assertEqual(
+                links.urlize(
+                    '"http://onion.com/something-funny-about-arxiv-1234"'
+                ),
+                '"<a class="link-external link-http" href="http://onion.com/something-funny-about-arxiv-1234" rel="external noopener nofollow">this http URL</a>"',
+                'Should handle URL surrounded by double quotes'
+            )
 
-        self.assertEqual(links.urlize('< http://example.com/1<2 ><'),
-                         '&lt; <a class="link-external link-http" href="http://example.com/1" rel="external noopener nofollow">this http URL</a>&lt;2 &gt;&lt;',
-                         'urlize (URL linking) 5/6')
+            self.assertEqual(links.urlize('< http://example.com/1<2 ><'),
+                             '&lt; <a class="link-external link-http" href="http://example.com/1" rel="external noopener nofollow">this http URL</a>&lt;2 &gt;&lt;',
+                             'urlize (URL linking) 5/6')
 
-        self.assertEqual(
-            links.urlize('Accepted for publication in A&A. The data will be available via CDS, and can be found "http://atlasgal.mpifr-bonn.mpg.de/cgi-bin/ATLASGAL_FILAMENTS.cgi"'),
-            'Accepted for publication in A&amp;A. The data will be available via CDS, and can be found "<a class="link-external link-http" href="http://atlasgal.mpifr-bonn.mpg.de/cgi-bin/ATLASGAL_FILAMENTS.cgi" rel="external noopener nofollow">this http URL</a>"'
-        )
+            self.assertEqual(
+                links.urlize('Accepted for publication in A&A. The data will be available via CDS, and can be found "http://atlasgal.mpifr-bonn.mpg.de/cgi-bin/ATLASGAL_FILAMENTS.cgi"'),
+                'Accepted for publication in A&amp;A. The data will be available via CDS, and can be found "<a class="link-external link-http" href="http://atlasgal.mpifr-bonn.mpg.de/cgi-bin/ATLASGAL_FILAMENTS.cgi" rel="external noopener nofollow">this http URL</a>"'
+            )
 
-        self.assertEqual(
-            links.urlize('see http://www.tandfonline.com/doi/abs/doi:10.1080/15980316.2013.860928?journalCode=tjid20'),
-            'see <a class="link-external link-http" href="http://www.tandfonline.com/doi/abs/doi:10.1080/15980316.2013.860928?journalCode=tjid20" rel="external noopener nofollow">this http URL</a>'
-        )
+            self.assertEqual(
+                links.urlize('see http://www.tandfonline.com/doi/abs/doi:10.1080/15980316.2013.860928?journalCode=tjid20'),
+                'see <a class="link-external link-http" href="http://www.tandfonline.com/doi/abs/doi:10.1080/15980316.2013.860928?journalCode=tjid20" rel="external noopener nofollow">this http URL</a>'
+            )
 
-        self.assertEqual(
-            links.urlize('http://authors.elsevier.com/a/1TcSd,Ig45ZtO'),
-            '<a class="link-external link-http" href="http://authors.elsevier.com/a/1TcSd,Ig45ZtO" rel="external noopener nofollow">this http URL</a>'
-        )
+            self.assertEqual(
+                links.urlize('http://authors.elsevier.com/a/1TcSd,Ig45ZtO'),
+                '<a class="link-external link-http" href="http://authors.elsevier.com/a/1TcSd,Ig45ZtO" rel="external noopener nofollow">this http URL</a>'
+            )
 
-    @mock.patch(f'{links.__name__}.url_for', mock_url_for)
-    def test_category_id(self):
-        self.assertEqual(
-            links.urlize('version of arXiv.math.GR/0512484 (2011).', ['arxiv_id']),
-            'version of arXiv.<a class="link-https" data-arxiv-id="math.GR/0512484" href="https://arxiv.org/abs/math.GR/0512484">math.GR/0512484</a> (2011).'
-        )
+        @mock.patch(f'{links.__name__}.url_for', mock_url_for)
+        def test_category_id(self):
+            self.assertEqual(
+                links.urlize('version of arXiv.math.GR/0512484 (2011).', ['arxiv_id']),
+                'version of arXiv.<a class="link-https" data-arxiv-id="math.GR/0512484" href="https://arxiv.org/abs/math.GR/0512484">math.GR/0512484</a> (2011).'
+            )
 
     @mock.patch(f'{links.__name__}.url_for', mock_url_for)
     def test_parens(self):
         """ARXIVNG-250 Linkification should not choke on parentheses."""
-        self.assertEqual(
-            links.urlize('http://www-nuclear.univer.kharkov.ua/lib/1017_3(55)_12_p28-59.pdf'),
-            '<a class="link-external link-http" href="http://www-nuclear.univer.kharkov.ua/lib/1017_3(55)_12_p28-59.pdf" rel="external noopener nofollow">this http URL</a>'
-        )
+        with self.app.app_context():
+            self.assertEqual(
+                links.urlize('http://www-nuclear.univer.kharkov.ua/lib/1017_3(55)_12_p28-59.pdf'),
+                '<a class="link-external link-http" href="http://www-nuclear.univer.kharkov.ua/lib/1017_3(55)_12_p28-59.pdf" rel="external noopener nofollow">this http URL</a>'
+            )
 
     @mock.patch(f'{links.__name__}.url_for', mock_url_for)
     def test_hosts(self):
-        self.assertEqual(
-            links.urlize('can be downloaded from http://rwcc.bao.ac.cn:8001/swap/NLFFF_DBIE_code/HeHan_NLFFF_JGR.pdf'),
-            'can be downloaded from <a class="link-external link-http" href="http://rwcc.bao.ac.cn:8001/swap/NLFFF_DBIE_code/HeHan_NLFFF_JGR.pdf" rel="external noopener nofollow">this http URL</a>',
-            "Should deal with ports correctly"
-        )
-        self.assertEqual(
-            links.urlize('images is at http://85.20.11.14/hosting/punsly/APJLetter4.2.07/'),
-            'images is at <a class="link-external link-http" href="http://85.20.11.14/hosting/punsly/APJLetter4.2.07/" rel="external noopener nofollow">this http URL</a>',
-            "should deal with numeric IP correctly"
-        )
+        with self.app.app_context():
+            self.assertEqual(
+                links.urlize('can be downloaded from http://rwcc.bao.ac.cn:8001/swap/NLFFF_DBIE_code/HeHan_NLFFF_JGR.pdf'),
+                'can be downloaded from <a class="link-external link-http" href="http://rwcc.bao.ac.cn:8001/swap/NLFFF_DBIE_code/HeHan_NLFFF_JGR.pdf" rel="external noopener nofollow">this http URL</a>',
+                "Should deal with ports correctly"
+            )
+            self.assertEqual(
+                links.urlize('images is at http://85.20.11.14/hosting/punsly/APJLetter4.2.07/'),
+                'images is at <a class="link-external link-http" href="http://85.20.11.14/hosting/punsly/APJLetter4.2.07/" rel="external noopener nofollow">this http URL</a>',
+                "should deal with numeric IP correctly"
+            )
 
     @mock.patch(f'{links.__name__}.url_for', mock_url_for)
     def test_urls_with_plus(self):
-        self.assertEqual(
-            links.urlize('http://www.fkf.mpg.de/andersen/docs/pub/abstract2004+/pavarini_02.pdf'),
-            '<a class="link-external link-http" href="http://www.fkf.mpg.de/andersen/docs/pub/abstract2004+/pavarini_02.pdf" rel="external noopener nofollow">this http URL</a>'
-        )
+        with self.app.app_context():
+            self.assertEqual(
+                links.urlize('http://www.fkf.mpg.de/andersen/docs/pub/abstract2004+/pavarini_02.pdf'),
+                '<a class="link-external link-http" href="http://www.fkf.mpg.de/andersen/docs/pub/abstract2004+/pavarini_02.pdf" rel="external noopener nofollow">this http URL</a>'
+            )
 
     @mock.patch(f'{links.__name__}.url_for', mock_url_for)
     def test_anchors_with_slash(self):
-        self.assertIn(
-            'href="https://dms.sztaki.hu/ecml-pkkd-2016/#/app/privateleaderboard"',
-            links.urlize('https://dms.sztaki.hu/ecml-pkkd-2016/#/app/privateleaderboard'),
-            "Should deal with slash in URL anchor correctly"
-        )
+        with self.app.app_context():
+            self.assertIn(
+                'href="https://dms.sztaki.hu/ecml-pkkd-2016/#/app/privateleaderboard"',
+                links.urlize('https://dms.sztaki.hu/ecml-pkkd-2016/#/app/privateleaderboard'),
+                "Should deal with slash in URL anchor correctly"
+            )
 
     @mock.patch(f'{links.__name__}.url_for', mock_url_for)
     def test_ftp(self):
-        self.assertEqual(
-            links.urlize('7 Pages; ftp://ftp%40micrognu%2Ecom:anon%40anon@ftp.micrognu.com/pnenp/conclusion.pdf'),
-            '7 Pages; <a class="link-external link-ftp" href="ftp://ftp%40micrognu%2Ecom:anon%40anon@ftp.micrognu.com/pnenp/conclusion.pdf" rel="external noopener nofollow">this ftp URL</a>'
-       )
+        with self.app.app_context():
+            self.assertEqual(
+                links.urlize('7 Pages; ftp://ftp%40micrognu%2Ecom:anon%40anon@ftp.micrognu.com/pnenp/conclusion.pdf'),
+                '7 Pages; <a class="link-external link-ftp" href="ftp://ftp%40micrognu%2Ecom:anon%40anon@ftp.micrognu.com/pnenp/conclusion.pdf" rel="external noopener nofollow">this ftp URL</a>'
+           )
 
     @mock.patch(f'{links.__name__}.url_for', mock_url_for)
     def test_arxiv_prefix(self):
-        self.assertEqual(
-            links.urlize("see arxiv:1201.12345"),
-            'see <a class="link-https" data-arxiv-id="1201.12345" href="https://arxiv.org/abs/1201.12345">arXiv:1201.12345</a>')
+        with self.app.app_context():
+            self.assertEqual(
+                links.urlize("see arxiv:1201.12345"),
+                'see <a class="link-https" data-arxiv-id="1201.12345" href="https://arxiv.org/abs/1201.12345">arXiv:1201.12345</a>')
 
 
     @mock.patch(f'{links.__name__}.clickthrough')
     def test_doi_2(self, mock_clickthrough):
-        mock_clickthrough.clickthrough_url = lambda x: x
-        self.assertRegex(links.urlize('10.1088/1475-7516/2018/07/009'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
+        with self.app.app_context():
+            mock_clickthrough.clickthrough_url = lambda x: x
+            self.assertRegex(links.urlize('10.1088/1475-7516/2018/07/009'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
 
-        self.assertRegex(links.urlize('10.1088/1475-7516/2019/02/E02/meta'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
-        self.assertRegex(links.urlize('10.1088/1475-7516/2019/02/E02/META'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
-        self.assertRegex(links.urlize('doi:10.1088/1475-7516/2018/07/009'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
+            self.assertRegex(links.urlize('10.1088/1475-7516/2019/02/E02/meta'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
+            self.assertRegex(links.urlize('10.1088/1475-7516/2019/02/E02/META'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
+            self.assertRegex(links.urlize('doi:10.1088/1475-7516/2018/07/009'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
 
-        self.assertRegex(links.urlize('doi:10.1088/1475-7516/2019/02/E02/meta'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
-        self.assertRegex(links.urlize('doi:10.1088/1475-7516/2019/02/E02/META'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
+            self.assertRegex(links.urlize('doi:10.1088/1475-7516/2019/02/E02/meta'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
+            self.assertRegex(links.urlize('doi:10.1088/1475-7516/2019/02/E02/META'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
 
 
     @mock.patch(f'{links.__name__}.clickthrough')
     def test_double_doi(self, mock_clickthrough):
-        mock_clickthrough.clickthrough_url = lambda x: x
-        txt = links.urlize('10.1088/1475-7516/2018/07/009 10.1088/1475-7516/2019/02/E02/meta' )
-        self.assertNotRegex(txt, r'this.*URL',
-                            'DOIs should not get the generic "this https URL" they should have the DOI text')
-        self.assertRegex(txt, r'<a.*>10.1088/1475-7516/2018/07/009</a> <a.*>10.1088/1475-7516/2019/02/E02/meta</a>',
-                         'Should handle two DOIs in a row correctly')
+        with self.app.app_context():
+            mock_clickthrough.clickthrough_url = lambda x: x
+            txt = links.urlize('10.1088/1475-7516/2018/07/009 10.1088/1475-7516/2019/02/E02/meta' )
+            self.assertNotRegex(txt, r'this.*URL',
+                                'DOIs should not get the generic "this https URL" they should have the DOI text')
+            self.assertRegex(txt, r'<a.*>10.1088/1475-7516/2018/07/009</a> <a.*>10.1088/1475-7516/2019/02/E02/meta</a>',
+                             'Should handle two DOIs in a row correctly')
 
 
     @mock.patch(f'{links.__name__}.clickthrough')
     def test_broad_doi(self, mock_clickthrough):
-        mock_clickthrough.clickthrough_url = lambda x: x
+        with self.app.app_context():
+            mock_clickthrough.clickthrough_url = lambda x: x
 
-        broad_doi_fn = links.urlizer(['doi_field'])
-        
-        self.assertRegex(broad_doi_fn('10.1088/1475-7516/2018/07/009'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
+            broad_doi_fn = links.urlizer(['doi_field'])
 
-        self.assertRegex(broad_doi_fn('10.1088/1475-7516/2019/02/E02/meta'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
-        self.assertRegex(broad_doi_fn('10.1088/1475-7516/2019/02/E02/META'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
-        self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2018/07/009'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
+            self.assertRegex(broad_doi_fn('10.1088/1475-7516/2018/07/009'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
 
-        self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2019/02/E02/meta'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
-        self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2019/02/E02/META'),
-                         r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
-        
-        txt = broad_doi_fn('10.1088/1475-7516/2018/07/009 10.1088/1475-7516/2019/02/E02/meta' )
-        self.assertNotRegex(txt, r'this.*URL',
-                            'DOIs should not get the generic "this https URL" they should have the DOI text')
-        self.assertRegex(txt, r'<a.*>10.1088/1475-7516/2018/07/009</a> <a.*>10.1088/1475-7516/2019/02/E02/meta</a>',
-                         'Should handle two DOIs in a row correctly')
+            self.assertRegex(broad_doi_fn('10.1088/1475-7516/2019/02/E02/meta'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
+            self.assertRegex(broad_doi_fn('10.1088/1475-7516/2019/02/E02/META'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
+            self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2018/07/009'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
 
-        urlized_doi = broad_doi_fn('10.1175/1520-0469(1996)053<0946:ASTFHH>2.0.CO;2')
+            self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2019/02/E02/meta'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
+            self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2019/02/E02/META'),
+                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
 
-        self.assertNotIn('href="http://2.0.CO"',
-                         urlized_doi,
-                         "Should not have odd second <A> tag for DOI urlize for ao-sci/9503001 see ARXIVNG-2049")
+            txt = broad_doi_fn('10.1088/1475-7516/2018/07/009 10.1088/1475-7516/2019/02/E02/meta' )
+            self.assertNotRegex(txt, r'this.*URL',
+                                'DOIs should not get the generic "this https URL" they should have the DOI text')
+            self.assertRegex(txt, r'<a.*>10.1088/1475-7516/2018/07/009</a> <a.*>10.1088/1475-7516/2019/02/E02/meta</a>',
+                             'Should handle two DOIs in a row correctly')
 
-        leg_rx = r'<a .* href="https://dx.doi.org/10.1175/1520-0469%281996%29053%3C0946%3AASTFHH%3E2.0.CO%3B2".*'
-        self.assertRegex(urlized_doi, leg_rx,
-                         "Should handle Complex DOI for ao-sci/9503001 see ARXIVNG-2049")
+            urlized_doi = broad_doi_fn('10.1175/1520-0469(1996)053<0946:ASTFHH>2.0.CO;2')
 
-        # in legacy:
-        # <a href="/ct?url=https%3A%2F%2Fdx.doi.org%2F10.1175%252F1520-0469%25281996%2529053%253C0946%253AASTFHH%253E2.0.CO%253B2&amp;v=34a1af05">10.1175/1520-0469(1996)053&lt;0946:ASTFHH&gt;2.0.CO;2</a>
+            self.assertNotIn('href="http://2.0.CO"',
+                             urlized_doi,
+                             "Should not have odd second <A> tag for DOI urlize for ao-sci/9503001 see ARXIVNG-2049")
 
-        # Post clickthrough on legacy goes to :
-        # https://dx.doi.org/10.1175%2F1520-0469%281996%29053%3C0946%3AASTFHH%3E2.0.CO%3B2
+            leg_rx = r'<a .* href="https://dx.doi.org/10.1175/1520-0469%281996%29053%3C0946%3AASTFHH%3E2.0.CO%3B2".*'
+            self.assertRegex(urlized_doi, leg_rx,
+                             "Should handle Complex DOI for ao-sci/9503001 see ARXIVNG-2049")
+
+            # in legacy:
+            # <a href="/ct?url=https%3A%2F%2Fdx.doi.org%2F10.1175%252F1520-0469%25281996%2529053%253C0946%253AASTFHH%253E2.0.CO%253B2&amp;v=34a1af05">10.1175/1520-0469(1996)053&lt;0946:ASTFHH&gt;2.0.CO;2</a>
+
+            # Post clickthrough on legacy goes to :
+            # https://dx.doi.org/10.1175%2F1520-0469%281996%29053%3C0946%3AASTFHH%3E2.0.CO%3B2
 
 
     def test_dont_urlize_category_name(self):
-        urlize = links.urlizer()
-        self.assertEqual(urlize('math.CO'), 'math.CO',
-                         'category name math.CO should not get urlized')
-        self.assertIn('href="http://supermath.co', urlize('supermath.co'),
-                      'hostname close to category name should get urlized')
+        with self.app.app_context():
+            urlize = links.urlizer()
+            self.assertEqual(urlize('math.CO'), 'math.CO',
+                             'category name math.CO should not get urlized')
+            self.assertIn('href="http://supermath.co', urlize('supermath.co'),
+                          'hostname close to category name should get urlized')


### PR DESCRIPTION
This is a bit of an odd one. There were some strange errors in the production logs that were persistent but not immediately reproducible.
These turned out to be related to bleach.  https://bleach.readthedocs.io/en/latest/clean.html

https://arxiv-org.atlassian.net/browse/ARXIVNG-2107

I reproduced this on my laptop and fixed it by making the bleach object thread local. 

I can reproduce error on my laptop by:
- running apache,
- with wsgi with 16 threads,
- configiuring arxiv-browse to not use the DB
- then running "ab -c 300 -t 120 http://localhost/test/abs/1411.4413"

Erick and Jamie I'm wondering your thoughts on:
1. Are thread locals a good way to solve this problem?
2. Is the dynamic creation of the thread local bleach objects in _deferred_thread_local_linker_of_kind a good way to implement this solution? (Or is there a more straightforward way?)
3. Is this going to create any new problems?
