### PR TITLE
ARXIVNG-3432: Fix arXiv/base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV LC_ALL=en_US.UTF-8 \
 # if a package is missing.
 #
 RUN yum -y install epel-release \
-  && yum -y install https://centos7.iuscommunity.org/ius-release.rpm \
+  && yum -y install https://repo.ius.io/ius-release-el7.rpm \
   && echo $'#!/bin/bash\n\
 PKGS_TO_INSTALL=$(cat <<-END\n\
   ca-certificates\n\


### PR DESCRIPTION

Docker image would not build correctly due to an obsolete package url. I replaced obsolete url with the new url for package and build completes successfully.

You might want to verify that you can create the image using: 

#git clone git@github.com:arXiv/arxiv-base.git
#git checkout -b ARXIVNG-3432
#'docker build --tag arxiv/base:0.12 .'

