### PR TITLE
ARXIVCE-700: fix donate url

### DIFF
--- a/arxiv/base/static/js/member_acknowledgement.js
+++ b/arxiv/base/static/js/member_acknowledgement.js
@@ -45,7 +45,7 @@
 
     if (label) {
       s = 'We gratefully acknowledge support from<br/>';
-      s += 'the Simons Foundation, <a href="https://info.arxiv.org/about/ourmembers.html">' + label + "</a>, and all contributors. <a href='info.arxiv.org/about/donate.html'>Donate</a>";
+      s += 'the Simons Foundation, <a href="https://info.arxiv.org/about/ourmembers.html">' + label + "</a>, and all contributors. <a href='https://info.arxiv.org/about/donate.html'>Donate</a>";
       support_elem = document.getElementById('support-ack-url');
       if (support_elem) {
         support_elem.innerHTML = s;

--- a/arxiv/base/templates/base/header.html
+++ b/arxiv/base/templates/base/header.html
@@ -3,7 +3,7 @@
   <div class="level-left">
     <a class="level-item" href="{{ url_for('university') }}"><img src="{{ url_for('base.static', filename='images/cornell-reduced-white-SMALL.svg') }}" alt="Cornell University" width="200" aria-label="logo" /></a>
   </div>
-  <div class="level-right is-marginless"><p class="sponsors level-item is-marginless"><span id="support-ack-url">We gratefully acknowledge support from<br /> the Simons Foundation, <a href="https://info.arxiv.org/about/ourmembers.html">member institutions</a>, and all contributors. <a href="info.arxiv.org/about/donate.html">Donate</a></span></p></div>
+  <div class="level-right is-marginless"><p class="sponsors level-item is-marginless"><span id="support-ack-url">We gratefully acknowledge support from<br /> the Simons Foundation, <a href="https://info.arxiv.org/about/ourmembers.html">member institutions</a>, and all contributors. <a href="https://info.arxiv.org/about/donate.html">Donate</a></span></p></div>
 </div>
 <!-- contains arXiv identity and search bar -->
 <div class="identity level is-marginless">


### PR DESCRIPTION
The typo is here: https://dev.arxiv.org/user/
There's also some member js that overwrites it, and needs to be updated.

Looks like we've transitioned to using the .venv dir in the project.

Prod auth is using:
arxiv-auth                       1.0.0rc3
arxiv-base                       1.0.0a3

Prod browse is using:
arxiv-base 1.0.0a5

Looks like auth is being worked on now. Probably BrianC, along with browse.
