### PR TITLE
changes default success message header color

### DIFF
--- a/arxiv/base/static/css/arxivstyle.css
+++ b/arxiv/base/static/css/arxivstyle.css
@@ -9922,7 +9922,7 @@ main {
 }
 
 .message.is-success .message-header {
-  color: #000;
+  color: #ffffff;
 }
 
 /** All of the custom styles for arXiv-NG - related to specific graphical style rather than overrides of Bulma - are placed here. **/

--- a/arxiv/base/static/sass/_overrides.sass
+++ b/arxiv/base/static/sass/_overrides.sass
@@ -120,6 +120,6 @@ main
         background-color: darken($color, 10%)
         border-color: transparent
         color: $color-invert
-        
+
 .message.is-success .message-header
-  color: #000
+  color: #ffffff


### PR DESCRIPTION
Very minor: changes the default text color of headers in success messages from black to white to meet a11y contrast guidelines. 

![Screen Shot 2020-02-21 at 10 06 07 AM](https://user-images.githubusercontent.com/56078140/75045719-d47a5700-5491-11ea-8644-895423588291.png)
