### PR TITLE
Moves alerts to macros to allow control of them in submission-ui

### DIFF
--- a/arxiv/base/alerts.py
+++ b/arxiv/base/alerts.py
@@ -10,7 +10,8 @@ message categories/severity.
 
    For security purposes, alerts are not treated as safe in the template by
    default. To treat a message as safe, use ``safe=True`` when generating the
-   flash notification.
+   flash notification. If you use ``safe=True`` you must escape any
+   user input that goes into the alert.
 
 
 For example:
@@ -19,12 +20,15 @@ For example:
 
    from flask import url_for
    from arxiv.base import alerts
+   from jinja2 import escape
 
    def handle_request():
        ...
 
+       danger_txt = request.form.somefield.value
        help_url = url_for('help')
        alerts.flash_warning(f'This is a warning, see <a href="{help_url}">'
+                            f'your input {escape(danger_txt)} was not found'
                             f'the docs</a> for more information',
                             title='Warning title', safe=True)
        alerts.flash_info('This is some info', title='Info title')

--- a/arxiv/base/templates/base/base.html
+++ b/arxiv/base/templates/base/base.html
@@ -2,39 +2,23 @@
 <html lang="en">
   <head>
     {% include "base/head.html" %}
-    <!-- Custom style sheets or other head includes -->
-    {% block addl_head %}
+    {% block addl_head %}{# Custom style sheets or other head includes #}
     {% endblock addl_head %}
   </head>
   <body>
   {% import "base/macros.html" as macros %}
   <header>
-    <noscript><p><img src="https://webstats.arxiv.org/matomo.php?idsite=1&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+    {{ macros.noscripttracker()}}
     <a href="#main-container" class="is-sr-only">Skip to main content</a>
     {% block header %}
     {% include "base/header.html" %}
     {% endblock header %}
   </header>
-
   <main class="container" id="main-container">
-    {% with messages = get_alerts() -%}
-      {% if messages -%}
-        <div class="notifications" role="alert" aria-atomic="true">
-          {% for category, message in messages -%}
-            <div class="notification is-{{ category }}">
-              {% if message.dismissable %}<button class="delete notification-dismiss"></button>{% endif %}
-              {% if message.title %}<h2 class="is-size-5 is-marginless">{{ message.title }}</h2>{%- endif %}
-              <p>{{ message.message }}</p>
-            </div>
-          {%- endfor %}
-        </div>
-      {%- endif %}
-    {%- endwith %}
-
+    {%block alerts %}{{ macros.alerts(get_alerts()) }}{% endblock alerts %}
     {% block content %}
     {% endblock content %}
   </main>
-
   <footer>
     {% block footer %}
     {% include "base/footer.html" %}

--- a/arxiv/base/templates/base/base.html
+++ b/arxiv/base/templates/base/base.html
@@ -18,7 +18,7 @@
     {% endblock header %}
   </header>
   <main class="container" id="main-container">
-    {%block alerts %}{{ macros.alerts(get_alerts()) }}{% endblock alerts %}
+    {% block alerts %}{{ macros.alerts(get_alerts()) }}{% endblock alerts %}
     {% block content %}
     {% endblock content %}
   </main>

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -1,5 +1,25 @@
 {# macros to be available to all templates across arxiv #}
 
+{% macro alerts(messages=[]) %}
+
+{% if messages -%}
+<div class="notifications" role="alert" aria-atomic="true">
+    {% for category, message in messages -%}
+    <div class="notification is-{{ category }}">
+        {% if message.dismissable %}<button class="delete notification-dismiss"></button>{% endif %}
+        {% if message.title %}<h2 class="is-size-5 is-marginless">{{ message.title }}</h2>{%- endif %}
+        <p>{{ message.message }}</p>
+    </div>
+    {%- endfor %}
+</div>
+{%- endif %}
+
+{% endmacro %}
+
+{% macro noscripttracker() -%}
+<noscript><p><img src="https://webstats.arxiv.org/matomo.php?idsite=1&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+{% endmacro %}
+
 {% macro compactsearch(alignstyle="level-right") -%}
   {# Creates an inline search widget with one input box, a dropdown for field
     selection, a button, and two tiny help/advanced links. Can be wrapped with


### PR DESCRIPTION
"There are are error messages originating from arxiv-base that are displaying above the pagination. We should consolidate error display in the submit-ui templates to below the page title."
https://arxiv-org.atlassian.net/browse/ARXIVNG-2917