### PR TITLE
Disable auto-linking or urlization in abstract

### DIFF
--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -138,7 +138,7 @@
     <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ title|tex2utf|arxiv_id_urlize|safe }}</h1>
     <div class="authors"><span class="descriptor">Authors:</span>{{ authors }}</div>
     <div class="dateline">{{ abs_date_line(arxiv_id, submitted_date, version, submission_history) }}</div>
-    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|abstract_lf_to_br|urlize|safe }}</blockquote>
+    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|abstract_lf_to_br|safe }}</blockquote>
     <!--CONTEXT-->
     <div class="metatable">
       <table summary="Additional metadata">


### PR DESCRIPTION
In response to https://twitter.com/ibnesayeed/status/1133908420099100672 thread a ticket was created at https://arxiv-org.atlassian.net/browse/ARXIVNG-2180. This PR attempts to fix this issue by disabling auto-linking in abstract. However, if auto linking is desired, then the filter needs to be improved to preserve the original text as the anchor text. I believe that people usually do not add very long URLs in abstract (unlike other places such as comments), so masking the original text in abstract is more problematic than helpful. Another side-effect of auto-linking is occasional false-positives such as realizing ASP.Net as a URL.

Replacing original text with a generic anchor text may yield something as shown below.

![arxiv-abstract-this-http-url](https://user-images.githubusercontent.com/65147/58715476-f0cee480-8394-11e9-8b52-6a6438629582.png)
