### PR TITLE
Fixes some fastly_log_ingest problems

### DIFF
--- a/arxiv/identifier/test_arxiv_identifier.py
+++ b/arxiv/identifier/test_arxiv_identifier.py
@@ -1,0 +1,35 @@
+from . import Identifier
+
+def test_id_without_extra():
+    arxiv_id = Identifier('physics/0303098')
+    assert (arxiv_id
+            and arxiv_id.id == 'physics/0303098'
+            and arxiv_id.archive == 'physics'
+            and arxiv_id.year == 2003 and arxiv_id.month == 3
+            and arxiv_id.num == 98)
+    assert (arxiv_id.is_old_id
+            and not arxiv_id.extra
+            and not arxiv_id.arxiv_prefix)
+
+
+def test_id_trailing_slash():
+    arxiv_id = Identifier('physics/0303098/')
+    assert (arxiv_id
+            and arxiv_id.id == 'physics/0303098'
+            and arxiv_id.archive == 'physics'
+            and arxiv_id.year == 2003 and arxiv_id.month == 3
+            and arxiv_id.num == 98)
+    assert (arxiv_id.is_old_id
+            and arxiv_id.extra == "/"
+            and not arxiv_id.arxiv_prefix)
+
+def test_id_with_extra():
+    arxiv_id = Identifier('physics/0303098/static/icon.png')
+    assert (arxiv_id
+            and arxiv_id.id == 'physics/0303098'
+            and arxiv_id.archive == 'physics'
+            and arxiv_id.year == 2003 and arxiv_id.month == 3
+            and arxiv_id.num == 98)
+    assert (arxiv_id.is_old_id
+            and arxiv_id.arxiv_prefix == False)
+    assert (arxiv_id.extra == '/static/icon.png')

--- a/arxiv/ops/fastly_log_ingest/README.md
+++ b/arxiv/ops/fastly_log_ingest/README.md
@@ -1,0 +1,35 @@
+# Fastly log ingest
+This is a small python program that listens to a GCP pub/sub for fastly log messages and writes those to 
+the GCP logging API. Then they can be viewed with tools like log exporter or used in log based metrics.
+
+## Rational
+Fastly does not have a log tool. They integrate with several platforms and expect user to 
+choose a tool like Elasticsearch. 
+For information see [fastly's log docs](https://www.fastly.com/documentation/guides/integrations/logging/)
+
+Fastly does not have a direct log integration with GCP logging API. They do have integration 
+with GCP Big query.
+
+Why is this not a cloud function or cloud run? We often want to do as much as possible 
+serverless to avoid managing VMs. Yet this is written as a program than runs on a VM. Why?
+1. There is limit to the number of logging API calls per minute. At times arxiv.org 
+   has seen very high rates of traffic. If each log line was sent as a single API call 
+   we could reach those limits during times of excessive traffic.
+2. In light of 1. we can use GCP logging API batch feature to reduce our number of calls
+   by a factor of 100
+3. Cloud run and cloud functions do not immediately support batching since ACK the message
+   at completion. This app will receive pubsub messages batch them up and only send an ACK once
+   the batch has been sent to GCP logging. 
+
+## Deploy
+For deploy see [Dockerfile](/deploy/Dockerfile-fastlylogingest) 
+
+## Development
+To develop locally setup up local GCP credentials with privileges similar to what is in
+the deployment guide Docker file. Run the program like this:
+    
+    cd arxiv-base
+    python -m venv venv
+    venv/bin/activate
+    poetry install
+    VERBOSE=1 SHOW_PER_THREAD_RATES=1 python arxiv/ops/fastly_log_ingest/app.py

--- a/arxiv/ops/fastly_log_ingest/app.py
+++ b/arxiv/ops/fastly_log_ingest/app.py
@@ -1,41 +1,59 @@
 """Script to subscribe to fastly pub/sub messages and write to logging."""
+
 import json
+import logging
 import os
+import signal
+import threading
 from collections import deque
 from datetime import datetime
 from threading import Condition, Thread
-import logging
-
 from time import perf_counter
-from typing import List
-from zoneinfo import ZoneInfo
+from typing import List, Tuple
 
+import google.auth
 from google.api_core.exceptions import PermissionDenied
 from google.cloud import pubsub_v1, logging as gcp_logging
-import google.auth
 from google.cloud.logging_v2.entries import Resource
 from google.cloud.pubsub_v1.subscriber.message import Message
-from arxiv.ops.fastly_log_ingest import Rate
+
+from . import Rate
 
 PROJECT_ID = os.environ.get("PROJECT_ID", "arxiv-production")
 SUBSCRIPTION_ID = os.environ.get("SUBSCRIPTION_ID", "logs-fastly-arxiv-org-sub")
 
-VERBOSE = os.environ.get("VERBOSE", "verbose_off_by_default") == "1"
-THREADS = int(os.environ.get("THREADS", 1))  # threads to send logs
-SEND_PERIOD = int(os.environ.get("SEND_PERIOD", 8.0))  # seconds to wait for messages to accumulate
-INFO_PERIOD = int(os.environ.get("INFO_PERIOD", 12.0))  # seconds between info logging
-
 LOGGER_NAME = os.environ.get("LOGGER_NAME", "fastly_log_ingest")
-# name of logger in GCP, don't prefix with project-id or anything
+"""Name of logger in GCP, don't prefix with project-id or anything."""
+
+THREADS = int(os.environ.get("THREADS", 1))
+"""Number of threads to use to send logs"""
+
+SEND_PERIOD = int(os.environ.get("SEND_PERIOD", 8.0))
+"""seconds to wait for messages to accumulate"""
+
+PREFERRED_PER_BATCH = int(os.environ.get("PREFERRED_PER_BATCH", 50))
+"""Number of records in a batch to start sending to log. Must be smaller than MAX_PER_BATCH"""
+
+MAX_PER_BATCH = int(os.environ.get("MAX_PER_BATCH", 100))
 """Number of log records in a batch. Limit seems to be 16kb but not sure."""
-MAX_PER_BATCH = int(os.environ.get("MAX_PER_BATCH", 10))
+
+MAX_BYTES_PER_VALUE = int(os.environ.get("MAX_BYTES_PER_VALUE", 1024 * 2))
+"""Maximum number of bytes allowed for a single value of a log record."""
+
+""""############### just logging config #######################"""
+
+VERBOSE = os.environ.get("VERBOSE", "verbose_off_by_default") == "1"
+
+INFO_PERIOD = int(os.environ.get("INFO_PERIOD", 12.0))
+"""Seconds between rate info logging."""
+
+SHOW_PER_THREAD_RATES = bool(os.environ.get("SHOW_PER_THREAD_RATES", "off_by_default")) == "1"
+"""Whether to show the log messages about per thread rates."""
 
 logging.basicConfig(encoding='utf-8', level=logging.INFO)
 logger = logging.getLogger(__name__)
 if VERBOSE:
     logger.setLevel(logging.DEBUG)
-
-utc_zone = ZoneInfo("UTC")
 
 
 def _log_credentials(cred):
@@ -45,120 +63,146 @@ def _log_credentials(cred):
         logger.info(f"Credentials: type {type(cred)}")
 
 
-class WorkItem:
-    """An item of work which is a Pub/Sub message and an arrival time."""
-
-    def _status_to_severity(self, status: int):
-        if not status:
-            return "ERROR"
-        if status < 400:
-            return "INFO"
-        if status < 500:
-            return "WARNING"
+def status_to_severity(status: int):
+    if not status:
         return "ERROR"
+    if status < 400:
+        return "INFO"
+    if status < 500:
+        return "WARNING"
+    return "ERROR"
 
-    def __init__(self, message: Message, arrival_time: float):
-        self.message = message
-        self.arrival_time = arrival_time
-        try:
-            self.data: dict = json.loads(message.data.decode('utf-8').strip())
-        except Exception as e:
-            logger.warning(f'Failed to log the following message: {message.data.decode("utf-8", errors='replace')} with {str(e)}')
 
-    def to_payload(self) -> dict:
-        """Convert the message into a `payload` for the log entry."""
-        return {key: value for key, value in self.data.items() if key != "timestamp"}
+def truncate(value):
+    if value is None:
+        return ""
+    out_value = str(value)
+    if len(out_value) > MAX_BYTES_PER_VALUE:
+        return out_value[:MAX_BYTES_PER_VALUE-11] + "-TRUNCATED"
+    else:
+        return out_value
 
-    def to_metadata(self) -> dict:
-        """Convert the message into the metadata the log entry.
 
-        Seting `timestamp` here causes the time of the log line to be the time
-        of the original http request instead of the time of the line entry into GCP.
-        """
-        return {
-            "severity": self._status_to_severity(self.data.get("status", 500)),
-            # This cause the log line to show up in GCP at the date of the original http request
-            "timestamp": datetime.strptime(self.data["timestamp"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=utc_zone),
-            "resource": Resource(type="generic_node",
-                                 labels={"project_id": PROJECT_ID,
-                                         "namespace": "fastly",
-                                         "node_id": self.data.get("fastly_server", "server_unknown")})
+def to_gcp_log_item(message: Message) -> Tuple[dict,dict]:
+    try:
+        data: dict = json.loads(message.data.decode('utf-8').strip())
+        return (
+            {key: truncate(value) for key, value in data.items() if key != "timestamp"},
+            {
+                "severity": status_to_severity(data.get("status", 500)),
+                # This cause the log line to show up in GCP at the date of the original http request
+                "timestamp": datetime.strptime(data["timestamp"], "%Y-%m-%dT%H:%M:%S%z"),
+                "resource": Resource(type="generic_node",
+                                     labels={"project_id": PROJECT_ID,
+                                             "namespace": "fastly",
+                                             "node_id": data.get("fastly_server", "server_unknown")})
+            }
+        )
+    except Exception:
+        logger.exception("Problem converting message to log item")
+        return {}, {}
 
-        }
+
+WorkItem = Tuple[Message, float]
+"""An item of work which is a Pub/Sub message and an arrival time."""
 
 
 RUN = True
+"""Global used to force threads to stop."""
 
-shared_messages: deque[WorkItem] = deque()
-msg_rate = Rate(plural_noun="pub/sub messages")
-last_pubsub_info = perf_counter()
-cv = Condition()  # lock protects the above three objects
+shared_messages: deque[WorkItem] = deque()  # thread safe, left side: oldest, right newest.
+msg_rate = Rate(plural_noun="pub/sub messages")  # thread safe
+last_pubsub_info = perf_counter()  # only incremented and only by assignment
+cv = Condition()  # Used only for notification waiting log_to_gcp threads
+streaming_pull_future = None
 
 
-def _logging_thread():
-    log_write_rate = Rate(plural_noun="log entries")
-    logging.info("About to get logging_v2 client.")
+def orderly_shutdown(signum, frame):
+    global RUN
+    RUN = False
+    global streaming_pull_future
+    if streaming_pull_future:
+        streaming_pull_future.cancel()
+        streaming_pull_future.result()
+    with cv:
+        cv.notify_all()
+
+
+signal.signal(signal.SIGINT, orderly_shutdown)
+signal.signal(signal.SIGTERM, orderly_shutdown)
+
+
+def log_to_gcp():
+    """Function for thread that reads from `shared_messages` and sends them to GCP logging API."""
+    log_write_rate = Rate(plural_noun=f"log entries by {threading.current_thread().name}")
+    last_info_msg = perf_counter()
+
+    logging.debug("About to get GCP logging client.")
     log_client = gcp_logging.Client(project=PROJECT_ID)
     fastly_logger = log_client.logger(name=LOGGER_NAME)
+    logging.debug("Got logging_v2 client.")
 
-    logging.info("Got logging_v2 client.")
-    last_info_msg = perf_counter()
     while RUN:
-        work_items: List[WorkItem] = []
-        with cv:
-            cv.wait_for(lambda: shared_messages, timeout=2.0)  # timeout to allow exit or periodic message
-            now = perf_counter()
-            msg_count = len(shared_messages)
-            if msg_count and (msg_count > MAX_PER_BATCH or (now - shared_messages[0].arrival_time) > SEND_PERIOD):
-                work_items.extend([shared_messages.pop() for _ in range(min([msg_count, MAX_PER_BATCH]))])
-
-        if work_items:
-            logger.debug("About to log batch of %d pub/sub messages", len(work_items))
-            log_items = []
-            for item in work_items:
+        try:
+            work_items: List[WorkItem] = []
+            with cv:
+                cv.wait_for(lambda: (len(shared_messages) and (
+                        len(shared_messages) > PREFERRED_PER_BATCH
+                        or shared_messages[0][1] and (perf_counter() - shared_messages[0][1]) > SEND_PERIOD)),
+                        timeout=1.0)
                 try:
-                    log_items.append((item.to_payload(), item.to_metadata()))
-                except Exception as exc:
-                    logger.error("Skipping line, problem while converting log line", exc)
+                    [work_items.append(shared_messages.popleft()) for _ in range(MAX_PER_BATCH)]
+                except IndexError:
+                    pass  # ran out of messages, not a problem
 
-            with fastly_logger.batch() as batch:
-                [batch.log_struct(info=info, **kv) for info, kv in log_items]
+            if work_items:
+                messages = (to_gcp_log_item(message) for message, _ in work_items)
+                with fastly_logger.batch() as batch:
+                    [batch.log_struct(info=info, **kv) for info, kv in messages if info and kv]
 
-            aki = 0
-            for item in work_items:
-                item.message.ack()
-                aki += 1
+                aki = 0
+                for item in work_items:
+                    item[0].ack()
+                    aki += 1
 
-            logger.debug("Acked %d pubsub messages", aki)
-            log_write_rate.event(quantity=len(work_items))
-        now = perf_counter()
-        if now - last_info_msg >= INFO_PERIOD:
-            last_info_msg = now
-            logger.info(log_write_rate.rate_msg())
-    logger.info(log_write_rate.rate_msg())  # on exit
+                logger.debug("Acked %d pubsub messages", aki)
+                if SHOW_PER_THREAD_RATES:
+                    log_write_rate.event(quantity=len(work_items))
+
+                if SHOW_PER_THREAD_RATES:
+                    now = perf_counter()
+                    if now - last_info_msg >= INFO_PERIOD:
+                        last_info_msg = now
+                        logger.info(log_write_rate.rate_msg())
+        except Exception:
+            logger.exception("Exception in the write-logs-to-gcp loop")
+    if SHOW_PER_THREAD_RATES:
+        logger.info(log_write_rate.rate_msg())  # on exit
+    logger.info("Worker finished orderly shutdown.")
 
 
 def _pubsub_callback(message: Message) -> None:
     global last_pubsub_info
     arrival = perf_counter()
-    with cv:
-        shared_messages.append(WorkItem(message, arrival))
-        msg_rate.event()
-        now = perf_counter()
-        if now - last_pubsub_info > INFO_PERIOD:
-            last_pubsub_info = now
-            logger.info(msg_rate.rate_msg())
+    shared_messages.append((message, arrival))
+    msg_rate.event()
+
+    # with cv:
+    #     cv.notify()
+
+    if arrival - last_pubsub_info > INFO_PERIOD:
+        last_pubsub_info = arrival
+        logger.info(msg_rate.rate_msg())
 
 
 if __name__ == "__main__":
     credentials, project = google.auth.default()
-    logger.info("GOOGLE_APPLICATION_CREDENTIALS envvar:"
-                f"{os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', '(not set)')}")
+    logger.info("GOOGLE_APPLICATION_CREDENTIALS envvar:" f"{os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', '(not set)')}")
     _log_credentials(credentials)
     logger.info("about to start logging threads")
     threads = []
     for _ in range(0, THREADS):
-        threads.append(Thread(target=_logging_thread))
+        threads.append(Thread(target=log_to_gcp))
     [t.start() for t in threads]
     logger.info(f"Started {len(threads)} log writer threads.")
     """>>>>>>>> Setup of streaming pull from Pub/Sub <<<<<<<<"""

--- a/deploy/Dockerfile-fastlylogingest
+++ b/deploy/Dockerfile-fastlylogingest
@@ -18,7 +18,7 @@
 # docker push $TAG
 #
 # Then create a small VM with a that docker image and the
-# service account fastly-logs-ingest, set it to run the docker image, set the image to run prilvinged,
+# service account fastly-logs-ingest, set it to run the docker image, set the image to run privileged,
 # set logging to on.
 # Chech the logs of the VM to see if there are the expected debugging messages.
 #


### PR DESCRIPTION
Adds `try/catch` to WorkItem loop
Adds README
Adds SIGTERM handling for quick finishing of queue on shutdown
Has both a PREFERRED_PER_BATCH and MAX_PER_BATCH
Better date handling
Fixes `notify()`

Before the changes this did about 200 messages per sec, after it does about 300. 