### PR TITLE
ARXIVNG-2188 support for extra config params in base service integration

### DIFF
--- a/arxiv/base/middleware/__init__.py
+++ b/arxiv/base/middleware/__init__.py
@@ -125,7 +125,9 @@ def wrap(app: Flask, middlewares: List[IWSGIMiddlewareFactory]) -> Callable:
                           ' deprecated. You should update your middleware'
                           ' to accept arbitrary kwargs', DeprecationWarning)
             wrapped_app = middleware(wrapped_app)
-        app.middlewares[middleware.__name__] = wrapped_app
+
+        key = getattr(middleware, '__name__', str(middleware))
+        app.middlewares[key] = wrapped_app
 
     app.wsgi_app = wrapped_app  # type: ignore
     return app

--- a/arxiv/base/middleware/base.py
+++ b/arxiv/base/middleware/base.py
@@ -41,7 +41,7 @@ class IWSGIMiddleware(Protocol):
 
 
 class IWSGIMiddlewareFactory(Protocol):
-    """Defines a minimal WSGI middlware factory."""
+    """Defines a minimal WSGI middleware factory."""
 
     def __call__(self, app: IWSGIApp, config: Mapping = {}) -> IWSGIMiddleware:
         """Generate a :class:`.WSGIMiddleware`."""

--- a/arxiv/integration/api/service.py
+++ b/arxiv/integration/api/service.py
@@ -5,6 +5,10 @@ The goal of this module is to handle boilerplate connection and request
 handling that is invariant (or nearly so) among service integration modules
 that target HTTP APIs.
 
+.. todo::
+   Make retry parameters easier to configure.
+
+
 Specific goals
 --------------
 
@@ -14,9 +18,6 @@ Specific goals
 - Provide basic retry functionality.
 - Handle binding a service instance (with its persistent session) to the
   Flask application context.
-
-.. todo::
-   Make retry parameters easier to configure.
 
 """
 
@@ -88,8 +89,15 @@ class HTTPIntegration(metaclass=MetaIntegration):
 
        @app.route('/foo')
        def foo():
-           MyCoolIntegration.get_something('foo', request.environ['token'])
+           mci = MyCoolIntegration.current_session()
+           mci.get_something('foo', request.environ['token'])
            ...
+
+
+    Any additional parameters in your app config that start with the
+    ``service_name`` in upper case will be passed in as kwargs to the
+    constructor. By default, these are stored on ``._extra`` for internal
+    use.
 
     """
 

--- a/arxiv/integration/api/service.py
+++ b/arxiv/integration/api/service.py
@@ -118,6 +118,7 @@ class HTTPIntegration(metaclass=MetaIntegration):
         extra : kwargs
 
         """
+        self._extra = extra
         self._session = requests.Session()
         self._verify = verify
         self._retry = Retry(

--- a/arxiv/integration/api/service.py
+++ b/arxiv/integration/api/service.py
@@ -246,7 +246,7 @@ class HTTPIntegration(metaclass=MetaIntegration):
             app = current_app
         name = cls.Meta.service_name.upper()
         try:
-            params = app.config.get_namespace(f'{name}_')
+            params = app.config.get_namespace(f'{name}_')     # type: ignore
             endpoint = params.pop('endpoint')
             verify = params.pop('verify')
         except KeyError as e:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-base',
-    version='0.15.8rc1',
+    version='0.15.8rc5',
     packages=[f'arxiv.{package}' for package
               in find_packages('arxiv', exclude=['*test*'])],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-base',
-    version='0.15.7',
+    version='0.15.8rc1',
     packages=[f'arxiv.{package}' for package
               in find_packages('arxiv', exclude=['*test*'])],
     zip_safe=False,


### PR DESCRIPTION
This adds support for additional (arbitrary) config params in the base service integration in ``arxiv.base.integration.service``. Any params in the config that start with the service name (in upper case) will be passed as kwargs to the ``HTTPIntegration`` constructor.