### PR TITLE
ARXIVNG-3004 edits macros.html (abs macro) for mobile-friendly abs page

### DIFF
--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -93,7 +93,7 @@
     {% set latest_version = submission_history[-1].version %}
   {% endif %}
 
-  (Submitted on {{ first_version_submitted_date.strftime('%-d %b %Y') }}
+  [Submitted on {{ first_version_submitted_date.strftime('%-d %b %Y') }}
   {%- if this_is_the_first_version and there_are_more_versions %} (this version){%- endif -%}
   {%- if not this_is_the_first_version %} (<a href="{{ url_for('abs', paper_id=arxiv_id, version=1) }}">v1</a>){%- endif %}
   {%- if not this_is_the_first_version and not this_is_the_latest_version -%}
@@ -104,7 +104,7 @@
   {%- elif not this_is_the_first_version and this_is_the_latest_version -%}
     , last revised {{ latest_version_submitted_date.strftime('%-d %b %Y') }} (this version, v{{ version }})
   {%- endif -%}
-  )
+  ]
 {%- endmacro -%}
 
 {%- macro version_atag(arxiv_id, version, primary_category) -%}
@@ -149,11 +149,20 @@
 {% endif %}
 <div id="content-inner">
   <div id="abs">
-
+    <div class="dateline">{{ abs_date_line(arxiv_id, submitted_date, version, submission_history) }}</div>
     <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ title|tex2utf|arxiv_id_urlize|safe }}</h1>
     <div class="authors"><span class="descriptor">Authors:</span>{{ authors }}</div>
-    <div class="dateline">{{ abs_date_line(arxiv_id, submitted_date, version, submission_history) }}</div>
-    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|abstract_lf_to_br|urlize|safe }}</blockquote>
+
+    {% if formats|length > 0 and ('pdf' in formats or 'pdfonly' in formats) %}
+      <a class="mobile-submission-download" href="{{url_for('.pdf', arxiv_id=requested_id)}}">Download PDF</a>
+    {% else %}
+      <a class="mobile-submission-download mobile-download-grey" href="#other">No PDF available. Click to view other formats</a>
+    {% endif %}
+
+    <blockquote class="abstract mathjax">
+      <span class="descriptor">Abstract:</span>{{ abstract|tex2utf_no_symbols|abstract_lf_to_br|urlize|safe }}
+    </blockquote>
+
     <!--CONTEXT-->
     <div class="metatable">
       <table summary="Additional metadata">

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -137,7 +137,8 @@
     submission_history = [],
     secondary_categories = [],
     include_stylesheet = 1,
-    embed_stylesheet = 0) -%}
+    embed_stylesheet = 0,
+    download_button_markup = None) -%}
 
 {% if include_stylesheet and not embed_stylesheet %}
 <link rel="stylesheet" type="text/css" href="{{ url_for('base.static', filename='css/abs.css') }}">
@@ -153,10 +154,9 @@
     <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ title|tex2utf|arxiv_id_urlize|safe }}</h1>
     <div class="authors"><span class="descriptor">Authors:</span>{{ authors }}</div>
 
-    {% if formats|length > 0 and ('pdf' in formats or 'pdfonly' in formats) %}
-      <a class="mobile-submission-download" href="{{url_for('.pdf', arxiv_id=requested_id)}}">Download PDF</a>
-    {% else %}
-      <a class="mobile-submission-download mobile-download-grey" href="#other">No PDF available. Click to view other formats</a>
+    {#- optionally include markup for the download button -#}
+    {% if download_button_markup %}
+      {{ download_button_markup }}
     {% endif %}
 
     <blockquote class="abstract mathjax">


### PR DESCRIPTION
This commit makes a few small edits to the abs macro in response to the new mobile-friendly abs changes. Those abs changes are in browse branch ARXIVNG-3004.

Changes:
- moving the mobile download button from the top of the page to in between authors and abstract (in response to user requests).
- adding some new classes to elements (not visible on desktop).
- moving the submitted date element above the title (visible on all screen widths).

This ticket has one pending item and is not ready to merge (ARXIVNG-3032) but wanted to get this branch up for review and collaboration.

Screenshots (mobile and desktop) are below for reference. 

![Screen Shot 2020-02-28 at 9 43 00 AM](https://user-images.githubusercontent.com/56078140/75557820-bfac3f00-5a0e-11ea-8547-8e3912961d9d.png)

![Screen Shot 2020-02-28 at 9 42 41 AM](https://user-images.githubusercontent.com/56078140/75557838-c935a700-5a0e-11ea-9f44-0687d16a6ba1.png)
