### PR TITLE
Change to flask sqlalchemy db session close

### DIFF
--- a/arxiv/base/__init__.py
+++ b/arxiv/base/__init__.py
@@ -125,6 +125,10 @@ class Base(object):
 
         @app.teardown_appcontext
         def remove_scoped_session (response_or_exc: BaseException | None) -> None:
-            if response_or_exc:
-                Session.rollback()
+            """Cleans up the DB session.
+
+            Will rollback any uncomitted transactions (via Session.remove()
+            which will call Sesion.close()). When Session is used again in this thread,
+            a new one will be created.
+            """
             Session.remove()


### PR DESCRIPTION
Removes unnecessary rollback on error. The existing call to Session.remove() would already do this if there was an open transaction.

This call was the source of some errors in arxiv-browse. Errors during the `.remove()` call will could still happen but this change will avoid rollbacks when there are no changes and in `READ_UNCOMMITTED`.  arxiv-browse runs in `READ_UNCOMMITTED` and makes no INSERT or UPDATEs.

The Sqlalchemy docs say (sqlalchemy.scoping.scoped_session.close())

"This expunges all ORM objects associated with this  `_orm.Session`, ends any transaction in progress and
 `releases` any `_engine.Connection` objects which this  `_orm.Session` itself has checked out from associated  `_engine.Engine` objects. The operation then leaves the  `_orm.Session` in a state which it may be used again."

See: https://github.com/sqlalchemy/sqlalchemy/blob/5b117f3d4b38d12d61a39fc60582d4348232334f/lib/sqlalchemy/orm/scoping.py#L483

arxivce-1639