### PR TITLE
Only disable greek textism, not letter ones

### DIFF
--- a/arxiv/base/filters.py
+++ b/arxiv/base/filters.py
@@ -43,12 +43,12 @@ def abstract_lf_to_br(text: JinjaFilterInput) -> Markup:
 
 
 def f_tex2utf(text: JinjaFilterInput,
-              letters: bool = True) -> Markup:
+              greek: bool = True) -> Markup:
     """Return output of tex2utf function as escaped Markup."""
     if isinstance(text, Markup):
-        return escape(tex2utf(text.unescape(), letters=letters))
+        return escape(tex2utf(text.unescape(), greek=greek))
     else:
-        return Markup(escape(tex2utf(text, letters=letters)))
+        return Markup(escape(tex2utf(text, greek=greek)))
 
 
 def embed_content(path: str) -> Markup:
@@ -98,8 +98,8 @@ def register_filters(app: Flask) -> None:
     """
     app.template_filter('abstract_lf_to_br')(abstract_lf_to_br)
     app.template_filter('urlize')(urlizer())
-    app.template_filter('tex2utf')(partial(f_tex2utf, letters=True))
-    app.template_filter('tex2utf_no_symbols')(partial(f_tex2utf, letters=False))
+    app.template_filter('tex2utf')(partial(f_tex2utf, greek=True))
+    app.template_filter('tex2utf_no_symbols')(partial(f_tex2utf, greek=False))
     app.template_filter('canonical_url')(canonical_url)
     app.template_filter('clickthrough_url')(clickthrough_url)
     app.template_filter('get_category_display')(get_category_display)

--- a/arxiv/util/tests/test_tex2utf.py
+++ b/arxiv/util/tests/test_tex2utf.py
@@ -187,6 +187,7 @@ class TextTex2Utf(TestCase):
         self.assertEqual(utf_out, 'ARXIVDEV-2322 ' + chr(0x110) + ' fix')
 
     def test_ARXIVOPS805(self):
+        """{\aa} wasn't being converted correctly in /abs abstract field to å"""
         self.assertEqual(tex2utf("ARXIVOPS-805 \\aa  fix"),
                          'ARXIVOPS-805 å fix')
 

--- a/arxiv/util/tests/test_tex2utf.py
+++ b/arxiv/util/tests/test_tex2utf.py
@@ -11,7 +11,7 @@ class TextTex2Utf(TestCase):
         utf_out = tex2utf(test_str)
         self.assertEqual(utf_out, test_str)
 
-        utf_out = tex2utf(test_str, letters=False)
+        utf_out = tex2utf(test_str, greek=False)
         self.assertEqual(utf_out, test_str)
 
         test_str = "\\'e"
@@ -24,12 +24,12 @@ class TextTex2Utf(TestCase):
             0xc9))
 
         test_str = "\\'E"
-        utf_out = tex2utf(test_str, letters=True)
+        utf_out = tex2utf(test_str, greek=True)
         self.assertEqual(utf_out, chr(
             0xc9))
 
         test_str = "\\'E"
-        utf_out = tex2utf(test_str, letters=False)
+        utf_out = tex2utf(test_str, greek=False)
         self.assertEqual(utf_out, chr(0xc9))
 
         test_str = "\\'E"
@@ -186,18 +186,12 @@ class TextTex2Utf(TestCase):
         utf_out = tex2utf(test_str)
         self.assertEqual(utf_out, 'ARXIVDEV-2322 ' + chr(0x110) + ' fix')
 
-        #     (tex, err) =  arXiv:: Filters: : Tex2UTF: : UTF2tex("Test Test_String. \x{03bb}" )
-        #     self.assertEqual(tex,
-        #                       "Test Test_String. {\\lambda}",
-        #                       "arXiv::Filters::Tex2UTF::UTF2tex()")
-        #
-        # self.assertEqual(arXiv:: Filters: : Tex2UTF: : escapeUTF8("\x{03bb}"),
-        #                   "&#x3BB;",
-        #                   'arXiv::Filters::Tex2UTF::escapeUTF8("\x{03bb}")')
-        #
-        #     latin1 = "\x{91}\x{92}\x{93}\x{94}\x{96}\x{97}\x{98}\x{A0}\x{A6}\x{B1}\x{B2}\x{B3}\x{B5}\x{BC}\x{BD}\x{BE}"
-        #     latin1expected = "`'\"\"----~ |{\\pm}^2^3{\\mu}1/41/23/4"
-        #     is (arXiv: : Filters: : Tex2UTF: : latin2tex("Test Test_String. \x{03bb} latin1" ),
-        #         "Test Test_String. {\\lambda} latin1expected",
-        #         "arXiv::Filters::Tex2UTF::latin2tex(`'\"\"----~ |{\\pm}^2^3{\\mu}1/41/23/4)")
-        #     done_testing
+    def test_ARXIVOPS805(self):
+        self.assertEqual(tex2utf("ARXIVOPS-805 \\aa  fix"),
+                         'ARXIVOPS-805 å fix')
+
+        self.assertEqual(tex2utf("ARXIVOPS-805 \\aa  fix", greek=False),
+                         'ARXIVOPS-805 å fix')
+
+        self.assertEqual(tex2utf("ARXIVOPS-805 \\aa  fix", greek=True),
+                         'ARXIVOPS-805 å fix')

--- a/arxiv/util/tex2utf.py
+++ b/arxiv/util/tex2utf.py
@@ -74,6 +74,9 @@ textlet = {
     'dh': 0x00f0, 'dj': 0x0111, 'eth': 0x00f0, 'i': 0x0131,
     'l': 0x0142, 'ng': 0x014b, 'o': 0x00f8, 'ss': 0x00df,
     'th': 0x00fe,
+    }
+
+textgreek = {
     # Greek (upper)
     'Gamma': 0x0393, 'Delta': 0x0394, 'Theta': 0x0398,
     'Lambda': 0x039b, 'Xi': 0x039E, 'Pi': 0x03a0,
@@ -101,6 +104,7 @@ def _p_to_match(tex_to_chr: Dict[str, int]) -> Pattern:
 
 
 textlet_pattern = _p_to_match(textlet)
+textgreek_pattern = _p_to_match(textgreek)
 
 textsym = {
     'P': 0x00b6, 'S': 0x00a7, 'copyright': 0x00a9,
@@ -119,6 +123,10 @@ def _textsym_sub(match: Match) -> str:
     return chr(textsym[match.group(2)])
 
 
+def _textgreek_sub(match: Match) -> str:
+    return chr(textgreek[match.group(2)])
+
+
 def texch2UTF(acc: str) -> str:
     """Convert single character TeX accents to UTF-8.
 
@@ -134,24 +142,27 @@ def texch2UTF(acc: str) -> str:
         return re.sub(r'[^\w]+', '', acc, flags=re.IGNORECASE)
 
 
-def tex2utf(tex: str, letters: bool = True) -> str:
+def tex2utf(tex: str, greek: bool = True) -> str:
     r"""Convert some TeX accents and greek symbols to UTF-8 characters.
 
     :param tex: Text to filter.
 
-    :param letters: If False, do not convert greek letters or
+    :param greek: If False, do not convert greek letters or
     ligatures.  Greek symbols can cause problems. Ex. \phi is not
     suppose to look like φ. φ looks like \varphi.  See ARXIVNG-1612
 
     :returns: string, possibly with some TeX replaced with UTF8
 
     """
+
     # Do dotless i,j -> plain i,j where they are part of an accented i or j
     utf = re.sub(r"/(\\['`\^\"\~\=\.uvH])\{\\([ij])\}", r"\g<1>\{\g<2>\}", tex)
 
     # Now work on the Tex sequences, first those with letters only match
-    if letters:
-        utf = textlet_pattern.sub(_textlet_sub, utf)
+    utf = textlet_pattern.sub(_textlet_sub, utf)
+
+    if greek:
+        utf = textgreek_pattern.sub(_textgreek_sub, utf)
 
     utf = textsym_pattern.sub(_textsym_sub, utf)
 

--- a/arxiv/util/tex2utf.py
+++ b/arxiv/util/tex2utf.py
@@ -154,7 +154,6 @@ def tex2utf(tex: str, greek: bool = True) -> str:
     :returns: string, possibly with some TeX replaced with UTF8
 
     """
-
     # Do dotless i,j -> plain i,j where they are part of an accented i or j
     utf = re.sub(r"/(\\['`\^\"\~\=\.uvH])\{\\([ij])\}", r"\g<1>\{\g<2>\}", tex)
 


### PR DESCRIPTION
The fix for https://arxiv-org.atlassian.net/browse/ARXIVNG-1612 disabled tex2utf for TeX letters and greek symbols when only the greek symbols should have been disabled. 

This PR changes tex2utf() so there is a greek flag which only enables or disabled greek TeX to UTF8 translation.

The Jinja HTML filter tex2utf_no_symbols() that is used for the abstract is also changed to to disable greek but enable other letter TeXisms. 

https://arxiv-org.atlassian.net/browse/ARXIVOPS-805
