### PR TITLE
Changes abs page DOI link to handle more cases.

### DIFF
--- a/arxiv/base/urls/tests/test_urlize.py
+++ b/arxiv/base/urls/tests/test_urlize.py
@@ -310,6 +310,10 @@ class TestURLize(unittest.TestCase):
 
             broad_doi_fn = links.urlizer(['doi_field'])
 
+            # ARXIVNG-3523 unusual DOI
+            self.assertRegex(broad_doi_fn('21.11130/00-1735-0000-0005-146A-E'),
+                             r'<a.*href="https://.*21.11130.*>21.11130/00-1735-0000-0005-146A-E</a>')
+            
             self.assertRegex(broad_doi_fn('10.1088/1475-7516/2018/07/009'),
                              r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
 

--- a/arxiv/release/README.md
+++ b/arxiv/release/README.md
@@ -103,15 +103,15 @@ an accurate description of the version and local changes.
 ## How the version is set and found
 
 ### If I install a package from PyPY
-1. Someone tags a commit in github to arxiv-shoehorn
+1. Someone tags a commit in github to arxiv-example
 2. Travis-ci builds that commit, with the tag in TRAVIS_TAG
 3. The travis step ```python -m arxiv.release.tag_check
-   arxiv-shoehorn``` picks up the tag. If it is a valid python public
-   version, it gets written to the file ```arxiv/shoehorn/version.py```.
+   arxiv-example``` picks up the tag. If it is a valid python public
+   version, it gets written to the file ```arxiv/example/version.py```.
 4. Travis-ci uploads the built python package to PyPI. This version.py
    file is includded in that upload.
 5. When someone installs that package from PyPI,
-   ```arxiv.release.dist_version.get_version('arxiv-shoehorn')``` will
+   ```arxiv.release.dist_version.get_version('arxiv-example')``` will
    first check the version.py file and return the version from that.
 
 ### If I install a package with pip install -e ../somegitclone
@@ -127,7 +127,7 @@ In this case there is no version.py file
 6. ```get_version()``` finds no version.py file, and it finds no
    ```pkg_resources``` version
 7. So get_version() trys to run ```git describe --dirty``` and that
-   works since it is in a git check
+   works since it is in a git checked out directory.
 8. setup.py uses the git describe value as the package version during the install.
 9. arxiv.release.dist_version.get_version() will first check the
    version.py file and find nothing, then it will check the

--- a/arxiv/release/dist_version.py
+++ b/arxiv/release/dist_version.py
@@ -80,10 +80,10 @@ def write_version(dist_name: str, version: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w+") as ff:  # overwrite existing version
         when = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
-        ff.write("#  Created by tag_check.write_version\n")
+        ff.write("'Created by tag_check.write_version'\n")
         ff.write("#  NEVER CHECK THIS version.py file INTO GIT.\n")
         ff.write(
-            "#  It should be generated when the package is build for distribution.\n"
+            "#  Generated when the package was build for distribution.\n"
         )
         ff.write(f"__when__ = '{when}'\n")
         ff.write(f"__version__ = '{version}'\n")

--- a/arxiv/release/tag_check.py
+++ b/arxiv/release/tag_check.py
@@ -22,7 +22,7 @@ script:
 
 
 This can also be used to check if a version string is valid:
-``TRAVIS_TAG=0.2.3-somethingX python -m arxiv.release.tag_check``
+``TRAVIS_TAG=0.2.3-somethingX python -m arxiv.release.tag_check arxiv-base``
 
 This does not write or update a RELEASE-VERSION file.
 """


### PR DESCRIPTION
The DOI link in the abs metadata now accepts a very broad range
of values to trun into DOI links.

DOI links in other areas like the abstract are unaffected.

ARXIVNG-3423