### PR TITLE
Use Firefox instead of Chromium for Keycloak test

### DIFF
--- a/.github/workflows/pullreqeust_tests.yaml
+++ b/.github/workflows/pullreqeust_tests.yaml
@@ -26,10 +26,15 @@ jobs:
       # TODO The types are in bad shape and need to be fixed
       #   run: poetry run mypy --exclude "test*" -p arxiv
 
-      - name: Install Chrome Driver
+      - name: Install Firefox ESR and test driver
         run: |
-          sudo apt-get update
-          sudo apt-get install -y chromium-browser chromium-chromedriver
+          sudo add-apt-repository -y ppa:mozillateam/ppa
+          sudo apt update
+          sudo apt install -y firefox-esr
+          wget https://github.com/mozilla/geckodriver/releases/latest/download/geckodriver-v0.35.0-linux64.tar.gz                                                                                                                        
+          tar -xvzf geckodriver-v0.35.0-linux64.tar.gz                                                                                                                                                                                     
+          sudo mv geckodriver /usr/local/bin/                                                                                                                                                                                              
+          sudo chmod +x /usr/local/bin/geckodriver
 
       - name: Run other tests
         # These tests are split out because their coverage is low

--- a/arxiv/auth/openid/tests/test_keycloak.py
+++ b/arxiv/auth/openid/tests/test_keycloak.py
@@ -2,26 +2,23 @@ import subprocess
 import pytest
 from selenium import webdriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.chrome.service import Service
-from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.firefox.service import Service
+from selenium.webdriver.firefox.options import Options
 import time
 
 @pytest.fixture(scope="module")
 def web_driver() -> webdriver.Chrome:
-    # Set up the Selenium WebDriver
-    # You'd need
-    # sudo apt-get update
-    # sudo apt-get install -y chromium-browser chromium-chromedriver
-
     options = Options()
-    options.binary_location = "/usr/bin/chromium-browser"
-    options.add_argument("--headless")
-    options.add_argument("--disable-gpu")
-    service = Service(executable_path="/usr/bin/chromedriver")
-    _web_driver = webdriver.Chrome(service=service, options=options)
-    _web_driver.implicitly_wait(10)  # Wait for elements to be ready
+    options.headless = True
+    options.binary_location = "/usr/bin/firefox-esr"
+    options.add_argument('--headless')
+
+    service = Service(executable_path="/usr/local/bin/geckodriver")
+    _web_driver = webdriver.Firefox(service=service, options=options)
+    _web_driver.implicitly_wait(10)  # Wait for elements to be ready                                                                                                                                                             
     yield _web_driver
-    _web_driver.quit()  # Close the browser window after tests
+    _web_driver.quit()  # Close the browser window after tests                                                                                                                                                                   
+
 
 @pytest.fixture(scope="module")
 def toy_flask():


### PR DESCRIPTION
Chromium and its driver are snap based and it does not work with ACT. IOW, for testing, you don't want to rely on snapd up and running. I switched to use Firefox ESR since it is .beb based which in turn result in using the driver. 

Note that, this means the gecko driver is external and could become obsolete. When it happens, it may need to update the driver version which is unfortunate but the alternative is to be stuck with Chrome driver which is 20+ versions behind the stable Chrome stable release. 