### PR TITLE
[ARXIVCE-2684] set the postgresql isolation level to READ UNCOMITTED

### DIFF
--- a/arxiv/config/__init__.py
+++ b/arxiv/config/__init__.py
@@ -173,7 +173,7 @@ class Settings(BaseSettings):
     LATEXML_DB_URI: Optional[str] = DEFAULT_LATEXML_DB
     ECHO_SQL: bool = False
     CLASSIC_DB_TRANSACTION_ISOLATION_LEVEL: Optional[IsolationLevel] = None
-    LATEXML_DB_TRANSACTION_ISOLATION_LEVEL: Optional[IsolationLevel] = None
+    LATEXML_DB_TRANSACTION_ISOLATION_LEVEL: Optional[IsolationLevel] = "READ UNCOMMITTED"
 
     LATEXML_DB_QUERY_TIMEOUT: int = 5
     """Maximium seconds any query to the latxml DB can run.


### PR DESCRIPTION
The code is untested, following the [sqlalchemy docs](https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#setting-transaction-isolation-levels-dbapi-autocommit). 

[ARXIVCE-2684](https://arxiv-org.atlassian.net/browse/ARXIVCE-2684)