### PR TITLE
There is no `engine` in arxiv.db (any more?)

### DIFF
--- a/arxiv/ops/db_subset/clone_subset.py
+++ b/arxiv/ops/db_subset/clone_subset.py
@@ -19,8 +19,7 @@ from sqlalchemy.orm import (
     make_transient
 )
 
-from ...db import Base, LaTeXMLBase, session_factory
-from ...db import engine as classic_engine
+from ...db import Base, LaTeXMLBase, session_factory, _classic_engine as classic_engine
 from ...db.models import (
     DBLaTeXMLDocuments,
     DBLaTeXMLSubmissions,


### PR DESCRIPTION
as such, importing this file causes an import error.