### PR TITLE
Enhance test coverage reporting in CI workflow

### DIFF
--- a/.github/workflows/pullrequest_tests.yaml
+++ b/.github/workflows/pullrequest_tests.yaml
@@ -37,8 +37,8 @@ jobs:
       # Run tests with high coverage first
         run: |
           poetry run pytest --cov=arxiv.base --cov=arxiv.metadata --cov-fail-under=85 arxiv
-          poetry run pytest --cov=fourohfour --cov-fail-under=74 fourohfour
-          poetry run pytest --cov=arxiv --cov-fail-under=82 arxiv
+          poetry run pytest --cov=fourohfour --cov-fail-under=74 fourohfour --cov-append
+          poetry run pytest --cov=arxiv --cov-fail-under=82 arxiv --cov-append
 
       # - name: Check Types
       # TODO The types are in bad shape and need to be fixed
@@ -58,10 +58,18 @@ jobs:
 
       - name: Run other tests
         # These tests are split out because their coverage is low
-        run: poetry run pytest --cov=arxiv --cov-fail-under=40 arxiv --ignore=arxiv/base --ignore=arxiv/auth/legacy --db=sqlite
+        run: poetry run pytest --cov=arxiv --cov-fail-under=40 arxiv --ignore=arxiv/base --ignore=arxiv/auth/legacy --db=sqlite --cov-append --cov-report=html
       #- name: Check Doc Style
       #  run: poetry run pydocstyle --convention=numpy --add-ignore=D401 arxiv
 
       - name: Run App Tests
         run: poetry run python tests/run_app_tests.py
+
+      - name: Upload coverage HTML report
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: coverage-report
+          path: htmlcov/
+          retention-days: 30
 


### PR DESCRIPTION
- Added `--cov-append` option to coverage commands to accumulate coverage data.
- Included HTML report generation for coverage results.
- Implemented artifact upload for coverage reports with a retention period of 30 days.