### PR TITLE
Pre-release merge for arxiv-base v0.17.3

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,14 +34,16 @@
                 "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
                 "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
             ],
+            "markers": "python_full_version >= '3.5.3'",
             "version": "==3.0.1"
         },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
-            "version": "==19.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
         },
         "backports-datetime-fromisoformat": {
             "hashes": [
@@ -82,17 +84,19 @@
         },
         "click": {
             "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+                "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
+                "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
             ],
-            "version": "==7.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.3"
         },
         "decorator": {
             "hashes": [
-                "sha256:54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce",
-                "sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"
+                "sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374",
+                "sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7"
             ],
-            "version": "==4.4.1"
+            "markers": "python_version >= '3.5'",
+            "version": "==5.1.0"
         },
         "docutils": {
             "hashes": [
@@ -100,6 +104,7 @@
                 "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
                 "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.15.2"
         },
         "flask": {
@@ -113,53 +118,43 @@
         "flask-s3": {
             "hashes": [
                 "sha256:1d49061d4b78759df763358a901f4ed32bb43f672c9f8e1ec7226793f6ae0fd2",
-                "sha256:23cbbb1db4c29c313455dbe16f25be078d6318f0a11abcbb610f99e116945b62"
+                "sha256:23cbbb1db4c29c313455dbe16f25be078d6318f0a11abcbb610f99e116945b62",
+                "sha256:d6e1fc3834f0be74c17e26bb8d0f506f711eb888775ab6af9164c0abb6f4c97c"
             ],
             "index": "pypi",
             "version": "==0.3.3"
         },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "version": "==2.9"
-        },
-        "idna-ssl": {
-            "hashes": [
-                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==1.1.0"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
-                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.5.0"
+            "markers": "python_version >= '3.5'",
+            "version": "==3.3"
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
-                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
+                "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
+                "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"
             ],
-            "version": "==1.1.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
         },
         "jinja2": {
             "hashes": [
-                "sha256:c10142f819c2d22bdcd17548c46fa9b77cf4fda45097854c689666bf425e7484",
-                "sha256:c922560ac46888d47384de1dbdc3daaa2ea993af4b26a436dec31fa2c19ec668"
+                "sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45",
+                "sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c"
             ],
-            "version": "==3.0.0a1"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.2"
         },
         "jmespath": {
             "hashes": [
-                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
-                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "version": "==0.9.4"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.0"
         },
         "jsonschema": {
             "hashes": [
@@ -171,84 +166,129 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
-                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
-                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
-                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
-                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
-                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
-                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
-                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
-                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
-                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
-                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
-                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
-                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
-                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
-                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
-                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
-                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
-                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
-                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
-                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
-                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
-                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
-                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
-                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
-                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
-                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
-                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
-                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
-                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
-                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
-                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
-                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
-                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
+                "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
+                "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38",
+                "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
+                "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
+                "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
+                "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
+                "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
             ],
-            "version": "==1.1.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
         },
         "multidict": {
             "hashes": [
-                "sha256:317f96bc0950d249e96d8d29ab556d01dd38888fbe68324f46fd834b430169f1",
-                "sha256:42f56542166040b4474c0c608ed051732033cd821126493cf25b6c276df7dd35",
-                "sha256:4b7df040fb5fe826d689204f9b544af469593fb3ff3a069a6ad3409f742f5928",
-                "sha256:544fae9261232a97102e27a926019100a9db75bec7b37feedd74b3aa82f29969",
-                "sha256:620b37c3fea181dab09267cd5a84b0f23fa043beb8bc50d8474dd9694de1fa6e",
-                "sha256:6e6fef114741c4d7ca46da8449038ec8b1e880bbe68674c01ceeb1ac8a648e78",
-                "sha256:7774e9f6c9af3f12f296131453f7b81dabb7ebdb948483362f5afcaac8a826f1",
-                "sha256:85cb26c38c96f76b7ff38b86c9d560dea10cf3459bb5f4caf72fc1bb932c7136",
-                "sha256:a326f4240123a2ac66bb163eeba99578e9d63a8654a59f4688a79198f9aa10f8",
-                "sha256:ae402f43604e3b2bc41e8ea8b8526c7fa7139ed76b0d64fc48e28125925275b2",
-                "sha256:aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e",
-                "sha256:b51249fdd2923739cd3efc95a3d6c363b67bbf779208e9f37fd5e68540d1a4d4",
-                "sha256:bb519becc46275c594410c6c28a8a0adc66fe24fef154a9addea54c1adb006f5",
-                "sha256:c2c37185fb0af79d5c117b8d2764f4321eeb12ba8c141a95d0aa8c2c1d0a11dd",
-                "sha256:dc561313279f9d05a3d0ffa89cd15ae477528ea37aa9795c4654588a3287a9ab",
-                "sha256:e439c9a10a95cb32abd708bb8be83b2134fa93790a4fb0535ca36db3dda94d20",
-                "sha256:fc3b4adc2ee8474cb3cd2a155305d5f8eda0a9c91320f83e55748e1fcb68f8e3"
+                "sha256:1ece5a3369835c20ed57adadc663400b5525904e53bae59ec854a5d36b39b21a",
+                "sha256:275ca32383bc5d1894b6975bb4ca6a7ff16ab76fa622967625baeebcf8079000",
+                "sha256:3750f2205b800aac4bb03b5ae48025a64e474d2c6cc79547988ba1d4122a09e2",
+                "sha256:4538273208e7294b2659b1602490f4ed3ab1c8cf9dbdd817e0e9db8e64be2507",
+                "sha256:5141c13374e6b25fe6bf092052ab55c0c03d21bd66c94a0e3ae371d3e4d865a5",
+                "sha256:51a4d210404ac61d32dada00a50ea7ba412e6ea945bbe992e4d7a595276d2ec7",
+                "sha256:5cf311a0f5ef80fe73e4f4c0f0998ec08f954a6ec72b746f3c179e37de1d210d",
+                "sha256:6513728873f4326999429a8b00fc7ceddb2509b01d5fd3f3be7881a257b8d463",
+                "sha256:7388d2ef3c55a8ba80da62ecfafa06a1c097c18032a501ffd4cabbc52d7f2b19",
+                "sha256:9456e90649005ad40558f4cf51dbb842e32807df75146c6d940b6f5abb4a78f3",
+                "sha256:c026fe9a05130e44157b98fea3ab12969e5b60691a276150db9eda71710cd10b",
+                "sha256:d14842362ed4cf63751648e7672f7174c9818459d169231d03c56e84daf90b7c",
+                "sha256:e0d072ae0f2a179c375f67e3da300b47e1a83293c554450b29c900e50afaae87",
+                "sha256:f07acae137b71af3bb548bd8da720956a3bc9f9a0b87733e0899226a2317aeb7",
+                "sha256:fbb77a75e529021e7c4a8d4e823d88ef4d23674a202be4f5addffc72cbb91430",
+                "sha256:fcfbb44c59af3f8ea984de67ec7c306f618a3ec771c2843804069917a8f2e255",
+                "sha256:feed85993dbdb1dbc29102f50bca65bdc68f2c0c8d352468c25b54874f23c39d"
             ],
-            "version": "==4.7.5"
+            "markers": "python_version >= '3.5'",
+            "version": "==4.7.6"
         },
         "py": {
             "hashes": [
-                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
-                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
-            "version": "==1.8.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
         },
         "pyrsistent": {
             "hashes": [
-                "sha256:cdc7b5e3ed77bed61270a47d35434a30617b9becdf2478af76ad2c6ade307280"
+                "sha256:097b96f129dd36a8c9e33594e7ebb151b1515eb52cceb08474c10a5479e799f2",
+                "sha256:2aaf19dc8ce517a8653746d98e962ef480ff34b6bc563fc067be6401ffb457c7",
+                "sha256:404e1f1d254d314d55adb8d87f4f465c8693d6f902f67eb6ef5b4526dc58e6ea",
+                "sha256:48578680353f41dca1ca3dc48629fb77dfc745128b56fc01096b2530c13fd426",
+                "sha256:4916c10896721e472ee12c95cdc2891ce5890898d2f9907b1b4ae0f53588b710",
+                "sha256:527be2bfa8dc80f6f8ddd65242ba476a6c4fb4e3aedbf281dfbac1b1ed4165b1",
+                "sha256:58a70d93fb79dc585b21f9d72487b929a6fe58da0754fa4cb9f279bb92369396",
+                "sha256:5e4395bbf841693eaebaa5bb5c8f5cdbb1d139e07c975c682ec4e4f8126e03d2",
+                "sha256:6b5eed00e597b5b5773b4ca30bd48a5774ef1e96f2a45d105db5b4ebb4bca680",
+                "sha256:73ff61b1411e3fb0ba144b8f08d6749749775fe89688093e1efef9839d2dcc35",
+                "sha256:772e94c2c6864f2cd2ffbe58bb3bdefbe2a32afa0acb1a77e472aac831f83427",
+                "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b",
+                "sha256:a0c772d791c38bbc77be659af29bb14c38ced151433592e326361610250c605b",
+                "sha256:b29b869cf58412ca5738d23691e96d8aff535e17390128a1a52717c9a109da4f",
+                "sha256:c1a9ff320fa699337e05edcaae79ef8c2880b52720bc031b219e5b5008ebbdef",
+                "sha256:cd3caef37a415fd0dae6148a1b6957a8c5f275a62cca02e18474608cb263640c",
+                "sha256:d5ec194c9c573aafaceebf05fc400656722793dac57f254cd4741f3c27ae57b4",
+                "sha256:da6e5e818d18459fa46fac0a4a4e543507fe1110e808101277c5a2b5bab0cd2d",
+                "sha256:e79d94ca58fcafef6395f6352383fa1a76922268fa02caa2272fff501c2fdc78",
+                "sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b",
+                "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"
             ],
-            "version": "==0.15.7"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.18.0"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
-                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==2.8.1"
+            "version": "==2.8.2"
         },
         "pytz": {
             "hashes": [
@@ -283,10 +323,11 @@
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "version": "==1.14.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -299,11 +340,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
-                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
+                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.25.8"
+            "version": "==1.25.11"
         },
         "uwsgi": {
             "hashes": [
@@ -321,10 +362,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096",
-                "sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16"
+                "sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f",
+                "sha256:aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a"
             ],
-            "version": "==1.0.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.2"
         },
         "wtforms": {
             "hashes": [
@@ -336,32 +378,81 @@
         },
         "yarl": {
             "hashes": [
-                "sha256:0c2ab325d33f1b824734b3ef51d4d54a54e0e7a23d13b86974507602334c2cce",
-                "sha256:0ca2f395591bbd85ddd50a82eb1fde9c1066fafe888c5c7cc1d810cf03fd3cc6",
-                "sha256:2098a4b4b9d75ee352807a95cdf5f10180db903bc5b7270715c6bbe2551f64ce",
-                "sha256:25e66e5e2007c7a39541ca13b559cd8ebc2ad8fe00ea94a2aad28a9b1e44e5ae",
-                "sha256:26d7c90cb04dee1665282a5d1a998defc1a9e012fdca0f33396f81508f49696d",
-                "sha256:308b98b0c8cd1dfef1a0311dc5e38ae8f9b58349226aa0533f15a16717ad702f",
-                "sha256:3ce3d4f7c6b69c4e4f0704b32eca8123b9c58ae91af740481aa57d7857b5e41b",
-                "sha256:58cd9c469eced558cd81aa3f484b2924e8897049e06889e8ff2510435b7ef74b",
-                "sha256:5b10eb0e7f044cf0b035112446b26a3a2946bca9d7d7edb5e54a2ad2f6652abb",
-                "sha256:6faa19d3824c21bcbfdfce5171e193c8b4ddafdf0ac3f129ccf0cdfcb083e462",
-                "sha256:944494be42fa630134bf907714d40207e646fd5a94423c90d5b514f7b0713fea",
-                "sha256:a161de7e50224e8e3de6e184707476b5a989037dcb24292b391a3d66ff158e70",
-                "sha256:a4844ebb2be14768f7994f2017f70aca39d658a96c786211be5ddbe1c68794c1",
-                "sha256:c2b509ac3d4b988ae8769901c66345425e361d518aecbe4acbfc2567e416626a",
-                "sha256:c9959d49a77b0e07559e579f38b2f3711c2b8716b8410b320bf9713013215a1b",
-                "sha256:d8cdee92bc930d8b09d8bd2043cedd544d9c8bd7436a77678dd602467a993080",
-                "sha256:e15199cdb423316e15f108f51249e44eb156ae5dba232cb73be555324a1d49c2"
+                "sha256:053e09817eafb892e94e172d05406c1b3a22a93bc68f6eff5198363a3d764459",
+                "sha256:08c2044a956f4ef30405f2f433ce77f1f57c2c773bf81ae43201917831044d5a",
+                "sha256:15ec41a5a5fdb7bace6d7b16701f9440007a82734f69127c0fbf6d87e10f4a1e",
+                "sha256:1beef4734ca1ad40a9d8c6b20a76ab46e3a2ed09f38561f01e4aa2ea82cafcef",
+                "sha256:1d3b8449dfedfe94eaff2b77954258b09b24949f6818dfa444b05dbb05ae1b7e",
+                "sha256:22b2430c49713bfb2f0a0dd4a8d7aab218b28476ba86fd1c78ad8899462cbcf2",
+                "sha256:263c81b94e6431942b27f6f671fa62f430a0a5c14bb255f2ab69eeb9b2b66ff7",
+                "sha256:2e48f27936aa838939c798f466c851ba4ae79e347e8dfce43b009c64b930df12",
+                "sha256:2e7ad9db939082f5d0b9269cfd92c025cb8f2fbbb1f1b9dc5a393c639db5bd92",
+                "sha256:36ec44f15193f6d5288d42ebb8e751b967ebdfb72d6830983838d45ab18edb4f",
+                "sha256:376e41775aab79c5575534924a386c8e0f1a5d91db69fc6133fd27a489bcaf10",
+                "sha256:38173b8c3a29945e7ecade9a3f6ff39581eee8201338ee6a2c8882db5df3e806",
+                "sha256:3a31e4a8dcb1beaf167b7e7af61b88cb961b220db8d3ba1c839723630e57eef7",
+                "sha256:3ad51e17cd65ea3debb0e10f0120cf8dd987c741fe423ed2285087368090b33d",
+                "sha256:3d461b7a8e139b9e4b41f62eb417ffa0b98d1c46d4caf14c845e6a3b349c0bb1",
+                "sha256:3def6e681cc02397e5d8141ee97b41d02932b2bcf0fb34532ad62855eab7c60e",
+                "sha256:46a742ed9e363bd01be64160ce7520e92e11989bd4cb224403cfd31c101cc83d",
+                "sha256:484d61c047c45670ef5967653a1d0783e232c54bf9dd786a7737036828fa8d54",
+                "sha256:50127634f519b2956005891507e3aa4ac345f66a7ea7bbc2d7dcba7401f41898",
+                "sha256:59c0f13f9592820c51280d1cf811294d753e4a18baf90f0139d1dc93d4b6fc5f",
+                "sha256:622a36fa779efb4ff9eff5fe52730ff17521431379851a31e040958fc251670c",
+                "sha256:64773840952de17851a1c7346ad7f71688c77e74248d1f0bc230e96680f84028",
+                "sha256:69945d13e1bbf81784a9bc48824feb9cd66491e6a503d4e83f6cd7c7cc861361",
+                "sha256:7c8d0bb76eabc5299db203e952ec55f8f4c53f08e0df4285aac8c92bd9e12675",
+                "sha256:7e37786ea89a5d3ffbbf318ea9790926f8dfda83858544f128553c347ad143c6",
+                "sha256:7f7655ad83d1a8afa48435a449bf2f3009293da1604f5dd95b5ddcf5f673bd69",
+                "sha256:81cfacdd1e40bc931b5519499342efa388d24d262c30a3d31187bfa04f4a7001",
+                "sha256:821b978f2152be7695d4331ef0621d207aedf9bbd591ba23a63412a3efc29a01",
+                "sha256:82ff6f85f67500a4f74885d81659cd270eb24dfe692fe44e622b8a2fd57e7279",
+                "sha256:87721b549505a546eb003252185103b5ec8147de6d3ad3714d148a5a67b6fe53",
+                "sha256:8a8b10d0e7bac154f959b709fcea593cda527b234119311eb950096653816a86",
+                "sha256:8b8c409aa3a7966647e7c1c524846b362a6bcbbe120bf8a176431f940d2b9a2e",
+                "sha256:8ba402f32184f0b405fb281b93bd0d8ab7e3257735b57b62a6ed2e94cdf4fe50",
+                "sha256:8e3ffab21db0542ffd1887f3b9575ddd58961f2cf61429cb6458afc00c4581e0",
+                "sha256:8e7ebaf62e19c2feb097ffb7c94deb0f0c9fab52590784c8cd679d30ab009162",
+                "sha256:8ee78c9a5f3c642219d4607680a4693b59239c27a3aa608b64ef79ddc9698039",
+                "sha256:91cbe24300c11835ef186436363352b3257db7af165e0a767f4f17aa25761388",
+                "sha256:9624154ec9c02a776802da1086eed7f5034bd1971977f5146233869c2ac80297",
+                "sha256:98c51f02d542945d306c8e934aa2c1e66ba5e9c1c86b5bf37f3a51c8a747067e",
+                "sha256:98c9ddb92b60a83c21be42c776d3d9d5ec632a762a094c41bda37b7dfbd2cd83",
+                "sha256:a06d9d0b9a97fa99b84fee71d9dd11e69e21ac8a27229089f07b5e5e50e8d63c",
+                "sha256:a1fa866fa24d9f4108f9e58ea8a2135655419885cdb443e36b39a346e1181532",
+                "sha256:a3455c2456d6307bcfa80bc1157b8603f7d93573291f5bdc7144489ca0df4628",
+                "sha256:a532d75ca74431c053a88a802e161fb3d651b8bf5821a3440bc3616e38754583",
+                "sha256:a7dfc46add4cfe5578013dbc4127893edc69fe19132d2836ff2f6e49edc5ecd6",
+                "sha256:a7f08819dba1e1255d6991ed37448a1bf4b1352c004bcd899b9da0c47958513d",
+                "sha256:aa9f0d9b62d15182341b3e9816582f46182cab91c1a57b2d308b9a3c4e2c4f78",
+                "sha256:acbf1756d9dc7cd0ae943d883be72e84e04396f6c2ff93a6ddeca929d562039f",
+                "sha256:b22ea41c7e98170474a01e3eded1377d46b2dfaef45888a0005c683eaaa49285",
+                "sha256:b28cfb46140efe1a6092b8c5c4994a1fe70dc83c38fbcea4992401e0c6fb9cce",
+                "sha256:b36f5a63c891f813c6f04ef19675b382efc190fd5ce7e10ab19386d2548bca06",
+                "sha256:b64bd24c8c9a487f4a12260dc26732bf41028816dbf0c458f17864fbebdb3131",
+                "sha256:b7de92a4af85cfcaf4081f8aa6165b1d63ee5de150af3ee85f954145f93105a7",
+                "sha256:bb3e478175e15e00d659fb0354a6a8db71a7811a2a5052aed98048bc972e5d2b",
+                "sha256:be52bc5208d767cdd8308a9e93059b3b36d1e048fecbea0e0346d0d24a76adc0",
+                "sha256:c18a4b286e8d780c3a40c31d7b79836aa93b720f71d5743f20c08b7e049ca073",
+                "sha256:c63c1e208f800daad71715786bfeb1cecdc595d87e2e9b1cd234fd6e597fd71d",
+                "sha256:c7015dcedb91d90a138eebdc7e432aec8966e0147ab2a55f2df27b1904fa7291",
+                "sha256:cb4ff1ac7cb4500f43581b3f4cbd627d702143aa6be1fdc1fa3ebffaf4dc1be5",
+                "sha256:d30d67e3486aea61bb2cbf7cf81385364c2e4f7ce7469a76ed72af76a5cdfe6b",
+                "sha256:d54c925396e7891666cabc0199366ca55b27d003393465acef63fd29b8b7aa92",
+                "sha256:d579957439933d752358c6a300c93110f84aae67b63dd0c19dde6ecbf4056f6b",
+                "sha256:d750503682605088a14d29a4701548c15c510da4f13c8b17409c4097d5b04c52",
+                "sha256:db2372e350794ce8b9f810feb094c606b7e0e4aa6807141ac4fadfe5ddd75bb0",
+                "sha256:e35d8230e4b08d86ea65c32450533b906a8267a87b873f2954adeaecede85169",
+                "sha256:e510dbec7c59d32eaa61ffa48173d5e3d7170a67f4a03e8f5e2e9e3971aca622",
+                "sha256:e78c91faefe88d601ddd16e3882918dbde20577a2438e2320f8239c8b7507b8f",
+                "sha256:eb4b3f277880c314e47720b4b6bb2c85114ab3c04c5442c9bc7006b3787904d8",
+                "sha256:ec1b5a25a25c880c976d0bb3d107def085bb08dbb3db7f4442e0a2b980359d24",
+                "sha256:f3cd2158b2ed0fb25c6811adfdcc47224efe075f2d68a750071dacc03a7a66e4",
+                "sha256:f46cd4c43e6175030e2a56def8f1d83b64e6706eeb2bb9ab0ef4756f65eab23f",
+                "sha256:fdd1b90c225a653b1bd1c0cae8edf1957892b9a09c8bf7ee6321eeb8208eac0f"
             ],
-            "version": "==1.4.2"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2",
-                "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"
-            ],
-            "version": "==3.0.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.7.0"
         }
     },
     "develop": {
@@ -382,74 +473,81 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
-            "version": "==19.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
         },
         "babel": {
             "hashes": [
-                "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
-                "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
+                "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9",
+                "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"
             ],
-            "version": "==2.8.0"
+            "index": "pypi",
+            "version": "==2.9.1"
         },
         "certifi": {
             "hashes": [
-                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
-                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
             ],
-            "version": "==2019.11.28"
+            "version": "==2021.10.8"
         },
-        "chardet": {
+        "charset-normalizer": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
+                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '3'",
+            "version": "==2.0.7"
         },
         "click": {
             "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+                "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
+                "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
             ],
-            "version": "==7.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.3"
         },
         "coverage": {
             "hashes": [
-                "sha256:15cf13a6896048d6d947bf7d222f36e4809ab926894beb748fc9caa14605d9c3",
-                "sha256:1daa3eceed220f9fdb80d5ff950dd95112cd27f70d004c7918ca6dfc6c47054c",
-                "sha256:1e44a022500d944d42f94df76727ba3fc0a5c0b672c358b61067abb88caee7a0",
-                "sha256:25dbf1110d70bab68a74b4b9d74f30e99b177cde3388e07cc7272f2168bd1477",
-                "sha256:3230d1003eec018ad4a472d254991e34241e0bbd513e97a29727c7c2f637bd2a",
-                "sha256:3dbb72eaeea5763676a1a1efd9b427a048c97c39ed92e13336e726117d0b72bf",
-                "sha256:5012d3b8d5a500834783689a5d2292fe06ec75dc86ee1ccdad04b6f5bf231691",
-                "sha256:51bc7710b13a2ae0c726f69756cf7ffd4362f4ac36546e243136187cfcc8aa73",
-                "sha256:527b4f316e6bf7755082a783726da20671a0cc388b786a64417780b90565b987",
-                "sha256:722e4557c8039aad9592c6a4213db75da08c2cd9945320220634f637251c3894",
-                "sha256:76e2057e8ffba5472fd28a3a010431fd9e928885ff480cb278877c6e9943cc2e",
-                "sha256:77afca04240c40450c331fa796b3eab6f1e15c5ecf8bf2b8bee9706cd5452fef",
-                "sha256:7afad9835e7a651d3551eab18cbc0fdb888f0a6136169fbef0662d9cdc9987cf",
-                "sha256:9bea19ac2f08672636350f203db89382121c9c2ade85d945953ef3c8cf9d2a68",
-                "sha256:a8b8ac7876bc3598e43e2603f772d2353d9931709345ad6c1149009fd1bc81b8",
-                "sha256:b0840b45187699affd4c6588286d429cd79a99d509fe3de0f209594669bb0954",
-                "sha256:b26aaf69713e5674efbde4d728fb7124e429c9466aeaf5f4a7e9e699b12c9fe2",
-                "sha256:b63dd43f455ba878e5e9f80ba4f748c0a2156dde6e0e6e690310e24d6e8caf40",
-                "sha256:be18f4ae5a9e46edae3f329de2191747966a34a3d93046dbdf897319923923bc",
-                "sha256:c312e57847db2526bc92b9bfa78266bfbaabac3fdcd751df4d062cd4c23e46dc",
-                "sha256:c60097190fe9dc2b329a0eb03393e2e0829156a589bd732e70794c0dd804258e",
-                "sha256:c62a2143e1313944bf4a5ab34fd3b4be15367a02e9478b0ce800cb510e3bbb9d",
-                "sha256:cc1109f54a14d940b8512ee9f1c3975c181bbb200306c6d8b87d93376538782f",
-                "sha256:cd60f507c125ac0ad83f05803063bed27e50fa903b9c2cfee3f8a6867ca600fc",
-                "sha256:d513cc3db248e566e07a0da99c230aca3556d9b09ed02f420664e2da97eac301",
-                "sha256:d649dc0bcace6fcdb446ae02b98798a856593b19b637c1b9af8edadf2b150bea",
-                "sha256:d7008a6796095a79544f4da1ee49418901961c97ca9e9d44904205ff7d6aa8cb",
-                "sha256:da93027835164b8223e8e5af2cf902a4c80ed93cb0909417234f4a9df3bcd9af",
-                "sha256:e69215621707119c6baf99bda014a45b999d37602cb7043d943c76a59b05bf52",
-                "sha256:ea9525e0fef2de9208250d6c5aeeee0138921057cd67fcef90fbed49c4d62d37",
-                "sha256:fca1669d464f0c9831fd10be2eef6b86f5ebd76c724d1e0706ebdff86bb4adf0"
+                "sha256:04560539c19ec26995ecfb3d9307ff154fbb9a172cb57e3b3cfc4ced673103d1",
+                "sha256:1549e1d08ce38259de2bc3e9a0d5f3642ff4a8f500ffc1b2df73fd621a6cdfc0",
+                "sha256:1db67c497688fd4ba85b373b37cc52c50d437fd7267520ecd77bddbd89ea22c9",
+                "sha256:30922626ce6f7a5a30bdba984ad21021529d3d05a68b4f71ea3b16bda35b8895",
+                "sha256:36e9040a43d2017f2787b28d365a4bb33fcd792c7ff46a047a04094dc0e2a30d",
+                "sha256:381d773d896cc7f8ba4ff3b92dee4ed740fb88dfe33b6e42efc5e8ab6dfa1cfe",
+                "sha256:3bbda1b550e70fa6ac40533d3f23acd4f4e9cb4e6e77251ce77fdf41b3309fb2",
+                "sha256:3be1206dc09fb6298de3fce70593e27436862331a85daee36270b6d0e1c251c4",
+                "sha256:424c44f65e8be58b54e2b0bd1515e434b940679624b1b72726147cfc6a9fc7ce",
+                "sha256:4b34ae4f51bbfa5f96b758b55a163d502be3dcb24f505d0227858c2b3f94f5b9",
+                "sha256:4e28d2a195c533b58fc94a12826f4431726d8eb029ac21d874345f943530c122",
+                "sha256:53a294dc53cfb39c74758edaa6305193fb4258a30b1f6af24b360a6c8bd0ffa7",
+                "sha256:60e51a3dd55540bec686d7fff61b05048ca31e804c1f32cbb44533e6372d9cc3",
+                "sha256:61b598cbdbaae22d9e34e3f675997194342f866bb1d781da5d0be54783dce1ff",
+                "sha256:6807947a09510dc31fa86f43595bf3a14017cd60bf633cc746d52141bfa6b149",
+                "sha256:6a6a9409223a27d5ef3cca57dd7cd4dfcb64aadf2fad5c3b787830ac9223e01a",
+                "sha256:7092eab374346121805fb637572483270324407bf150c30a3b161fc0c4ca5164",
+                "sha256:77b1da5767ed2f44611bc9bc019bc93c03fa495728ec389759b6e9e5039ac6b1",
+                "sha256:8251b37be1f2cd9c0e5ccd9ae0380909c24d2a5ed2162a41fcdbafaf59a85ebd",
+                "sha256:9f1627e162e3864a596486774876415a7410021f4b67fd2d9efdf93ade681afc",
+                "sha256:a1b73c7c4d2a42b9d37dd43199c5711d91424ff3c6c22681bc132db4a4afec6f",
+                "sha256:a82d79586a0a4f5fd1cf153e647464ced402938fbccb3ffc358c7babd4da1dd9",
+                "sha256:abbff240f77347d17306d3201e14431519bf64495648ca5a49571f988f88dee9",
+                "sha256:ad9b8c1206ae41d46ec7380b78ba735ebb77758a650643e841dd3894966c31d0",
+                "sha256:bbffde2a68398682623d9dd8c0ca3f46fda074709b26fcf08ae7a4c431a6ab2d",
+                "sha256:bcae10fccb27ca2a5f456bf64d84110a5a74144be3136a5e598f9d9fb48c0caa",
+                "sha256:c9cd3828bbe1a40070c11fe16a51df733fd2f0cb0d745fb83b7b5c1f05967df7",
+                "sha256:cd1cf1deb3d5544bd942356364a2fdc8959bad2b6cf6eb17f47d301ea34ae822",
+                "sha256:d036dc1ed8e1388e995833c62325df3f996675779541f682677efc6af71e96cc",
+                "sha256:db42baa892cba723326284490283a68d4de516bfb5aaba369b4e3b2787a778b7",
+                "sha256:e4fb7ced4d9dec77d6cf533acfbf8e1415fe799430366affb18d69ee8a3c6330",
+                "sha256:e7a0b42db2a47ecb488cde14e0f6c7679a2c5a9f44814393b162ff6397fcdfbb",
+                "sha256:f2f184bf38e74f152eed7f87e345b51f3ab0b703842f447c22efe35e59942c24"
             ],
-            "version": "==5.0.3"
+            "markers": "python_version >= '3.6'",
+            "version": "==6.0.2"
         },
         "docutils": {
             "hashes": [
@@ -457,6 +555,7 @@
                 "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
                 "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.15.2"
         },
         "hypothesis": {
@@ -469,95 +568,123 @@
         },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "version": "==2.9"
+            "markers": "python_version >= '3.5'",
+            "version": "==3.3"
         },
         "imagesize": {
             "hashes": [
                 "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
                 "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
         },
         "isort": {
             "hashes": [
-                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
-                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+                "sha256:9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899",
+                "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"
             ],
-            "version": "==4.3.21"
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
+            "version": "==5.9.3"
         },
         "jinja2": {
             "hashes": [
-                "sha256:c10142f819c2d22bdcd17548c46fa9b77cf4fda45097854c689666bf425e7484",
-                "sha256:c922560ac46888d47384de1dbdc3daaa2ea993af4b26a436dec31fa2c19ec668"
+                "sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45",
+                "sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c"
             ],
-            "version": "==3.0.0a1"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.2"
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
-                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
-                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
-                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
-                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
-                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
-                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
-                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
-                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
-                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
-                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
-                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
-                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
-                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
-                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
-                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
-                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
-                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
-                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
-                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
-                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
+                "sha256:17e0967ba374fc24141738c69736da90e94419338fd4c7c7bef01ee26b339653",
+                "sha256:1fee665d2638491f4d6e55bd483e15ef21f6c8c2095f235fef72601021e64f61",
+                "sha256:22ddd618cefe54305df49e4c069fa65715be4ad0e78e8d252a33debf00f6ede2",
+                "sha256:24a5045889cc2729033b3e604d496c2b6f588c754f7a62027ad4437a7ecc4837",
+                "sha256:410283732af311b51b837894fa2f24f2c0039aa7f220135192b38fcc42bd43d3",
+                "sha256:4732c765372bd78a2d6b2150a6e99d00a78ec963375f236979c0626b97ed8e43",
+                "sha256:489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726",
+                "sha256:4f60460e9f1eb632584c9685bccea152f4ac2130e299784dbaf9fae9f49891b3",
+                "sha256:5743a5ab42ae40caa8421b320ebf3a998f89c85cdc8376d6b2e00bd12bd1b587",
+                "sha256:85fb7608121fd5621cc4377a8961d0b32ccf84a7285b4f1d21988b2eae2868e8",
+                "sha256:9698110e36e2df951c7c36b6729e96429c9c32b3331989ef19976592c5f3c77a",
+                "sha256:9d397bf41caad3f489e10774667310d73cb9c4258e9aed94b9ec734b34b495fd",
+                "sha256:b579f8acbf2bdd9ea200b1d5dea36abd93cabf56cf626ab9c744a432e15c815f",
+                "sha256:b865b01a2e7f96db0c5d12cfea590f98d8c5ba64ad222300d93ce6ff9138bcad",
+                "sha256:bf34e368e8dd976423396555078def5cfc3039ebc6fc06d1ae2c5a65eebbcde4",
+                "sha256:c6938967f8528b3668622a9ed3b31d145fab161a32f5891ea7b84f6b790be05b",
+                "sha256:d1c2676e3d840852a2de7c7d5d76407c772927addff8d742b9808fe0afccebdf",
+                "sha256:d7124f52f3bd259f510651450e18e0fd081ed82f3c08541dffc7b94b883aa981",
+                "sha256:d900d949b707778696fdf01036f58c9876a0d8bfe116e8d220cfd4b15f14e741",
+                "sha256:ebfd274dcd5133e0afae738e6d9da4323c3eb021b3e13052d8cbd0e457b1256e",
+                "sha256:ed361bb83436f117f9917d282a456f9e5009ea12fd6de8742d1a4752c3017e93",
+                "sha256:f5144c75445ae3ca2057faac03fda5a902eff196702b0a24daf1d6ce0650514b"
             ],
-            "version": "==1.4.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.6.0"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
-                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
-                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
-                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
-                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
-                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
-                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
-                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
-                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
-                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
-                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
-                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
-                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
-                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
-                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
-                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
-                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
-                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
-                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
-                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
-                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
-                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
-                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
-                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
-                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
-                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
-                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
-                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
-                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
-                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
-                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
-                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
-                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
+                "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
+                "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38",
+                "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
+                "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
+                "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
+                "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
+                "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
             ],
-            "version": "==1.1.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
         },
         "mccabe": {
             "hashes": [
@@ -601,10 +728,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73",
-                "sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
             ],
-            "version": "==20.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
         },
         "pydocstyle": {
             "hashes": [
@@ -616,10 +744,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b",
-                "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"
+                "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380",
+                "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"
             ],
-            "version": "==2.5.2"
+            "markers": "python_version >= '3.5'",
+            "version": "==2.10.0"
         },
         "pylint": {
             "hashes": [
@@ -631,10 +760,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
-                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+                "sha256:10fb0827f908440eda768ec659627c3ac5dc20a25b4adaf50e7e10b248c17a4f",
+                "sha256:f72f2294ef53f917d984093e8ac8ed5818837516132e68c67b7fdd5350c8dabf"
             ],
-            "version": "==2.4.6"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.0rc2"
         },
         "pytz": {
             "hashes": [
@@ -646,31 +776,33 @@
         },
         "requests": {
             "hashes": [
-                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
-                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
-            "version": "==2.23.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==2.26.0"
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "version": "==1.14.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
         },
         "snowballstemmer": {
             "hashes": [
-                "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
-                "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
+                "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2",
+                "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"
             ],
-            "version": "==2.0.0"
+            "version": "==2.1.0"
         },
         "sortedcontainers": {
             "hashes": [
-                "sha256:974e9a32f56b17c1bac2aebd9dcf197f3eb9cd30553c5852a3187ad162e1a03a",
-                "sha256:d9e96492dd51fae31e60837736b38fe42a187b5404c16606ff7ee7cd582d4c60"
+                "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88",
+                "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
             ],
-            "version": "==2.1.0"
+            "version": "==2.4.0"
         },
         "sphinx": {
             "hashes": [
@@ -690,45 +822,51 @@
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
-                "sha256:edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897",
-                "sha256:fb8dee85af95e5c30c91f10e7eb3c8967308518e0f7488a2828ef7bc191d0d5d"
+                "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
+                "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
             ],
-            "version": "==1.0.1"
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.2"
         },
         "sphinxcontrib-devhelp": {
             "hashes": [
-                "sha256:6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34",
-                "sha256:9512ecb00a2b0821a146736b39f7aeb90759834b07e81e8cc23a9c70bacb9981"
+                "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
+                "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
             ],
-            "version": "==1.0.1"
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.2"
         },
         "sphinxcontrib-htmlhelp": {
             "hashes": [
-                "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f",
-                "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"
+                "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07",
+                "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"
             ],
-            "version": "==1.0.3"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.0"
         },
         "sphinxcontrib-jsmath": {
             "hashes": [
                 "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
                 "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
         },
         "sphinxcontrib-qthelp": {
             "hashes": [
-                "sha256:513049b93031beb1f57d4daea74068a4feb77aa5630f856fcff2e50de14e9a20",
-                "sha256:79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f"
+                "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
+                "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
             ],
-            "version": "==1.0.2"
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.3"
         },
         "sphinxcontrib-serializinghtml": {
             "hashes": [
-                "sha256:c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227",
-                "sha256:db6615af393650bf1151a6cd39120c29abaf93cc60db8c48eb2dddbfdc3a9768"
+                "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd",
+                "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"
             ],
-            "version": "==1.1.3"
+            "markers": "python_version >= '3.5'",
+            "version": "==1.1.5"
         },
         "sphinxcontrib-websupport": {
             "hashes": [
@@ -740,29 +878,38 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
-                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
-                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
-                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
-                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
-                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
-                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
-                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
-                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
-                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
-                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
-                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
-                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
-                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
-                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
-                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
-                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
-                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
-                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
-                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
-                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+                "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace",
+                "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff",
+                "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266",
+                "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528",
+                "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6",
+                "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808",
+                "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4",
+                "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363",
+                "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341",
+                "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04",
+                "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41",
+                "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e",
+                "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3",
+                "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899",
+                "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805",
+                "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c",
+                "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c",
+                "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39",
+                "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a",
+                "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3",
+                "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7",
+                "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f",
+                "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075",
+                "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0",
+                "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40",
+                "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428",
+                "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927",
+                "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3",
+                "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
+                "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
-            "version": "==1.4.1"
+            "version": "==1.4.3"
         },
         "typing-extensions": {
             "hashes": [
@@ -775,17 +922,66 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
-                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
+                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.25.8"
+            "version": "==1.25.11"
         },
         "wrapt": {
             "hashes": [
-                "sha256:0ec40d9fd4ec9f9e3ff9bdd12dbd3535f4085949f4db93025089d7a673ea94e8"
+                "sha256:08d875215b1e7301e8440898739156ba4111fe964d1ee66670e6b4e5897e559f",
+                "sha256:0a6dcb3f6efef1d9db5fd1815f1c99c1ccb14899fa7c2a51a93b91f6c7242c76",
+                "sha256:0e77361c7274185f08f3c269f0674d9291264b7e102d258ba63d84260d9625e6",
+                "sha256:105780f9fe2bcca1d7d7b04fcad469efcfe11b44e0d2d6cdc2b5c92868b91174",
+                "sha256:14a594ad8e4fcf1a1d12e62f7d469b614cf25ee14e00ef7c0c19d1c714a2743f",
+                "sha256:15d7c5a6b25350186353596df06f45cb119083c1b4ee756feaa1263943905986",
+                "sha256:2198ba8c9fbf7dc8fa5f2335a0753e056dfb3fec7784ad8eafc1d4d813439129",
+                "sha256:26049122366c804924f1bfb1f5143f827db51a365fed45f08cdce2fb03bc9f52",
+                "sha256:27bb175495d94df321a7689e2d2b3ff4e38343c75082cfd7b2ba76c2075181b5",
+                "sha256:3474621afbe7fedf8f6dc4bc634865d8ed3d1892d130e645a18f52b163d8e418",
+                "sha256:3a2be30d10e5a6d8d4c69744ce151a525a71d11f56970bfb3a3b1cca187bec33",
+                "sha256:4e1ca5a3c5c90ca35b00b6e889ef0272ac18e857d761905e18f61b2d20524cd8",
+                "sha256:5323ffe37d5a08066fe7baf95f77cf0ef3cbb619738c024b1bf1210a59b4ece0",
+                "sha256:5c2c4e1a85d77156bb2f612e3a4fe5ff7d04ac1e99f24f38d829a4cbbc2a9bf1",
+                "sha256:5d504a4a3bfaeec9d3c01fd79c2c9bc36a23fbc127e31d771cfa9ed32cc1ac25",
+                "sha256:5ebf99d7aa491694146e077f8a203a07847fb69d2888366af8dcfa3e763dabc7",
+                "sha256:6926c940804894b3654f0bd58125879ff8af207640845330e4d4fd4dfc251483",
+                "sha256:6abdccaf86d4fb58184b3d4b20411ab007a2d13dd0fdb1c49630296c134de749",
+                "sha256:7534f231e7096453854601ce918b325c43a14c4dc3283e3d4ec98e0251960582",
+                "sha256:7b8a10200af13cbca4716fbef8676871f7c6a66acfb2363e368beed007f045b1",
+                "sha256:7ca857f41b642e0bfa02f467abb4c89049ce0747c02a2d172307cd2c0d97f33a",
+                "sha256:7cb22538701581294c79924ac7eb8423b0efd794705f6434730aeb9099faa053",
+                "sha256:8c2cca64a546aa3961ed21faf46aef3b3ca7d5271cae54724c93b6b72c9e5fce",
+                "sha256:8cceb316d73889a6b55ba5eee1e77b137b7b66cf576e58c2bfc6803baddf6eab",
+                "sha256:8d6b24310a59bde0dc47cec8fa368751730b074e8b05d7c44b61e2fdc09f00ac",
+                "sha256:8e8adde54c237fe2c1aadf180d9fc019229f605ea97548b279b59a794fc30b3a",
+                "sha256:96cbfdd1ead8898c583b6f5032f7ef6a8f6bb4092850b93beeb03d0ed3212740",
+                "sha256:aa821c20d4afc85d4fe09d3f7b5c56878560c990ea9efb38bcc93dda8c7f5b9a",
+                "sha256:ad40a7d17e02e54a76deacc30aa4b00760a93ac77f5255fab87f7386185c4cee",
+                "sha256:b3197b30ad7720cb1d4de5c27d5e155a44fb11ae4b426ff452f82e4fa1dde82f",
+                "sha256:ca7ef94f7a7f4ecf0ada751c267a4d7f58c51730c999f693ac8dee123f3786f4",
+                "sha256:cec3eaa8a0067c2ac5cd2692f2679928760e2e7323ffa264973dadbfd193e86f",
+                "sha256:d09b564b33c27bea374f8fe5d4c4fb32d259168f5edab9385084fe575c847d75",
+                "sha256:d58cd8c5b919d412250e6c4a422b8ab4accc72b76bf08be7fa764eca1c7cd212",
+                "sha256:d5ed2220a4e444cc33c72d5239f67d96a628647655d9b83e54b299dc081b2ecb",
+                "sha256:d738bcb5c42d98b326c59d9d6bb45ed84ca756713905c55d12dccacc02483e73",
+                "sha256:d80ed0455adf0a2d293ecb2f60b9afa3e270b40f7397ed931b8ffafca1ab5889",
+                "sha256:dae933429f5cc4935fd274ef13bed9e9c3d212ed8cfbd335ff339832ed5ecd3b",
+                "sha256:dd160fac1953b6a05a5cb2ebb5bfe108930d122e84571c8073752a1e328bba88",
+                "sha256:deb58c0a15f50d3bf4ddb375ad41246664f5fbe09432bb23718a5f544bf2d70e",
+                "sha256:e80679d366d4144858fcf450ca6481670d0ab51df31c957a08351d0ddce7daee",
+                "sha256:e9b59ad49a77003bf355ac5cfa1f0d31184044cb5b06b4a24a68f7c06570c43d",
+                "sha256:ea1fa44c28f1680a5b1d0fdb312dac611d1ff0ec280bf17929a586e0dffcde71",
+                "sha256:f0e4ba04134eb2bfa64cc2a3a502930ee98afd77911a210b0d1ee1de39f37eb4",
+                "sha256:f3d55c84600b949372570183caad6cd6a0b4338be87ab6a738c9198ee6ef6da1",
+                "sha256:f3e637103d13995e3ce83ccaba1bc5167f171e2716d6d28fbc6f30c40027423e",
+                "sha256:f6c9eaa2eb124fb8aae9427de03e595f73fae6d1ac6d1d5cb0e74d187f4f2b67",
+                "sha256:facc6ae3f33ccb167307978f2b11f7ef993bbb96f6a79a235a0a7063580ad359",
+                "sha256:fd918a91685483d690c52c347a3aba78c566c362e0200597532b0eaacf906bbc"
             ],
-            "version": "==1.12.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.13.3rc1"
         }
     }
 }

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -138,7 +138,9 @@
     secondary_categories = [],
     include_stylesheet = 1,
     embed_stylesheet = 0,
-    download_button_markup = None) -%}
+    download_button_markup = None,
+    preprint_doi = None
+) -%}
 
 {% if include_stylesheet and not embed_stylesheet %}
 <link rel="stylesheet" type="text/css" href="{{ url_for('base.static', filename='css/abs.css') }}">
@@ -207,6 +209,12 @@
         <tr>
           <td class="tablecell label">Report&nbsp;number:</td>
           <td class="tablecell jref">{{ report_num }}</td>
+        </tr>
+        {% endif -%}
+        {%- if preprint_doi %}
+        <tr>
+          <td class="tablecell label"><abbr title="Preprint Digital Object Identifier">Preprint DOI</abbr>:</td>
+          <td class="tablecell msc_classes"><a href="https://doi.org/{{ preprint_doi }}">https://doi.org/{{ preprint_doi }}</a></td>
         </tr>
         {% endif -%}
         <tr>

--- a/arxiv/base/urls/links.py
+++ b/arxiv/base/urls/links.py
@@ -33,8 +33,17 @@ handle FTP addresses.
 Updated 20 March, 2019: refactored to provide independent bleach attribute
 callbacks for each kind of link.
 """
-from typing import List, Pattern, Tuple, Callable, Dict, Union, Text, Any, \
-    MutableMapping
+from typing import (
+    List,
+    Pattern,
+    Tuple,
+    Callable,
+    Dict,
+    Union,
+    Text,
+    Any,
+    MutableMapping,
+)
 import re
 from functools import reduce
 from urllib.parse import quote, urlparse
@@ -53,13 +62,12 @@ Callable_Linker = Callable[[str], str]
 
 
 def _without_group_names(pattern: Pattern) -> str:
-    ptn: str = re.sub(r'\(\?P<[^>\!]+>', '(?:', pattern.pattern)
+    ptn: str = re.sub(r"\(\?P<[^>\!]+>", "(?:", pattern.pattern)
     return ptn
 
 
-DOI = re.compile(   # '10.1145/0001234.1234567'
-    r'(?P<doi>10.\d{4,9}/[-._;()/:A-Z0-9]+)',
-    re.I
+DOI = re.compile(  # '10.1145/0001234.1234567'
+    r"(?P<doi>10.\d{4,9}/[-._;()/:A-Z0-9]+)", re.I
 )
 """
 Pattern for matching DOIs.
@@ -72,7 +80,7 @@ https://www.crossref.org/blog/dois-and-matching-regular-expressions/
 """
 
 
-BROAD_DOI = re.compile(r'(?P<doi>\d{2,3}.\d{4,5}\/\S+)', re.I)
+BROAD_DOI = re.compile(r"(?P<doi>\d{2,3}.\d{4,5}\/\S+)", re.I)
 """
 Very broad pattern for matching DOIs in the abs DOI field.
 
@@ -83,29 +91,30 @@ Ex. 21.11130/00-1735-0000-0005-146A-E
 ARXIV_PATTERNS = [
     identifier.OLD_STYLE_WITH_ARCHIVE,  # math/0501233 hep-ph/0611734
     identifier.OLD_STYLE_WITH_CATEGORY,  # math.GR/0601136v3 math.GR/0601136
-    identifier.STANDARD  # 1609.05068 1207.1234v1 1207.1234 1807.12345v12
+    identifier.STANDARD,  # 1609.05068 1207.1234v1 1207.1234 1807.12345v12
 ]
 ARXIV_ID = re.compile(
-    "|".join([rf"(?:{_without_group_names(pattern)})"
-              for pattern in ARXIV_PATTERNS]),
-    re.IGNORECASE | re.VERBOSE | re.UNICODE
+    "|".join([rf"(?:{_without_group_names(pattern)})" for pattern in ARXIV_PATTERNS]),
+    re.IGNORECASE | re.VERBOSE | re.UNICODE,
 )
 
-OKCHARS = r'([a-z0-9,_.\-+~:]|%[a-f0-9]*)'
+OKCHARS = r"([a-z0-9,_.\-+~:]|%[a-f0-9]*)"
 """Characters that are acceptable during PATH, QUERY and ANCHOR parts"""
 
-PATH = rf'(?P<PATH>(/{OKCHARS}*)+)?'
+PATH = rf"(?P<PATH>(/{OKCHARS}*)+)?"
 """Regex for path part of URLs for use in urlize"""
 
-FTP = re.compile(rf'(?P<url>(?:ftp://)({OKCHARS}|(@))*{PATH})', re.I)
+FTP = re.compile(rf"(?P<url>(?:ftp://)({OKCHARS}|(@))*{PATH})", re.I)
 """Regex to match FTP URLs in text."""
 
-IP_ADDRESS = (r'(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}'
-              r'(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)')
+IP_ADDRESS = (
+    r"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}"
+    r"(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+)
 """Regex to match an IP address."""
 
-TLDS = '|'.join(bleach.linkifier.TLDS)
-PROTOCOLS = '|'.join(bleach.linkifier.html5lib_shim.allowed_protocols)
+TLDS = "|".join(bleach.linkifier.TLDS)
+PROTOCOLS = "|".join(bleach.linkifier.html5lib_shim.allowed_protocols)
 URL = re.compile(
     rf"""(?:{FTP.pattern})|
     (?:\(*  # Match any opening parentheses.
@@ -118,20 +127,20 @@ URL = re.compile(
         # /path/zz (excluding "unsafe" chars from RFC 1738,
         # except for # and ~, which happen in practice)
     """,
-    re.IGNORECASE | re.VERBOSE | re.UNICODE
+    re.IGNORECASE | re.VERBOSE | re.UNICODE,
 )
 
 
 def arxiv_id_to_url(arxiv_id: str) -> str:
     """Generate an URL for an arXiv ID."""
-    url: str = url_for('abs_by_id', paper_id=arxiv_id)
+    url: str = url_for("abs_by_id", paper_id=arxiv_id)
     return url
 
 
 def url_for_doi(doi: str) -> str:
     """Generate an URL for a DOI."""
-    quoted_doi = quote(doi, safe='/')
-    return f'https://dx.doi.org/{quoted_doi}'
+    quoted_doi = quote(doi, safe="/")
+    return f"https://doi.org/{quoted_doi}"
 
 
 def clickthrough_url_for_doi(doi: str) -> str:
@@ -140,16 +149,16 @@ def clickthrough_url_for_doi(doi: str) -> str:
 
 
 def _extend_class_attr(attrs: Attrs, new_class: str) -> Attrs:
-    if (None, 'class') not in attrs:
-        attrs[(None, 'class')] = ''
-    attrs[(None, 'class')] = (attrs[(None, 'class')] + f' {new_class}').strip()
+    if (None, "class") not in attrs:
+        attrs[(None, "class")] = ""
+    attrs[(None, "class")] = (attrs[(None, "class")] + f" {new_class}").strip()
     return attrs
 
 
 def _add_rel(attrs: Attrs, new: bool = False) -> Attrs:
     """Check if href is internal or external and adds attrs as appropriate."""
-    o = urlparse(attrs[(None, 'href')])
-    if not o.netloc.split(':')[0].endswith('arxiv.org'):   # External link?
+    o = urlparse(attrs[(None, "href")])
+    if not o.netloc.split(":")[0].endswith("arxiv.org"):  # External link?
         return _add_rel_external(attrs, new)
     else:
         return _add_rel_internal(attrs, new)
@@ -160,29 +169,29 @@ def _add_rel_external(attrs: Attrs, new: bool = False) -> Attrs:
     # noopener for security reasons
     # nofollow to disincentivize arXiv articles for SEO
     # external says that link is away from arxiv
-    attrs[(None, 'rel')] = 'external noopener nofollow'
-    _extend_class_attr(attrs, 'link-external')
+    attrs[(None, "rel")] = "external noopener nofollow"
+    _extend_class_attr(attrs, "link-external")
     return attrs
 
 
 def _add_rel_internal(attrs: Attrs, new: bool = False) -> Attrs:
     """Add an internal rel."""
-    _extend_class_attr(attrs, 'link-internal')
+    _extend_class_attr(attrs, "link-internal")
     return attrs
 
 
 def _this_url_text(attrs: Attrs, new: bool = False) -> Attrs:
-    o = urlparse(attrs[(None, 'href')])
-    if o.hostname and not o.hostname.endswith('arxiv.org'):
-        attrs['_text'] = f'this {o.scheme} URL'    # Replaces the link text.
+    o = urlparse(attrs[(None, "href")])
+    if o.hostname and not o.hostname.endswith("arxiv.org"):
+        attrs["_text"] = f"this {o.scheme} URL"  # Replaces the link text.
     return attrs
 
 
 def _add_scheme_info(attrs: Attrs, new: bool = False) -> Attrs:
-    o = urlparse(attrs[(None, 'href')])
-    if (None, 'class') not in attrs:
-        attrs[(None, 'class')] = ''
-    _extend_class_attr(attrs, f'link-{o.scheme}')
+    o = urlparse(attrs[(None, "href")])
+    if (None, "class") not in attrs:
+        attrs[(None, "class")] = ""
+    _extend_class_attr(attrs, f"link-{o.scheme}")
     return attrs
 
 
@@ -194,20 +203,20 @@ def _handle_arxiv_url(attrs: Attrs, new: bool = False) -> Attrs:
     identifier as a the target. We need to intercept these links, and generate
     a real URL.
     """
-    href = attrs[(None, 'href')]
-    if '://' in href:   # http://1902.00123
-        target = href.split('://', 1)[1]
-        prefix = ''
-    elif ':' in href:   # arxiv:1902.00123
-        target = href.split(':', 1)[1]
-        prefix = 'arXiv:'
+    href = attrs[(None, "href")]
+    if "://" in href:  # http://1902.00123
+        target = href.split("://", 1)[1]
+        prefix = ""
+    elif ":" in href:  # arxiv:1902.00123
+        target = href.split(":", 1)[1]
+        prefix = "arXiv:"
     else:
         target = href
-        prefix = ''
+        prefix = ""
     if ARXIV_ID.match(target):
-        attrs[(None, 'href')] = arxiv_id_to_url(target)
-        attrs['_text'] = f'{prefix}{target}'
-        attrs[(None, 'data-arxiv-id')] = target     # Add arxiv="<arxiv id>"
+        attrs[(None, "href")] = arxiv_id_to_url(target)
+        attrs["_text"] = f"{prefix}{target}"
+        attrs[(None, "data-arxiv-id")] = target  # Add arxiv="<arxiv id>"
     return attrs
 
 
@@ -219,20 +228,21 @@ def _handle_doi_url(attrs: Attrs, new: bool = False) -> Attrs:
     doi as a the target. We need to intercept these links, and generate
     a real URL.
     """
-    href = attrs[(None, 'href')]
-    if '://' in href:
-        target = href.split('://', 1)[1]
-        prefix = ''
-    elif ':' in href:
-        target = href.split(':', 1)[1]
-        prefix = 'doi:'
+    href = attrs[(None, "href")]
+    if "://" in href:
+        target = href.split("://", 1)[1]
+        prefix = ""
+    elif ":" in href:
+        target = href.split(":", 1)[1]
+        prefix = "doi:"
     else:
         target = href
-        prefix = ''
+        prefix = ""
     if DOI.match(target):
-        attrs[(None, 'href')] = clickthrough_url_for_doi(target)
-        attrs['_text'] = f'{prefix}{target}'
-        attrs[(None, 'data-doi')] = target     # Add arxiv="<arxiv id>"
+        doi_url = url_for_doi(target)
+        attrs[(None, "href")] = doi_url
+        attrs["_text"] = doi_url
+        attrs[(None, "data-doi")] = target  # Add arxiv="<arxiv id>"
     return attrs
 
 
@@ -243,20 +253,27 @@ def _handle_broad_doi_url(attrs: Attrs, new: bool = False) -> Attrs:
     It is always just a DOI so turn it into a DOI link.
     """
     doi_attrs = _handle_doi_url(attrs, new)
-    if (None, 'data-doi') in doi_attrs:
+    if (None, "data-doi") in doi_attrs:
         return doi_attrs
     else:
-        target = attrs['_text']
-        attrs[(None, 'href')] = clickthrough_url_for_doi(target)
-        attrs[(None, 'data-doi')] = target
+        target = attrs["_text"]
+        doi_url = url_for_doi(target)
+        attrs[(None, "href")] = doi_url
+        attrs[(None, "data-doi")] = target
         return attrs
 
 
 ENDS_WITH_TLD = r".*\.(" + TLDS + ")$"
-CATEGORIES_THAT_COULD_BE_HOSTNAMES = '|'.join([cat_id for cat_id in CATEGORIES.keys()
-                                               if re.search(ENDS_WITH_TLD, cat_id, re.IGNORECASE)])
-DONT_URLIZE_CATS = re.compile(CATEGORIES_THAT_COULD_BE_HOSTNAMES,
-                              re.IGNORECASE | re.UNICODE)
+CATEGORIES_THAT_COULD_BE_HOSTNAMES = "|".join(
+    [
+        cat_id
+        for cat_id in CATEGORIES.keys()
+        if re.search(ENDS_WITH_TLD, cat_id, re.IGNORECASE)
+    ]
+)
+DONT_URLIZE_CATS = re.compile(
+    CATEGORIES_THAT_COULD_BE_HOSTNAMES, re.IGNORECASE | re.UNICODE
+)
 
 
 def _dont_urlize_arxiv_categories(attrs: Attrs, new: bool = False) -> Attrs:
@@ -265,41 +282,41 @@ def _dont_urlize_arxiv_categories(attrs: Attrs, new: bool = False) -> Attrs:
 
     Ex. don't urlize math.CO but do urlize supermath.co
     """
-    url = urlparse(attrs[(None, 'href')])
+    url = urlparse(attrs[(None, "href")])
     if DONT_URLIZE_CATS.match(url.netloc):
         return None  # type: ignore
     else:
         return attrs
 
 
-PATTERNS = {
-    'doi': DOI,
-    'doi_field': BROAD_DOI,
-    'url': URL,
-    'arxiv_id': ARXIV_ID
-}
-ORDER = ['arxiv_id', 'doi', 'url', 'doi_field']
-DEFAULT_KINDS = ['arxiv_id', 'doi', 'url']
+PATTERNS = {"doi": DOI, "doi_field": BROAD_DOI, "url": URL, "arxiv_id": ARXIV_ID}
+ORDER = ["arxiv_id", "doi", "url", "doi_field"]
+DEFAULT_KINDS = ["arxiv_id", "doi", "url"]
 """Default list of identifier types to match and convert to to URLs.
 
 This does not include 'doi_field because that is a specialized kind
 for just the abs DOI field."""
 
 callbacks = {
-    'doi':      [_handle_doi_url, _add_scheme_info, _add_rel_external],
-    'doi_field': [_handle_broad_doi_url, _add_scheme_info, _add_rel_external],
-    'arxiv_id': [_handle_arxiv_url, _add_scheme_info],
-    'url':      [_dont_urlize_arxiv_categories, _this_url_text, _add_rel, _add_scheme_info]
+    "doi": [_handle_doi_url, _add_scheme_info, _add_rel_external],
+    "doi_field": [_handle_broad_doi_url, _add_scheme_info, _add_rel_external],
+    "arxiv_id": [_handle_arxiv_url, _add_scheme_info],
+    "url": [_dont_urlize_arxiv_categories, _this_url_text, _add_rel, _add_scheme_info],
 }
 """Bleach attribute callbacks for each kind."""
 
 
 def _get_pattern(kinds: List[str]) -> Pattern:
     return re.compile(
-        '|'.join([rf'(?:{PATTERNS[kind].pattern})' for kind
-                  in sorted(kinds, key=lambda kind: ORDER.index(kind))]),
-        re.IGNORECASE | re.VERBOSE | re.UNICODE
+        "|".join(
+            [
+                rf"(?:{PATTERNS[kind].pattern})"
+                for kind in sorted(kinds, key=lambda kind: ORDER.index(kind))
+            ]
+        ),
+        re.IGNORECASE | re.VERBOSE | re.UNICODE,
     )
+
 
 def _get_linker_of_kind(kind: str) -> Callable_Linker:
     # The returned object will attempt to match url_re in the input string.
@@ -307,9 +324,8 @@ def _get_linker_of_kind(kind: str) -> Callable_Linker:
     # adjusting callbacks and then stick the tag in the output string
     # replacing the matched text.
     linker: Callable[[str], str] = bleach.linkifier.Linker(
-        callbacks=callbacks[kind],
-        skip_tags=['a'],
-        url_re=_get_pattern([kind])).linkify
+        callbacks=callbacks[kind], skip_tags=["a"], url_re=_get_pattern([kind])
+    ).linkify
     return linker
 
 
@@ -332,12 +348,12 @@ def _deferred_thread_local_linker_of_kind(kind: str) -> Callable_Linker:
         # This must not be called while the app is starting up, only
         # when the linkiers are being used in requests. So the
         # function is created/cached at call time.
-        if 'linkers' not in g:
+        if "linkers" not in g:
             g.linkers = {}
         if kind not in g.linkers:
             g.linkers[kind] = _get_linker_of_kind(kind)
 
-        return g.linkers[kind](instr) #type: ignore
+        return g.linkers[kind](instr)  # type: ignore
 
     return deferred
 
@@ -348,11 +364,12 @@ def _get_linker(kinds: List[str]) -> Callable_Linker:
     # or in the loading of packages.
     # The actual creating of thread local bleach objects is
     # done in _deferred_thread_local_linker_of_kind.
-    if len(kinds) > 1 and 'doi_field' in kinds:
-        raise ValueError(
-            'doi_field should not be used in combination with other kinds')
-    ordered_linkers = [_deferred_thread_local_linker_of_kind(kind) for kind
-                       in sorted(kinds, key=lambda kind: ORDER.index(kind))]
+    if len(kinds) > 1 and "doi_field" in kinds:
+        raise ValueError("doi_field should not be used in combination with other kinds")
+    ordered_linkers = [
+        _deferred_thread_local_linker_of_kind(kind)
+        for kind in sorted(kinds, key=lambda kind: ORDER.index(kind))
+    ]
     return _compose_list_of_funcs(ordered_linkers)
 
 

--- a/arxiv/base/urls/tests/test_urlize.py
+++ b/arxiv/base/urls/tests/test_urlize.py
@@ -7,33 +7,33 @@ from .. import links
 
 
 def mock_url_for(endpoint, **kwargs):
-    if endpoint == 'abs_by_id':
-        paper_id = kwargs['paper_id']
-        return f'https://arxiv.org/abs/{paper_id}'
+    if endpoint == "abs_by_id":
+        paper_id = kwargs["paper_id"]
+        return f"https://arxiv.org/abs/{paper_id}"
 
 
 class Id_Patterns_Test(unittest.TestCase):
     def setUp(self):
-        self.app = Flask('bogus')
-        
+        self.app = Flask("bogus")
+
     def test_arxiv_ids(self):
         def find_match(txt):
             with self.app.app_context():
                 ptn = links._get_pattern(links.DEFAULT_KINDS)
                 return ptn.search(txt)
 
-        self.assertIsNotNone(find_match('math/9901123'))
-        self.assertIsNotNone(find_match('hep-ex/9901123'))
-        self.assertIsNotNone(find_match('gr-qc/9901123'))
+        self.assertIsNotNone(find_match("math/9901123"))
+        self.assertIsNotNone(find_match("hep-ex/9901123"))
+        self.assertIsNotNone(find_match("gr-qc/9901123"))
 
-        self.assertIsNotNone(find_match('1202.1234'))
-        self.assertIsNotNone(find_match('1202.1234v1'))
-        self.assertIsNotNone(find_match('1203.12345'))
-        self.assertIsNotNone(find_match('1203.12345v1'))
-        self.assertIsNotNone(find_match('1203.12345v12'))
+        self.assertIsNotNone(find_match("1202.1234"))
+        self.assertIsNotNone(find_match("1202.1234v1"))
+        self.assertIsNotNone(find_match("1203.12345"))
+        self.assertIsNotNone(find_match("1203.12345v1"))
+        self.assertIsNotNone(find_match("1203.12345v12"))
 
         # slightly odd but seen in comments
-        self.assertIsNotNone(find_match('hep-ph/1203.12345v12'))
+        self.assertIsNotNone(find_match("hep-ph/1203.12345v12"))
 
     def test_find_match(self):
         def find_match(txt):
@@ -41,309 +41,390 @@ class Id_Patterns_Test(unittest.TestCase):
                 ptn = links._get_pattern(links.DEFAULT_KINDS)
                 return ptn.search(txt)
 
-        self.assertIsNone(find_match('junk'))
-        self.assertIsNone(find_match(''))
-        self.assertIsNone(find_match(' '))
+        self.assertIsNone(find_match("junk"))
+        self.assertIsNone(find_match(""))
+        self.assertIsNone(find_match(" "))
 
-        self.assertIsNotNone(find_match('doi:10.1002/0470841559.ch1'))
-        self.assertIsNotNone(find_match('doi:10.1038/nphys1170'))
+        self.assertIsNotNone(find_match("doi:10.1002/0470841559.ch1"))
+        self.assertIsNotNone(find_match("doi:10.1038/nphys1170"))
 
-        self.assertIsNotNone(find_match('http://arxiv.org'))
-        self.assertIsNotNone(find_match('http://arxiv.org?something=1'))
-        self.assertIsNotNone(
-            find_match('http://arxiv.org?something=1&anohter=2')
-        )
+        self.assertIsNotNone(find_match("http://arxiv.org"))
+        self.assertIsNotNone(find_match("http://arxiv.org?something=1"))
+        self.assertIsNotNone(find_match("http://arxiv.org?something=1&anohter=2"))
         self.assertIsNotNone(find_match('"http://arxiv.org"'))
 
 
 class TestURLize(unittest.TestCase):
     def setUp(self):
-        self.app = Flask('bogus')
-        
-    def test_dont_urlize_cats( self ):
-        self.assertGreater(len(links.CATEGORIES_THAT_COULD_BE_HOSTNAMES), 0,
-                           'The links.CATEGORIES_THAT_COULD_BE_HOSTNAMES must not be empty or it will match everything')
+        self.app = Flask("bogus")
 
-        
-    @mock.patch(f'{links.__name__}.clickthrough')
+    def test_dont_urlize_cats(self):
+        self.assertGreater(
+            len(links.CATEGORIES_THAT_COULD_BE_HOSTNAMES),
+            0,
+            "The links.CATEGORIES_THAT_COULD_BE_HOSTNAMES must not be empty or it will match everything",
+        )
+
+    @mock.patch(f"{links.__name__}.clickthrough")
     def test_doi(self, mock_clickthrough):
         with self.app.app_context():
-            mock_clickthrough.clickthrough_url = lambda url: f'http://arxiv.org/clickthrough?url={url}'
+            mock_clickthrough.clickthrough_url = (
+                lambda url: f"http://arxiv.org/clickthrough?url={url}"
+            )
             self.maxDiff = 3000
             self.assertEqual(
-                links.urlize('here is a rando doi doi:10.1109/5.771073 that needs a link'),
-                'here is a rando doi doi:<a class="link-http link-external" data-doi="10.1109/5.771073" href="http://arxiv.org/clickthrough?url=https://dx.doi.org/10.1109/5.771073" rel="external noopener nofollow">10.1109/5.771073</a> that needs a link'
+                links.urlize(
+                    "here is a rando doi doi:10.1109/5.771073 that needs a link"
+                ),
+                'here is a rando doi doi:<a class="link-https link-external" data-doi="10.1109/5.771073" href="https://doi.org/10.1109/5.771073" rel="external noopener nofollow">https://doi.org/10.1109/5.771073</a> that needs a link',
             )
 
     def test_transform_token(self):
         # def doi_id_url_transform_token(tkn,fn):
         #     return doi_id_url_transform_token(fn, tkn)
         with self.app.app_context():
-            self.assertEqual(links.urlize('', ['url']), '')
+            self.assertEqual(links.urlize("", ["url"]), "")
 
             self.assertEqual(
-                links.urlize('it is fine, chapter 234 see<xxyx,234>'),
-                escape('it is fine, chapter 234 see<xxyx,234>')
-            )
-
-            self.assertEqual(links.urlize('http://arxiv.org', ['url']),
-                             '<a class="link-internal link-http" href="http://arxiv.org">http://arxiv.org</a>')
-
-            self.assertEqual(links.urlize('https://arxiv.org', ['url']),
-                             '<a class="link-internal link-https" href="https://arxiv.org">https://arxiv.org</a>')
-                        
-            self.assertEqual(
-                links.urlize('in the front http://arxiv.org oth', ['url']),
-                'in the front <a class="link-internal link-http" href="http://arxiv.org">http://arxiv.org</a> oth'
+                links.urlize("it is fine, chapter 234 see<xxyx,234>"),
+                escape("it is fine, chapter 234 see<xxyx,234>"),
             )
 
             self.assertEqual(
-                links.urlize('.http://arxiv.org.', ['url']),
-                '.<a class="link-internal link-http" href="http://arxiv.org">http://arxiv.org</a>.'
+                links.urlize("http://arxiv.org", ["url"]),
+                '<a class="link-internal link-http" href="http://arxiv.org">http://arxiv.org</a>',
             )
 
             self.assertEqual(
-                links.urlize('"http://arxiv.org"', ['url']),
-                '"<a class="link-internal link-http" href="http://arxiv.org">http://arxiv.org</a>"'
+                links.urlize("https://arxiv.org", ["url"]),
+                '<a class="link-internal link-https" href="https://arxiv.org">https://arxiv.org</a>',
             )
 
             self.assertEqual(
-                links.urlize('"https://arxiv.org/help"', ['url']),
-                '"<a class="link-internal link-https" href="https://arxiv.org/help">https://arxiv.org/help</a>"'
+                links.urlize("in the front http://arxiv.org oth", ["url"]),
+                'in the front <a class="link-internal link-http" href="http://arxiv.org">http://arxiv.org</a> oth',
             )
 
-    @mock.patch(f'{links.__name__}.clickthrough')
-    @mock.patch(f'{links.__name__}.url_for', mock_url_for)
+            self.assertEqual(
+                links.urlize(".http://arxiv.org.", ["url"]),
+                '.<a class="link-internal link-http" href="http://arxiv.org">http://arxiv.org</a>.',
+            )
+
+            self.assertEqual(
+                links.urlize('"http://arxiv.org"', ["url"]),
+                '"<a class="link-internal link-http" href="http://arxiv.org">http://arxiv.org</a>"',
+            )
+
+            self.assertEqual(
+                links.urlize('"https://arxiv.org/help"', ["url"]),
+                '"<a class="link-internal link-https" href="https://arxiv.org/help">https://arxiv.org/help</a>"',
+            )
+
+    @mock.patch(f"{links.__name__}.clickthrough")
+    @mock.patch(f"{links.__name__}.url_for", mock_url_for)
     def test_urlize(self, mock_clickthrough):
         with self.app.app_context():
-            mock_clickthrough.clickthrough_url.return_value = 'foo'
+            mock_clickthrough.clickthrough_url.return_value = "foo"
             self.assertEqual(
-                links.urlize('http://example.com/'),
+                links.urlize("http://example.com/"),
                 '<a class="link-external link-http" href="http://example.com/" rel="external noopener nofollow">this http URL</a>',
-                'urlize (URL linking) 1/6'
+                "urlize (URL linking) 1/6",
             )
             self.assertEqual(
-                links.urlize('https://example.com/'),
+                links.urlize("https://example.com/"),
                 '<a class="link-external link-https" href="https://example.com/" rel="external noopener nofollow">this https URL</a>',
-                'urlize (URL linking) 2/6'
+                "urlize (URL linking) 2/6",
             )
             self.assertEqual(
-                links.urlize('ftp://example.com/'),
+                links.urlize("ftp://example.com/"),
                 '<a class="link-external link-ftp" href="ftp://example.com/" rel="external noopener nofollow">this ftp URL</a>',
-                'urlize (URL linking) 3/6'
+                "urlize (URL linking) 3/6",
             )
 
             self.assertEqual(
-                links.urlize('http://projecteuclid.org/euclid.bj/1151525136'),
+                links.urlize("http://projecteuclid.org/euclid.bj/1151525136"),
                 '<a class="link-external link-http" href="http://projecteuclid.org/euclid.bj/1151525136" rel="external noopener nofollow">this http URL</a>',
-                'urlize (URL linking) 6/6'
+                "urlize (URL linking) 6/6",
             )
 
-            self.assertEqual(links.urlize('2448446.4710(5)'), '2448446.4710(5)',
-                             'urlize (should not match) 1/9')
-            self.assertEqual(links.urlize('HJD=2450274.4156+/-0.0009'),
-                             'HJD=2450274.4156+/-0.0009',
-                             'urlize (should not match) 2/9')
             self.assertEqual(
-                links.urlize('T_min[HJD]=49238.83662(14)+0.146352739(11)E.'),
-                'T_min[HJD]=49238.83662(14)+0.146352739(11)E.',
-                'urlize (should not match) 3/9'
+                links.urlize("2448446.4710(5)"),
+                "2448446.4710(5)",
+                "urlize (should not match) 1/9",
             )
-            self.assertEqual(links.urlize('Pspin=1008.3408s'),
-                             'Pspin=1008.3408s',
-                             'urlize (should not match) 4/9')
             self.assertEqual(
-                links.urlize('2453527.87455^{+0.00085}_{-0.00091}'),
-                '2453527.87455^{+0.00085}_{-0.00091}',
-                'urlize (should not match) 5/9'
+                links.urlize("HJD=2450274.4156+/-0.0009"),
+                "HJD=2450274.4156+/-0.0009",
+                "urlize (should not match) 2/9",
             )
-            self.assertEqual(links.urlize('2451435.4353'), '2451435.4353',
-                             'urlize (should not match) 6/9')
+            self.assertEqual(
+                links.urlize("T_min[HJD]=49238.83662(14)+0.146352739(11)E."),
+                "T_min[HJD]=49238.83662(14)+0.146352739(11)E.",
+                "urlize (should not match) 3/9",
+            )
+            self.assertEqual(
+                links.urlize("Pspin=1008.3408s"),
+                "Pspin=1008.3408s",
+                "urlize (should not match) 4/9",
+            )
+            self.assertEqual(
+                links.urlize("2453527.87455^{+0.00085}_{-0.00091}"),
+                "2453527.87455^{+0.00085}_{-0.00091}",
+                "urlize (should not match) 5/9",
+            )
+            self.assertEqual(
+                links.urlize("2451435.4353"),
+                "2451435.4353",
+                "urlize (should not match) 6/9",
+            )
 
             self.assertEqual(
-                links.urlize('cond-mat/97063007'),
+                links.urlize("cond-mat/97063007"),
                 '<a class="link-https" data-arxiv-id="cond-mat/9706300" href="https://arxiv.org/abs/cond-mat/9706300">cond-mat/9706300</a>7',
-                'urlize (should match) 7/9')
-
-            self.assertEqual(
-                links.urlize('[http://onion.com/something-funny-about-arxiv-1234]'),
-                '[<a class="link-external link-http" href="http://onion.com/something-funny-about-arxiv-1234" rel="external noopener nofollow">this http URL</a>]')
-
-            self.assertEqual(
-                links.urlize(
-                    '[http://onion.com/?q=something-funny-about-arxiv.1234]'
-                ),
-                '[<a class="link-external link-http" href="http://onion.com/?q=something-funny-about-arxiv.1234" rel="external noopener nofollow">this http URL</a>]'
+                "urlize (should match) 7/9",
             )
 
             self.assertEqual(
-                links.urlize('http://onion.com/?q=something funny'),
+                links.urlize("[http://onion.com/something-funny-about-arxiv-1234]"),
+                '[<a class="link-external link-http" href="http://onion.com/something-funny-about-arxiv-1234" rel="external noopener nofollow">this http URL</a>]',
+            )
+
+            self.assertEqual(
+                links.urlize("[http://onion.com/?q=something-funny-about-arxiv.1234]"),
+                '[<a class="link-external link-http" href="http://onion.com/?q=something-funny-about-arxiv.1234" rel="external noopener nofollow">this http URL</a>]',
+            )
+
+            self.assertEqual(
+                links.urlize("http://onion.com/?q=something funny"),
                 '<a class="link-external link-http" href="http://onion.com/?q=something" rel="external noopener nofollow">this http URL</a> funny',
-                'Spaces CANNOT be expected to be part of URLs'
+                "Spaces CANNOT be expected to be part of URLs",
+            )
+
+            self.assertEqual(
+                links.urlize('"http://onion.com/something-funny-about-arxiv-1234"'),
+                '"<a class="link-external link-http" href="http://onion.com/something-funny-about-arxiv-1234" rel="external noopener nofollow">this http URL</a>"',
+                "Should handle URL surrounded by double quotes",
+            )
+
+            self.assertEqual(
+                links.urlize("< http://example.com/1<2 ><"),
+                '&lt; <a class="link-external link-http" href="http://example.com/1" rel="external noopener nofollow">this http URL</a>&lt;2 &gt;&lt;',
+                "urlize (URL linking) 5/6",
             )
 
             self.assertEqual(
                 links.urlize(
-                    '"http://onion.com/something-funny-about-arxiv-1234"'
+                    'Accepted for publication in A&A. The data will be available via CDS, and can be found "http://atlasgal.mpifr-bonn.mpg.de/cgi-bin/ATLASGAL_FILAMENTS.cgi"'
                 ),
-                '"<a class="link-external link-http" href="http://onion.com/something-funny-about-arxiv-1234" rel="external noopener nofollow">this http URL</a>"',
-                'Should handle URL surrounded by double quotes'
-            )
-
-            self.assertEqual(links.urlize('< http://example.com/1<2 ><'),
-                             '&lt; <a class="link-external link-http" href="http://example.com/1" rel="external noopener nofollow">this http URL</a>&lt;2 &gt;&lt;',
-                             'urlize (URL linking) 5/6')
-
-            self.assertEqual(
-                links.urlize('Accepted for publication in A&A. The data will be available via CDS, and can be found "http://atlasgal.mpifr-bonn.mpg.de/cgi-bin/ATLASGAL_FILAMENTS.cgi"'),
-                'Accepted for publication in A&amp;A. The data will be available via CDS, and can be found "<a class="link-external link-http" href="http://atlasgal.mpifr-bonn.mpg.de/cgi-bin/ATLASGAL_FILAMENTS.cgi" rel="external noopener nofollow">this http URL</a>"'
+                'Accepted for publication in A&amp;A. The data will be available via CDS, and can be found "<a class="link-external link-http" href="http://atlasgal.mpifr-bonn.mpg.de/cgi-bin/ATLASGAL_FILAMENTS.cgi" rel="external noopener nofollow">this http URL</a>"',
             )
 
             self.assertEqual(
-                links.urlize('see http://www.tandfonline.com/doi/abs/doi:10.1080/15980316.2013.860928?journalCode=tjid20'),
-                'see <a class="link-external link-http" href="http://www.tandfonline.com/doi/abs/doi:10.1080/15980316.2013.860928?journalCode=tjid20" rel="external noopener nofollow">this http URL</a>'
+                links.urlize(
+                    "see http://www.tandfonline.com/doi/abs/doi:10.1080/15980316.2013.860928?journalCode=tjid20"
+                ),
+                'see <a class="link-external link-http" href="http://www.tandfonline.com/doi/abs/doi:10.1080/15980316.2013.860928?journalCode=tjid20" rel="external noopener nofollow">this http URL</a>',
             )
 
             self.assertEqual(
-                links.urlize('http://authors.elsevier.com/a/1TcSd,Ig45ZtO'),
-                '<a class="link-external link-http" href="http://authors.elsevier.com/a/1TcSd,Ig45ZtO" rel="external noopener nofollow">this http URL</a>'
+                links.urlize("http://authors.elsevier.com/a/1TcSd,Ig45ZtO"),
+                '<a class="link-external link-http" href="http://authors.elsevier.com/a/1TcSd,Ig45ZtO" rel="external noopener nofollow">this http URL</a>',
             )
 
-        @mock.patch(f'{links.__name__}.url_for', mock_url_for)
+        @mock.patch(f"{links.__name__}.url_for", mock_url_for)
         def test_category_id(self):
             self.assertEqual(
-                links.urlize('version of arXiv.math.GR/0512484 (2011).', ['arxiv_id']),
-                'version of arXiv.<a class="link-https" data-arxiv-id="math.GR/0512484" href="https://arxiv.org/abs/math.GR/0512484">math.GR/0512484</a> (2011).'
+                links.urlize("version of arXiv.math.GR/0512484 (2011).", ["arxiv_id"]),
+                'version of arXiv.<a class="link-https" data-arxiv-id="math.GR/0512484" href="https://arxiv.org/abs/math.GR/0512484">math.GR/0512484</a> (2011).',
             )
 
-    @mock.patch(f'{links.__name__}.url_for', mock_url_for)
+    @mock.patch(f"{links.__name__}.url_for", mock_url_for)
     def test_parens(self):
         """ARXIVNG-250 Linkification should not choke on parentheses."""
         with self.app.app_context():
             self.assertEqual(
-                links.urlize('http://www-nuclear.univer.kharkov.ua/lib/1017_3(55)_12_p28-59.pdf'),
-                '<a class="link-external link-http" href="http://www-nuclear.univer.kharkov.ua/lib/1017_3(55)_12_p28-59.pdf" rel="external noopener nofollow">this http URL</a>'
+                links.urlize(
+                    "http://www-nuclear.univer.kharkov.ua/lib/1017_3(55)_12_p28-59.pdf"
+                ),
+                '<a class="link-external link-http" href="http://www-nuclear.univer.kharkov.ua/lib/1017_3(55)_12_p28-59.pdf" rel="external noopener nofollow">this http URL</a>',
             )
 
-    @mock.patch(f'{links.__name__}.url_for', mock_url_for)
+    @mock.patch(f"{links.__name__}.url_for", mock_url_for)
     def test_hosts(self):
         with self.app.app_context():
             self.assertEqual(
-                links.urlize('can be downloaded from http://rwcc.bao.ac.cn:8001/swap/NLFFF_DBIE_code/HeHan_NLFFF_JGR.pdf'),
+                links.urlize(
+                    "can be downloaded from http://rwcc.bao.ac.cn:8001/swap/NLFFF_DBIE_code/HeHan_NLFFF_JGR.pdf"
+                ),
                 'can be downloaded from <a class="link-external link-http" href="http://rwcc.bao.ac.cn:8001/swap/NLFFF_DBIE_code/HeHan_NLFFF_JGR.pdf" rel="external noopener nofollow">this http URL</a>',
-                "Should deal with ports correctly"
+                "Should deal with ports correctly",
             )
             self.assertEqual(
-                links.urlize('images is at http://85.20.11.14/hosting/punsly/APJLetter4.2.07/'),
+                links.urlize(
+                    "images is at http://85.20.11.14/hosting/punsly/APJLetter4.2.07/"
+                ),
                 'images is at <a class="link-external link-http" href="http://85.20.11.14/hosting/punsly/APJLetter4.2.07/" rel="external noopener nofollow">this http URL</a>',
-                "should deal with numeric IP correctly"
+                "should deal with numeric IP correctly",
             )
 
-    @mock.patch(f'{links.__name__}.url_for', mock_url_for)
+    @mock.patch(f"{links.__name__}.url_for", mock_url_for)
     def test_urls_with_plus(self):
         with self.app.app_context():
             self.assertEqual(
-                links.urlize('http://www.fkf.mpg.de/andersen/docs/pub/abstract2004+/pavarini_02.pdf'),
-                '<a class="link-external link-http" href="http://www.fkf.mpg.de/andersen/docs/pub/abstract2004+/pavarini_02.pdf" rel="external noopener nofollow">this http URL</a>'
+                links.urlize(
+                    "http://www.fkf.mpg.de/andersen/docs/pub/abstract2004+/pavarini_02.pdf"
+                ),
+                '<a class="link-external link-http" href="http://www.fkf.mpg.de/andersen/docs/pub/abstract2004+/pavarini_02.pdf" rel="external noopener nofollow">this http URL</a>',
             )
 
-    @mock.patch(f'{links.__name__}.url_for', mock_url_for)
+    @mock.patch(f"{links.__name__}.url_for", mock_url_for)
     def test_anchors_with_slash(self):
         with self.app.app_context():
             self.assertIn(
                 'href="https://dms.sztaki.hu/ecml-pkkd-2016/#/app/privateleaderboard"',
-                links.urlize('https://dms.sztaki.hu/ecml-pkkd-2016/#/app/privateleaderboard'),
-                "Should deal with slash in URL anchor correctly"
+                links.urlize(
+                    "https://dms.sztaki.hu/ecml-pkkd-2016/#/app/privateleaderboard"
+                ),
+                "Should deal with slash in URL anchor correctly",
             )
 
-    @mock.patch(f'{links.__name__}.url_for', mock_url_for)
+    @mock.patch(f"{links.__name__}.url_for", mock_url_for)
     def test_ftp(self):
         with self.app.app_context():
             self.assertEqual(
-                links.urlize('7 Pages; ftp://ftp%40micrognu%2Ecom:anon%40anon@ftp.micrognu.com/pnenp/conclusion.pdf'),
-                '7 Pages; <a class="link-external link-ftp" href="ftp://ftp%40micrognu%2Ecom:anon%40anon@ftp.micrognu.com/pnenp/conclusion.pdf" rel="external noopener nofollow">this ftp URL</a>'
-           )
+                links.urlize(
+                    "7 Pages; ftp://ftp%40micrognu%2Ecom:anon%40anon@ftp.micrognu.com/pnenp/conclusion.pdf"
+                ),
+                '7 Pages; <a class="link-external link-ftp" href="ftp://ftp%40micrognu%2Ecom:anon%40anon@ftp.micrognu.com/pnenp/conclusion.pdf" rel="external noopener nofollow">this ftp URL</a>',
+            )
 
-    @mock.patch(f'{links.__name__}.url_for', mock_url_for)
+    @mock.patch(f"{links.__name__}.url_for", mock_url_for)
     def test_arxiv_prefix(self):
         with self.app.app_context():
             self.assertEqual(
                 links.urlize("see arxiv:1201.12345"),
-                'see <a class="link-https" data-arxiv-id="1201.12345" href="https://arxiv.org/abs/1201.12345">arXiv:1201.12345</a>')
+                'see <a class="link-https" data-arxiv-id="1201.12345" href="https://arxiv.org/abs/1201.12345">arXiv:1201.12345</a>',
+            )
 
-
-    @mock.patch(f'{links.__name__}.clickthrough')
+    @mock.patch(f"{links.__name__}.clickthrough")
     def test_doi_2(self, mock_clickthrough):
         with self.app.app_context():
             mock_clickthrough.clickthrough_url = lambda x: x
-            self.assertRegex(links.urlize('10.1088/1475-7516/2018/07/009'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
+            self.assertRegex(
+                links.urlize("10.1088/1475-7516/2018/07/009"),
+                r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>https://doi.org/10.1088/1475-7516/2018/07/009</a>',
+            )
 
-            self.assertRegex(links.urlize('10.1088/1475-7516/2019/02/E02/meta'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
-            self.assertRegex(links.urlize('10.1088/1475-7516/2019/02/E02/META'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
-            self.assertRegex(links.urlize('doi:10.1088/1475-7516/2018/07/009'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
+            self.assertRegex(
+                links.urlize("10.1088/1475-7516/2019/02/E02/meta"),
+                r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>https://doi.org/10.1088/1475-7516/2019/02/E02/meta</a>',
+            )
+            self.assertRegex(
+                links.urlize("10.1088/1475-7516/2019/02/E02/META"),
+                r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>https://doi.org/10.1088/1475-7516/2019/02/E02/META</a>',
+            )
+            self.assertRegex(
+                links.urlize("doi:10.1088/1475-7516/2018/07/009"),
+                r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>https://doi.org/10.1088/1475-7516/2018/07/009</a>',
+            )
 
-            self.assertRegex(links.urlize('doi:10.1088/1475-7516/2019/02/E02/meta'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
-            self.assertRegex(links.urlize('doi:10.1088/1475-7516/2019/02/E02/META'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
+            self.assertRegex(
+                links.urlize("doi:10.1088/1475-7516/2019/02/E02/meta"),
+                r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>https://doi.org/10.1088/1475-7516/2019/02/E02/meta</a>',
+            )
+            self.assertRegex(
+                links.urlize("doi:10.1088/1475-7516/2019/02/E02/META"),
+                r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>https://doi.org/10.1088/1475-7516/2019/02/E02/META</a>',
+            )
 
-
-    @mock.patch(f'{links.__name__}.clickthrough')
+    @mock.patch(f"{links.__name__}.clickthrough")
     def test_double_doi(self, mock_clickthrough):
         with self.app.app_context():
             mock_clickthrough.clickthrough_url = lambda x: x
-            txt = links.urlize('10.1088/1475-7516/2018/07/009 10.1088/1475-7516/2019/02/E02/meta' )
-            self.assertNotRegex(txt, r'this.*URL',
-                                'DOIs should not get the generic "this https URL" they should have the DOI text')
-            self.assertRegex(txt, r'<a.*>10.1088/1475-7516/2018/07/009</a> <a.*>10.1088/1475-7516/2019/02/E02/meta</a>',
-                             'Should handle two DOIs in a row correctly')
+            txt = links.urlize(
+                "10.1088/1475-7516/2018/07/009 10.1088/1475-7516/2019/02/E02/meta"
+            )
+            self.assertNotRegex(
+                txt,
+                r"this.*URL",
+                'DOIs should not get the generic "this https URL" they should have the DOI text',
+            )
+            self.assertRegex(
+                txt,
+                r"<a.*>https://doi.org/10.1088/1475-7516/2018/07/009</a> <a.*>https://doi.org/10.1088/1475-7516/2019/02/E02/meta</a>",
+                "Should handle two DOIs in a row correctly",
+            )
 
-
-    @mock.patch(f'{links.__name__}.clickthrough')
+    @mock.patch(f"{links.__name__}.clickthrough")
     def test_broad_doi(self, mock_clickthrough):
         with self.app.app_context():
             mock_clickthrough.clickthrough_url = lambda x: x
 
-            broad_doi_fn = links.urlizer(['doi_field'])
+            broad_doi_fn = links.urlizer(["doi_field"])
 
             # ARXIVNG-3523 unusual DOI
-            self.assertRegex(broad_doi_fn('21.11130/00-1735-0000-0005-146A-E'),
-                             r'<a.*href="https://.*21.11130.*>21.11130/00-1735-0000-0005-146A-E</a>')
-            
-            self.assertRegex(broad_doi_fn('10.1088/1475-7516/2018/07/009'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
+            self.assertRegex(
+                broad_doi_fn("21.11130/00-1735-0000-0005-146A-E"),
+                r'<a.*href="https://.*21.11130.*>21.11130/00-1735-0000-0005-146A-E</a>',
+            )
 
-            self.assertRegex(broad_doi_fn('10.1088/1475-7516/2019/02/E02/meta'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
-            self.assertRegex(broad_doi_fn('10.1088/1475-7516/2019/02/E02/META'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
-            self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2018/07/009'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>10.1088/1475-7516/2018/07/009</a>')
+            self.assertRegex(
+                broad_doi_fn("10.1088/1475-7516/2018/07/009"),
+                r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>https://doi.org/10.1088/1475-7516/2018/07/009</a>',
+            )
 
-            self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2019/02/E02/meta'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>10.1088/1475-7516/2019/02/E02/meta</a>')
-            self.assertRegex(broad_doi_fn('doi:10.1088/1475-7516/2019/02/E02/META'),
-                             r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>10.1088/1475-7516/2019/02/E02/META</a>')
+            self.assertRegex(
+                broad_doi_fn("10.1088/1475-7516/2019/02/E02/meta"),
+                r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>https://doi.org/10.1088/1475-7516/2019/02/E02/meta</a>',
+            )
+            self.assertRegex(
+                broad_doi_fn("10.1088/1475-7516/2019/02/E02/META"),
+                r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>https://doi.org/10.1088/1475-7516/2019/02/E02/META</a>',
+            )
+            self.assertRegex(
+                broad_doi_fn("doi:10.1088/1475-7516/2018/07/009"),
+                r'<a.*href="https://.*10.1088/1475-7516/2018/07/009".*>https://doi.org/10.1088/1475-7516/2018/07/009</a>',
+            )
 
-            txt = broad_doi_fn('10.1088/1475-7516/2018/07/009 10.1088/1475-7516/2019/02/E02/meta' )
-            self.assertNotRegex(txt, r'this.*URL',
-                                'DOIs should not get the generic "this https URL" they should have the DOI text')
-            self.assertRegex(txt, r'<a.*>10.1088/1475-7516/2018/07/009</a> <a.*>10.1088/1475-7516/2019/02/E02/meta</a>',
-                             'Should handle two DOIs in a row correctly')
+            self.assertRegex(
+                broad_doi_fn("doi:10.1088/1475-7516/2019/02/E02/meta"),
+                r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/meta".*>https://doi.org/10.1088/1475-7516/2019/02/E02/meta</a>',
+            )
+            self.assertRegex(
+                broad_doi_fn("doi:10.1088/1475-7516/2019/02/E02/META"),
+                r'<a.*href="https://.*10.1088/1475-7516/2019/02/E02/META".*>https://doi.org/10.1088/1475-7516/2019/02/E02/META</a>',
+            )
 
-            urlized_doi = broad_doi_fn('10.1175/1520-0469(1996)053<0946:ASTFHH>2.0.CO;2')
+            txt = broad_doi_fn(
+                "10.1088/1475-7516/2018/07/009 10.1088/1475-7516/2019/02/E02/meta"
+            )
+            self.assertNotRegex(
+                txt,
+                r"this.*URL",
+                'DOIs should not get the generic "this https URL" they should have the DOI text',
+            )
+            self.assertRegex(
+                txt,
+                r"<a.*>https://doi.org/10.1088/1475-7516/2018/07/009</a> <a.*>https://doi.org/10.1088/1475-7516/2019/02/E02/meta</a>",
+                "Should handle two DOIs in a row correctly",
+            )
 
-            self.assertNotIn('href="http://2.0.CO"',
-                             urlized_doi,
-                             "Should not have odd second <A> tag for DOI urlize for ao-sci/9503001 see ARXIVNG-2049")
+            urlized_doi = broad_doi_fn(
+                "10.1175/1520-0469(1996)053<0946:ASTFHH>2.0.CO;2"
+            )
 
-            leg_rx = r'<a .* href="https://dx.doi.org/10.1175/1520-0469%281996%29053%3C0946%3AASTFHH%3E2.0.CO%3B2".*'
-            self.assertRegex(urlized_doi, leg_rx,
-                             "Should handle Complex DOI for ao-sci/9503001 see ARXIVNG-2049")
+            self.assertNotIn(
+                'href="http://2.0.CO"',
+                urlized_doi,
+                "Should not have odd second <A> tag for DOI urlize for ao-sci/9503001 see ARXIVNG-2049",
+            )
+
+            leg_rx = r'<a .* href="https://doi.org/10.1175/1520-0469%281996%29053%3C0946%3AASTFHH%3E2.0.CO%3B2".*'
+            self.assertRegex(
+                urlized_doi,
+                leg_rx,
+                "Should handle Complex DOI for ao-sci/9503001 see ARXIVNG-2049",
+            )
 
             # in legacy:
             # <a href="/ct?url=https%3A%2F%2Fdx.doi.org%2F10.1175%252F1520-0469%25281996%2529053%253C0946%253AASTFHH%253E2.0.CO%253B2&amp;v=34a1af05">10.1175/1520-0469(1996)053&lt;0946:ASTFHH&gt;2.0.CO;2</a>
@@ -351,27 +432,44 @@ class TestURLize(unittest.TestCase):
             # Post clickthrough on legacy goes to :
             # https://dx.doi.org/10.1175%2F1520-0469%281996%29053%3C0946%3AASTFHH%3E2.0.CO%3B2
 
-
     def test_dont_urlize_category_name(self):
         with self.app.app_context():
             urlize = links.urlizer()
-            self.assertEqual(urlize('math.CO'), 'math.CO',
-                             'category name math.CO should not get urlized')
-            self.assertIn('href="http://supermath.co', urlize('supermath.co'),
-                          'hostname close to category name should get urlized')
+            self.assertEqual(
+                urlize("math.CO"),
+                "math.CO",
+                "category name math.CO should not get urlized",
+            )
+            self.assertIn(
+                'href="http://supermath.co',
+                urlize("supermath.co"),
+                "hostname close to category name should get urlized",
+            )
 
     def test_dont_urlize_arxiv_dot_org(self):
         with self.app.app_context():
             urlize = links.urlizer()
 
-            self.assertNotRegex(urlize('something https://arxiv.org bla'), r'this.*URL',
-                             'arxiv.org should not get "this https URL" ARXIVNG-2130')
+            self.assertNotRegex(
+                urlize("something https://arxiv.org bla"),
+                r"this.*URL",
+                'arxiv.org should not get "this https URL" ARXIVNG-2130',
+            )
 
-            self.assertNotRegex(urlize('something arxiv.org bla'), r'this.*URL',
-                                'arxiv.org should not get "this https URL" ARXIVNG-2130')
+            self.assertNotRegex(
+                urlize("something arxiv.org bla"),
+                r"this.*URL",
+                'arxiv.org should not get "this https URL" ARXIVNG-2130',
+            )
 
-            self.assertRegex(urlize('something arXiv.org'), r'arXiv\.org',
-                             'arXiv.org should be preserved as text [ARXIVNG-2130]')
+            self.assertRegex(
+                urlize("something arXiv.org"),
+                r"arXiv\.org",
+                "arXiv.org should be preserved as text [ARXIVNG-2130]",
+            )
 
-            self.assertRegex(urlize('something arxiv.org'), r'arxiv\.org',
-                             'arXiv.org should be preserved as text [ARXIVNG-2130]')
+            self.assertRegex(
+                urlize("something arxiv.org"),
+                r"arxiv\.org",
+                "arXiv.org should be preserved as text [ARXIVNG-2130]",
+            )

--- a/arxiv/taxonomy/definitions.py
+++ b/arxiv/taxonomy/definitions.py
@@ -1018,7 +1018,7 @@ CATEGORIES = {
         'description': 'General methodological, applied, and empirical contributions to '
                        'economics.',
         'is_active': True,
-        'is_general': False
+        'is_general': True
     },
     'econ.TH': {
         'name': 'Theoretical Economics',
@@ -1595,7 +1595,7 @@ CATEGORIES = {
                        'Accelerator design and optimization. Advanced '
                        'accelerator concepts. Radiation sources including '
                        'synchrotron light sources and free electron lasers. '
-                       'Applications of accelerators.',       
+                       'Applications of accelerators.',
         'is_active': True,
         'is_general': False
     },

--- a/arxiv/taxonomy/definitions.py
+++ b/arxiv/taxonomy/definitions.py
@@ -1517,7 +1517,7 @@ CATEGORIES = {
     'nlin.AO': {
         'name': 'Adaptation and Self-Organizing Systems',
         'in_archive': 'nlin',
-        'description': 'adaptation, self-organizing systems, statistical '
+        'description': 'Adaptation, self-organizing systems, statistical '
                        'physics, fluctuating systems, stochastic processes, '
                        'interacting particle systems, machine learning',
         'is_active': True,
@@ -1526,7 +1526,7 @@ CATEGORIES = {
     'nlin.CD': {
         'name': 'Chaotic Dynamics',
         'in_archive': 'nlin',
-        'description': 'dynamical systems, chaos, quantum chaos, topological '
+        'description': 'Dynamical systems, chaos, quantum chaos, topological '
                        'dynamics, cycle expansions, turbulence, '
                        'propagation',
         'is_active': True,
@@ -1535,7 +1535,7 @@ CATEGORIES = {
     'nlin.CG': {
         'name': 'Cellular Automata and Lattice Gases',
         'in_archive': 'nlin',
-        'description': 'computational methods, time series analysis, signal '
+        'description': 'Computational methods, time series analysis, signal '
                        'processing, wavelets, lattice gases',
         'is_active': True,
         'is_general': False
@@ -1543,14 +1543,14 @@ CATEGORIES = {
     'nlin.PS': {
         'name': 'Pattern Formation and Solitons',
         'in_archive': 'nlin',
-        'description': 'pattern formation, coherent structures, solitons',
+        'description': 'Pattern formation, coherent structures, solitons',
         'is_active': True,
         'is_general': False
     },
     'nlin.SI': {
         'name': 'Exactly Solvable and Integrable Systems',
         'in_archive': 'nlin',
-        'description': 'exactly solvable systems, integrable PDEs, integrable '
+        'description': 'Exactly solvable systems, integrable PDEs, integrable '
                        'ODEs, Painleve analysis, integrable discrete maps, '
                        'solvable lattice models, integrable quantum '
                        'systems',
@@ -1560,12 +1560,24 @@ CATEGORIES = {
     'nucl-ex': {
         'name': 'Nuclear Experiment',
         'in_archive': 'nucl-ex',
+        'description': 'Nuclear Experiment Results from experimental nuclear physics '
+                       'including the areas of fundamental interactions, measurements '
+                       'at low- and medium-energy, as well as relativistic heavy-ion '
+                       'collisions.  Does not include: detectors and instrumentation nor '
+                       'analysis methods to conduct experiments; descriptions of '
+                       'experimental programs (present or future); comments on published results',
         'is_active': True,
         'is_general': False
     },
     'nucl-th': {
         'name': 'Nuclear Theory',
         'in_archive': 'nucl-th',
+        'description': 'Nuclear Theory Theory of nuclear structure covering wide area '
+                       'from models of hadron structure to neutron stars. Nuclear '
+                       'equation of states at different external conditions. Theory of '
+                       'nuclear reactions including heavy-ion reactions at low and high '
+                       'energies. It does not include problems of data analysis, physics '
+                       'of nuclear reactors, problems of safety, reactor construction',
         'is_active': True,
         'is_general': False
     },

--- a/arxiv/util/authors.py
+++ b/arxiv/util/authors.py
@@ -243,7 +243,7 @@ def _add_affiliation(author_line: str,
 
     # Now see if we have enumerated references (just commas, digits, &, and)
     affils = m.group(1).rstrip().lstrip()
-    affils = re.sub(r'(&|and)/,', ',', affils, flags=re.IGNORECASE)
+    affils = re.sub(r'\s+(&|and)\s+', ',', affils, flags=re.IGNORECASE)
 
     if re.match(r'^[\d,\s]+$', affils):
         for affil in affils.split(','):

--- a/arxiv/util/tests/test_authors.py
+++ b/arxiv/util/tests/test_authors.py
@@ -268,6 +268,42 @@ class TestAuthorAffiliationParsing(TestCase):
             'jr issue (Anatoly Zlotnik and Jr-Shin Li)'
         )
 
+        self.assertListEqual(
+            # 2106.08865; back propagation with comma (1,2), (4,5)
+            parse_author_affil(
+                "E. Trigueros P\'aez (1 and 2) and R. H. Barb\'a (3) and I. Negueruela (1) "
+                "and J. Ma\'iz Apell\'aniz (2) and S. Sim\'on-D\'iaz (4 and 5) and G.Holgado (2) "
+                "((1) Departamento de F\'isica Aplicada - Universidad de Alicante, (2) "
+                "Centro de Astrobiolog\'ia - CSIC-INTA, (3) Departamento de Astronom\'ia - Universidad "
+                "de La Serena, (4) Instituto de Astrof\'isica de Canarias, (5) Departamento "
+                "de Astrof\'isica - Universidad de La Laguna)"),            [["P'aez", 'E. Trigueros', '', "Departamento de F'isica Aplicada - Universidad de Alicante", "Centro de Astrobiolog'ia - CSIC-INTA"],
+             ["Barb'a", 'R. H.', '', "Departamento de Astronom'ia - Universidad de La Serena"],
+             ['Negueruela', 'I.', '', "Departamento de F'isica Aplicada - Universidad de Alicante"],
+             ["Apell'aniz", "J. Ma'iz", '', "Centro de Astrobiolog'ia - CSIC-INTA"],
+             ["Sim'on-D'iaz", 'S.', '', "Instituto de Astrof'isica de Canarias", "Departamento de Astrof'isica - Universidad de La Laguna"],
+             ['Holgado', 'G.', '', "Centro de Astrobiolog'ia - CSIC-INTA"]],
+             'back propagation for 2106.08865 with comma as separator'
+        )
+
+        self.assertListEqual(
+            # 2106.08865; back propagation with "and", e.g. Some Author (1 and 2), Another Author (4 and 5)
+            parse_author_affil(
+                "E. Trigueros P\'aez (1 and 2) and R. H. Barb\'a (3) and I. Negueruela (1) "
+                "and J. Ma\'iz Apell\'aniz (2) and S. Sim\'on-D\'iaz (4 and 5) and G.Holgado (2) "
+                "((1) Departamento de F\'isica Aplicada - Universidad de Alicante, (2) "
+                "Centro de Astrobiolog\'ia - CSIC-INTA, (3) Departamento de Astronom\'ia - Universidad "
+                "de La Serena, (4) Instituto de Astrof\'isica de Canarias, (5) Departamento "
+                "de Astrof\'isica - Universidad de La Laguna)"),
+            [["P'aez", 'E. Trigueros', '', "Departamento de F'isica Aplicada - Universidad de Alicante", "Centro de Astrobiolog'ia - CSIC-INTA"],
+             ["Barb'a", 'R. H.', '', "Departamento de Astronom'ia - Universidad de La Serena"],
+             ['Negueruela', 'I.', '', "Departamento de F'isica Aplicada - Universidad de Alicante"],
+             ["Apell'aniz", "J. Ma'iz", '', "Centro de Astrobiolog'ia - CSIC-INTA"],
+             ["Sim'on-D'iaz", 'S.', '', "Instituto de Astrof'isica de Canarias", "Departamento de Astrof'isica - Universidad de La Laguna"],
+             ['Holgado', 'G.', '', "Centro de Astrobiolog'ia - CSIC-INTA"]],
+             'back propagation for 2106.08865 with "and" as separator'
+        )
+
+
         # ====== Extra tests for arXiv::AuthorAffil ARXIVDEV-728 ======
 
         # [parse_author_affil]

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'pytz',
         'uwsgi',
         'boto3',
-        'bleach==3.1.0',
+        'bleach==3.3.0',
         'backports-datetime-fromisoformat==1.0.0',
         'typing-extensions'
     ],


### PR DESCRIPTION
* changes DOI linking and display to follow CrossRef and DataCite best practices:
  * link to https://doi.org/
  * always display the full link
* fixes bug with back-propagation of author affiliations
* corrections to category descriptions
* defines `econ.GN` as a general category