### PR TITLE
Fix the utf-8 column type decorator not applied.

### DIFF
--- a/arxiv/base/tests/test_docmeta.py
+++ b/arxiv/base/tests/test_docmeta.py
@@ -1,6 +1,5 @@
-
 from typing import Any, Dict
-from unittest import TestCase,mock
+from unittest import TestCase, mock
 from datetime import datetime
 
 from arxiv.document.metadata import DocMetadata, AuthorList, Submitter
@@ -9,44 +8,45 @@ from arxiv.identifier import Identifier
 from arxiv.license import License
 from arxiv.document.version import VersionEntry, SourceFlag
 
-SAMPLE_DOCMETA=DocMetadata(
-        raw_safe="abs text here",
-        arxiv_id='1204.5678',
-        arxiv_id_v="1204.5678v1",
-        arxiv_identifier=Identifier("1204.5678v1"),
-        title="title of paper",
-        abstract="also abs text here",
-        authors=AuthorList("First Name, Second, Name"),
-        submitter=Submitter(name="a submitter", email="fakeemail@arxiv.org"),
-        categories="hep-th cs.NA math-ph math.MP",
-        primary_category=CATEGORIES['hep-th'],
-        primary_archive=CATEGORIES['hep-th'].get_archive(),
-        primary_group=CATEGORIES['hep-th'].get_archive().get_group(),
-        secondary_categories=[
-            CATEGORIES["math-ph"],
-            CATEGORIES["math.MP"],
-            CATEGORIES["cs.NA"]
-        ],
-        journal_ref="journal of mystical knowledge",
-        report_num=None,
-        doi=None,
-        acm_class=None,
-        msc_class=None,
-        proxy=None,
-        comments="very insightful comments",
-        version=1,
-        license=License(),
-        version_history=[
-            VersionEntry(
-                version=1,
-                raw="",
-                submitted_date=datetime.now(),
-                size_kilobytes=30,
-                source_flag=SourceFlag("D"),
-            )
-        ],
-        modified=datetime(year=2011, month=3, day=7)
-    )
+SAMPLE_DOCMETA = DocMetadata(
+    raw_safe="abs text here",
+    arxiv_id='1204.5678',
+    arxiv_id_v="1204.5678v1",
+    arxiv_identifier=Identifier("1204.5678v1"),
+    title="title of paper",
+    abstract="also abs text here",
+    authors=AuthorList("First Name, Second, Name"),
+    submitter=Submitter(name="a submitter", email="fakeemail@arxiv.org"),
+    categories="hep-th cs.NA math-ph math.MP",
+    primary_category=CATEGORIES['hep-th'],
+    primary_archive=CATEGORIES['hep-th'].get_archive(),
+    primary_group=CATEGORIES['hep-th'].get_archive().get_group(),
+    secondary_categories=[
+        CATEGORIES["math-ph"],
+        CATEGORIES["math.MP"],
+        CATEGORIES["cs.NA"]
+    ],
+    journal_ref="journal of mystical knowledge",
+    report_num=None,
+    doi=None,
+    acm_class=None,
+    msc_class=None,
+    proxy=None,
+    comments="very insightful comments",
+    version=1,
+    license=License(),
+    version_history=[
+        VersionEntry(
+            version=1,
+            raw="",
+            submitted_date=datetime.now(),
+            size_kilobytes=30,
+            source_flag=SourceFlag("D"),
+        )
+    ],
+    modified=datetime(year=2011, month=3, day=7)
+)
+
 
 class DocMetadataTest(TestCase):
     fields: Dict[str, Any]
@@ -104,20 +104,20 @@ class DocMetadataTest(TestCase):
         self.assertTrue('private' not in str(ctx.exception))
 
     def test_get_secondaries(self):
-        #get secondaries should only return cannonical instance of each secondary category with no duplicates
+        # get secondaries should only return cannonical instance of each secondary category with no duplicates
 
         self.assertEqual(
-            SAMPLE_DOCMETA.get_secondaries(), 
-            set([CATEGORIES["math-ph"], CATEGORIES["math.NA"]]), 
+            SAMPLE_DOCMETA.get_secondaries(),
+            set([CATEGORIES["math-ph"], CATEGORIES["math.NA"]]),
             "only retrieves canonical version of each secondary"
         )
 
         self.assertEqual(
-            SAMPLE_DOCMETA.display_secondaries(), 
-            ['Mathematical Physics (math-ph)', 'Numerical Analysis (math.NA)'], 
+            SAMPLE_DOCMETA.display_secondaries(),
+            ['Mathematical Physics (math-ph)', 'Numerical Analysis (math.NA)'],
             "secondary display string must match"
         )
-        
+
     def test_misc(self):
         self.assertTrue(len(SAMPLE_DOCMETA.get_browse_context_list()) == 6)
         self.assertTrue(SAMPLE_DOCMETA.highest_version() == 1)
@@ -125,8 +125,29 @@ class DocMetadataTest(TestCase):
         # Throws an error:
         # print( "canonical url", SAMPLE_DOCMETA.canonical_url() )
         # self.assertFalse(SAMPLE_DOCMETA.canonical_url() > 0)
-        
+
     def test_get_raw(self):
         # These may be fragile if the data in SAMPLE_DOCMETA changes...
-        self.assertTrue(len(SAMPLE_DOCMETA.raw()) == 373)
-        self.assertTrue(len(SAMPLE_DOCMETA.raw().split('\n')) == 15)
+        output = SAMPLE_DOCMETA.raw()
+        expected = ('------------------------------------------------------------------------------\n'
+                    '\\\n'
+                    'arXiv:1204.5678\n'
+                    'From: a submitter\n'
+                    'Date: Tue, 3 Feb 2026 10:40:58    (30kb,D)\n'
+                    '\n'
+                    'Title: title of paper\n'
+                    'Authors: First Name, Second, Name\n'
+                    'Categories: hep-th cs.NA math-ph math.MP\n'
+                    'Comments: very insightful comments\n'
+                    'Journal-ref: journal of mystical knowledge\n'
+                    'License: None\n'
+                    '\\\n'
+                    '  also abs text here\n'
+                    '\\')
+        self.assertTrue(isinstance(output, str))
+        for a, b in zip(output.splitlines(), expected.splitlines()):
+            # Date changes every run, and as long as both start with "Date: ", good enough
+            if a.startswith('Date: ') and b.startswith('Date: '):
+                continue
+            self.assertEqual(a, b)
+        # removed number of lines test since the expected implies the n-lines, and tests line by line

--- a/arxiv/db/column_types.py
+++ b/arxiv/db/column_types.py
@@ -181,7 +181,8 @@ class BinaryStringType(TypeDecorator):
         This ensures MySQL returns the raw bytes without latin-1 interpretation,
         so we can decode them as UTF-8 in process_result_value.
         """
-        return func.cast(col, LargeBinary)
+        from sqlalchemy import type_coerce
+        return type_coerce(func.cast(col, LargeBinary), self)
 
 
 class TranscodedText(TypeDecorator):
@@ -300,7 +301,8 @@ class TranscodedText(TypeDecorator):
         This ensures MySQL returns the raw bytes without latin-1 interpretation,
         so we can decode them as UTF-8 in process_result_value.
         """
-        return func.cast(col, LargeBinary)
+        from sqlalchemy import type_coerce
+        return type_coerce(func.cast(col, LargeBinary), self)
 
 
 # Convenience type for common cases

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  mysql:
+    image: mysql:8.4
+    container_name: arxiv-test-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: arXiv
+      MYSQL_USER: testuser
+      MYSQL_PASSWORD: testpassword
+    ports:
+      - "13306:3306"
+    volumes:
+      - ../arxiv/db/arxiv_db_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
+      - ./init_db/02_test_user.sql:/docker-entrypoint-initdb.d/02_test_user.sql:ro
+    command:
+      - --sql-mode=STRICT_TRANS_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO
+      - --character-set-server=latin1
+      - --collation-server=latin1_swedish_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-prootpassword"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/tests/init_db/02_test_user.sql
+++ b/tests/init_db/02_test_user.sql
@@ -1,0 +1,27 @@
+-- Create test policy class (required by tapir_users foreign key)
+INSERT INTO tapir_policy_classes (class_id, name, description, password_storage, recovery_policy, permanent_login)
+VALUES (1, 'test_policy', 'Test policy class', 0, 0, 0);
+
+-- Create test user
+INSERT INTO tapir_users (
+    user_id,
+    first_name,
+    last_name,
+    suffix_name,
+    email,
+    policy_class,
+    joined_date,
+    flag_approved,
+    flag_email_verified
+)
+VALUES (
+    1,
+    'Test',
+    'User',
+    '',
+    'test_user@example.com',
+    1,
+    UNIX_TIMESTAMP(),
+    1,
+    1
+);

--- a/tests/test_utf8_columns.py
+++ b/tests/test_utf8_columns.py
@@ -1,0 +1,215 @@
+"""
+Minimal test for TapirEmailTemplate Utf8String and Utf8Text column types.
+
+To run this test:
+    pytest tests/test_utf8_columns.py -v
+
+The test fixture automatically manages the Docker MySQL container.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import time
+from typing import Generator
+
+import pytest
+from sqlalchemy import Engine, create_engine, NullPool
+from sqlalchemy.orm import Session
+
+from arxiv.db.models import TapirEmailTemplate
+
+
+# Test database connection parameters
+DB_HOST: str = "127.0.0.1"
+DB_PORT: int = 13306
+DB_NAME: str = "arXiv"
+DB_USER: str = "testuser"
+DB_PASSWORD: str = "testpassword"
+
+# Path to docker-compose.yml
+TESTS_DIR: str = os.path.dirname(os.path.abspath(__file__))
+DOCKER_COMPOSE_FILE: str = os.path.join(TESTS_DIR, "docker-compose.yml")
+
+
+def is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    """Check if a port is open."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout)
+        result = sock.connect_ex((host, port))
+        return result == 0
+
+
+def wait_for_mysql(host: str, port: int, user: str, password: str, db: str,
+                   timeout: int = 60) -> bool:
+    """Wait for MySQL to be ready to accept connections."""
+    from sqlalchemy import text
+
+    uri = f"mysql://{user}:{password}@{host}:{port}/{db}"
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        if is_port_open(host, port):
+            try:
+                engine = create_engine(uri, poolclass=NullPool)
+                with engine.connect() as conn:
+                    conn.execute(text("SELECT 1"))
+                engine.dispose()
+                return True
+            except Exception:
+                pass
+        time.sleep(1)
+    return False
+
+
+@pytest.fixture(scope="module")
+def db_engine() -> Generator[Engine, None, None]:
+    """Create database engine for testing.
+
+    This fixture:
+    1. Purges any existing MySQL container
+    2. Starts a fresh MySQL container via docker-compose
+    3. Waits for MySQL to be ready
+    4. Yields the SQLAlchemy engine
+    5. Cleans up the container after tests
+    """
+    # Purge existing container
+    subprocess.run(
+        ["docker", "compose", "-f", DOCKER_COMPOSE_FILE, "down", "-v", "--remove-orphans"],
+        capture_output=True,
+        check=False
+    )
+
+    # Start fresh container
+    result = subprocess.run(
+        ["docker", "compose", "-f", DOCKER_COMPOSE_FILE, "up", "-d"],
+        capture_output=True,
+        text=True
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Failed to start MySQL container: {result.stderr}")
+
+    # Wait for MySQL to be ready
+    if not wait_for_mysql(DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME, timeout=60):
+        # Clean up on failure
+        subprocess.run(
+            ["docker", "compose", "-f", DOCKER_COMPOSE_FILE, "down", "-v"],
+            capture_output=True,
+            check=False
+        )
+        pytest.fail("MySQL container did not become ready in time")
+
+    # Create engine
+    uri = f"mysql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+    engine = create_engine(uri, poolclass=NullPool)
+
+    yield engine
+
+    # Cleanup
+    engine.dispose()
+    subprocess.run(
+        ["docker", "compose", "-f", DOCKER_COMPOSE_FILE, "down", "-v", "--remove-orphans"],
+        capture_output=True,
+        check=False
+    )
+
+
+@pytest.fixture
+def db_session(db_engine: Engine) -> Generator[Session, None, None]:
+    """Create a new database session for each test."""
+    with Session(db_engine) as session:
+        yield session
+        session.rollback()
+
+
+utf8_data: str = """
+Email template with UTF-8 content:
+- Japanese: こんにちは世界
+"""
+
+
+class TestTapirEmailTemplateUtf8:
+    """Test TapirEmailTemplate with UTF-8 data in Utf8String and Utf8Text columns."""
+
+    def test_insert_and_read_utf8_data(self, db_session: Session) -> None:
+        """Test that UTF-8 characters can be stored and retrieved correctly."""
+        # UTF-8 test strings including various scripts
+        utf8_short_name = "test_tmpl"
+        utf8_long_name = "Test Template with UTF-8: 日本語"
+
+        # Create the template using the test_user (user_id=1)
+        template = TapirEmailTemplate(
+            short_name=utf8_short_name,
+            lang="en",
+            long_name=utf8_long_name,
+            data=utf8_data,
+            sql_statement="SELECT 1",
+            update_date=0,
+            created_by=1,  # test_user
+            updated_by=1,  # test_user
+            workflow_status=0,
+            flag_system=0,
+        )
+
+        db_session.add(template)
+        db_session.commit()
+
+        # Refresh to get the auto-generated template_id
+        db_session.refresh(template)
+        template_id = template.template_id
+
+        # Clear the session cache and re-fetch from database
+        db_session.expire_all()
+
+        # Query the template back
+        fetched = db_session.get(TapirEmailTemplate, template_id)
+
+        # Verify the UTF-8 data was stored and retrieved correctly
+        assert fetched is not None
+        assert fetched.data == utf8_data
+        assert "こんにちは世界" in fetched.data
+
+        # Clean up
+        db_session.delete(fetched)
+        db_session.commit()
+
+    def test_utf8_boundary_characters(self, db_session: Session) -> None:
+        """Test boundary UTF-8 characters (1-byte, 2-byte, 3-byte, 4-byte sequences)."""
+        # 1-byte: ASCII (U+0000 to U+007F)
+        # 2-byte: Latin, Greek, etc. (U+0080 to U+07FF)
+        # 3-byte: CJK, etc. (U+0800 to U+FFFF)
+
+        boundary_data = (
+            "ASCII: Hello "
+            "2-byte: é ñ ü ß "
+            "3-byte: 日本語 "
+        )
+
+        template = TapirEmailTemplate(
+            short_name="boundary",
+            lang="en",
+            long_name="Boundary Test",
+            data=boundary_data,
+            sql_statement="SELECT 1",
+            update_date=0,
+            created_by=1,
+            updated_by=1,
+            workflow_status=0,
+            flag_system=0,
+        )
+
+        db_session.add(template)
+        db_session.commit()
+        db_session.refresh(template)
+        template_id = template.template_id
+
+        db_session.expire_all()
+        fetched = db_session.get(TapirEmailTemplate, template_id)
+
+        assert fetched is not None
+        assert fetched.data == boundary_data
+
+        # Clean up
+        db_session.delete(fetched)
+        db_session.commit()


### PR DESCRIPTION
Sorry for the inconvenience. 

The column expression didn't know to ask the class to post process. 

The tests added (not sure this runs with GHA. I will find it out soon enough).

Testing started at 5:49 PM ...
Connected to pydev debugger (build 251.23774.444)
Launching pytest with arguments /home/ntai/arxiv/arxiv-base/tests/test_utf8_columns.py --no-header --no-summary -q in /home/ntai/arxiv/arxiv-base/tests

============================= test session starts ==============================
collecting ... collected 2 items

test_utf8_columns.py::TestTapirEmailTemplateUtf8::test_insert_and_read_utf8_data 
test_utf8_columns.py::TestTapirEmailTemplateUtf8::test_utf8_boundary_characters 

============================== 2 passed in 20.37s ==============================
PASSED [ 50%]PASSED [100%]
Process finished with exit code 0


https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/sql/type_api.py#L1596-L1600

The intension of TypeDecorator is to allow the post-process the returned data, and not quite sure why it broke.  I swear that I've seen process_return_value was trigged in my debugger. It is now force-feeding the decorator type in the column experssion which I should not have to do it, as the column type has already been mapped in the column type. 

