### PR TITLE
Fixes python36u docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ PKGS_TO_INSTALL=$(cat <<-END\n\
   gcc-c++ \n\
   git\n\
   mariadb-devel\n\
-  python36u\n\
-  python36u-devel\n\
+  python36\n\
+  python36-devel\n\
   sqlite\n\
   wget\n\
   which\n\


### PR DESCRIPTION
Switches from IUS python36u to EPEL python3 due to IUS no longer
providing python36u.

https://github.com/iusrepo/packaging/issues/7

ARXIVNG-3570