### PR TITLE
made retry configurable in base HTTPIntegration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ dist/
 *.egg-info/
 *.DS_Store
 .sass-cache/
+.pytest_cache/


### PR DESCRIPTION
Fixes #146 . I made this use an instance method so that the config could be defined programmatically.