### PR TITLE
only replace Category object if canonical one is different

### DIFF
--- a/arxiv/taxonomy/category.py
+++ b/arxiv/taxonomy/category.py
@@ -33,7 +33,9 @@ class BaseTaxonomy(BaseModel):
         Example: Earth and Planetary Astrophysics (astro-ph.EP)
         """
         from .definitions import CATEGORIES,ARCHIVES, GROUPS
-        if not canonical:
+        if self.id.startswith("bad-arch") or self.id=="grp_bad":
+            return self.full_name
+        elif not canonical:
             return f'{self.full_name} ({self.id})'
         else:
             name=self.canonical_id 

--- a/arxiv/taxonomy/category.py
+++ b/arxiv/taxonomy/category.py
@@ -119,3 +119,22 @@ class Category(BaseTaxonomy):
             return CATEGORIES[self.canonical_id]
         else:
             return self
+        
+
+def create_bad_arch(name: str) -> Archive:
+    return Archive(
+        id="bad-arch",
+        full_name=f"Invalid Archive: {name}",
+        is_active=False,
+        in_group="grp_bad",
+        start_date=date(2024, 1, 1)
+    )
+
+def create_bad_category(name:str) -> Category:
+    return Category(
+        id="bad-arch.bad-cat",
+        full_name=f"Invalid Category: {name}",
+        is_active=False,
+        in_archive="bad-arch",
+        is_general=False
+    ) 

--- a/arxiv/taxonomy/category.py
+++ b/arxiv/taxonomy/category.py
@@ -113,4 +113,7 @@ class Category(BaseTaxonomy):
     def get_canonical(self) -> 'Category':
         """returns the canonical version of the category object"""
         from .definitions import CATEGORIES
-        return CATEGORIES[self.canonical_id]
+        if self.canonical_id!= self.id:
+            return CATEGORIES[self.canonical_id]
+        else:
+            return self

--- a/arxiv/taxonomy/taxonomy_test.py
+++ b/arxiv/taxonomy/taxonomy_test.py
@@ -6,7 +6,7 @@ from typing import Union
 from arxiv.taxonomy.definitions import GROUPS, ARCHIVES, \
     ARCHIVES_ACTIVE, CATEGORIES, ARCHIVES_SUBSUMED, \
     LEGACY_ARCHIVE_AS_PRIMARY, LEGACY_ARCHIVE_AS_SECONDARY, CATEGORY_ALIASES, CATEGORIES_ACTIVE
-from arxiv.taxonomy.category import Category, Archive, Group
+from arxiv.taxonomy.category import Category, Archive, Group, create_bad_arch, create_bad_category
 
 
 class TestTaxonomy(TestCase):
@@ -152,3 +152,20 @@ class TestTaxonomy(TestCase):
             self.assertEqual(canon.display(True), canon.display(False), "display string always the same for canonical name")
             self.assertNotEqual(not_canon.display(True), not_canon.display(False), "display has different text for canonincal and non canonical options")
 
+    def test_bad_objects(self):
+        """the goal is to reasonably handle bad category types sometimes found in very old data"""
+        cat= create_bad_category("physics")
+        arch=create_bad_arch("hamsters")
+
+        self.assertIsInstance(cat, Category) 
+        self.assertIsInstance(arch, Archive)
+
+        self.assertEqual(cat.display(), "Invalid Category: physics", "display string should not include id")
+        self.assertEqual(cat.display(True), "Invalid Category: physics", "display string should not include id")
+        self.assertEqual(arch.display(), "Invalid Archive: hamsters", "display string should not include id")
+        self.assertEqual(arch.display(True), "Invalid Archive: hamsters", "display string should not include id")
+        
+        self.assertEqual(cat.full_name, "Invalid Category: physics", "full name should have data on original bad item")
+        self.assertEqual(cat.full_name, cat.get_canonical().full_name, "name data should be retained after canonical calls")
+        self.assertEqual(arch.full_name, "Invalid Archive: hamsters", "full name should have data on original bad item")
+        self.assertEqual(arch.full_name, arch.get_canonical().full_name, "name data should be retained after canonical calls")


### PR DESCRIPTION
this change is to support the creation of custom categories if unknown categories are created in our system. It stops category objects from being replaced with ones from CATEGORIES if they already have the same canonical id