### PR TITLE
[WOMBAT-359] Adopt Utf8Text for arXiv_admin_log.logtext

### DIFF
--- a/.github/workflows/pullrequest_tests.yaml
+++ b/.github/workflows/pullrequest_tests.yaml
@@ -67,7 +67,8 @@ jobs:
 
       - name: Upload coverage HTML report
         uses: actions/upload-artifact@v4
-        if: success()
+        # when running "gh act", this step cannot be executed as this is running locally
+        if: success() && !env.ACT
         with:
           name: coverage-report
           path: htmlcov/

--- a/.github/workflows/pullrequest_tests.yaml
+++ b/.github/workflows/pullrequest_tests.yaml
@@ -27,6 +27,10 @@ jobs:
           # Install with QA/gcld3
           poetry install --with=dev --no-ansi --extras qa
 
+      - name: Run /tests
+        run: |
+          poetry run pytest tests
+
       - name: Run db/test with MySQL docker
         run: |
           sudo apt update

--- a/arxiv/db/arxiv-db-metadata.yaml
+++ b/arxiv/db/arxiv-db-metadata.yaml
@@ -42,7 +42,7 @@ Subscription_UniversalInstitutionIP:
 arXiv_admin_log:
   class_name: AdminLog
   columns:
-    logtext: "mapped_column(Utf8Text.class_factory())"
+    logtext: "mapped_column(Utf8Text.column_factory())"
     updated: "mapped_column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP'), server_onupdate=text('CURRENT_TIMESTAMP'))"
 
 arXiv_admin_metadata:
@@ -429,9 +429,9 @@ tapir_email_mailings:
 tapir_email_templates:
   class_name: TapirEmailTemplate
   columns:
-    short_name: "mapped_column(Utf8String.class_factory(32), nullable=False, server_default=FetchedValue())"
-    long_name: "mapped_column(Utf8String.class_factory(255), nullable=False, server_default=FetchedValue())"
-    data: "mapped_column(Utf8Text.class_factory(), nullable=False)"
+    short_name: "mapped_column(Utf8String.column_factory(32), nullable=False, server_default=FetchedValue())"
+    long_name: "mapped_column(Utf8String.column_factory(255), nullable=False, server_default=FetchedValue())"
+    data: "mapped_column(Utf8Text.column_factory(), nullable=False)"
 
 tapir_email_tokens:
   class_name: TapirEmailToken

--- a/arxiv/db/arxiv-db-metadata.yaml
+++ b/arxiv/db/arxiv-db-metadata.yaml
@@ -42,8 +42,9 @@ Subscription_UniversalInstitutionIP:
 arXiv_admin_log:
   class_name: AdminLog
   columns:
+    logtext: "mapped_column(Utf8Text.class_factory())"
     updated: "mapped_column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP'), server_onupdate=text('CURRENT_TIMESTAMP'))"
-  
+
 arXiv_admin_metadata:
   class_name: AdminMetadata
   table_args:
@@ -428,9 +429,9 @@ tapir_email_mailings:
 tapir_email_templates:
   class_name: TapirEmailTemplate
   columns:
-    short_name: "mapped_column(Utf8String(32), nullable=False, server_default=FetchedValue())"
-    long_name: "mapped_column(Utf8String(255), nullable=False, server_default=FetchedValue())"
-    data: "mapped_column(Utf8Text, nullable=False)"
+    short_name: "mapped_column(Utf8String.class_factory(32), nullable=False, server_default=FetchedValue())"
+    long_name: "mapped_column(Utf8String.class_factory(255), nullable=False, server_default=FetchedValue())"
+    data: "mapped_column(Utf8Text.class_factory(), nullable=False)"
 
 tapir_email_tokens:
   class_name: TapirEmailToken

--- a/arxiv/db/column_types.py
+++ b/arxiv/db/column_types.py
@@ -32,7 +32,7 @@ class BinaryStringComparator(UserDefinedType.Comparator):
             # Encode the string to bytes using UTF-8
             other = other.encode('utf-8')
         # Compare using BINARY cast on both sides
-        return operator(func.binary(self.expr), func.binary(other))
+        return operator(func.cast(self.expr, LargeBinary), func.cast(other, LargeBinary))
 
     def contains(self, other: Any, **kwargs: Any) -> Any:
         """Override contains to work with binary data."""
@@ -40,21 +40,21 @@ class BinaryStringComparator(UserDefinedType.Comparator):
             other = other.encode('utf-8')
         # Use LIKE with BINARY
         pattern = b'%' + other + b'%'
-        return func.binary(self.expr).like(func.binary(pattern))
+        return func.cast(self.expr, LargeBinary).like(func.cast(pattern, LargeBinary))
 
     def startswith(self, other: Any, escape: Optional[str] = None, autoescape: bool = False) -> Any:
         """Override startswith to work with binary data."""
         if isinstance(other, str):
             other = other.encode('utf-8')
         pattern = other + b'%'
-        return func.binary(self.expr).like(func.binary(pattern))
+        return func.cast(self.expr, LargeBinary).like(func.cast(pattern, LargeBinary))
 
     def endswith(self, other: Any, escape: Optional[str] = None, autoescape: bool = False) -> Any:
         """Override endswith to work with binary data."""
         if isinstance(other, str):
             other = other.encode('utf-8')
         pattern = b'%' + other
-        return func.binary(self.expr).like(func.binary(pattern))
+        return func.cast(self.expr, LargeBinary).like(func.cast(pattern, LargeBinary))
 
 
 class BinaryStringType(TypeDecorator):
@@ -167,7 +167,7 @@ class BinaryStringType(TypeDecorator):
         The BINARY() cast bypasses MySQL's character set validation,
         allowing UTF-8 bytes to be stored in latin-1 columns.
         """
-        return func.binary(bindvalue)
+        return func.cast(bindvalue, LargeBinary)
 
     def column_expression(self, col: Any) -> Any:
         """Wrap column in BINARY cast for SELECT queries.
@@ -283,7 +283,7 @@ class TranscodedText(TypeDecorator):
         The BINARY() cast bypasses MySQL's character set validation,
         allowing UTF-8 bytes to be stored in latin-1 columns.
         """
-        return func.binary(bindvalue)
+        return func.cast(bindvalue, LargeBinary)
 
     def column_expression(self, col: Any) -> Any:
         """Wrap column in BINARY cast for SELECT queries.

--- a/arxiv/db/column_types.py
+++ b/arxiv/db/column_types.py
@@ -3,8 +3,10 @@
 These TypeDecorators handle transcoding from bytes to strings based on the column's character set.
 """
 
-from typing import Optional, Any
+from typing import Optional, Any, Type
 from sqlalchemy import TypeDecorator, String, Text, LargeBinary, func
+from sqlalchemy.sql.type_api import _CT, ColumnElement, TypeEngine
+from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.dialects import mysql
 from sqlalchemy.types import UserDefinedType
 from logging import getLogger
@@ -19,11 +21,11 @@ class BinaryStringComparator(UserDefinedType.Comparator):
     by encoding the comparison value as bytes and using binary comparison.
     """
 
-    def __clause_element__(self):
+    def __clause_element__(self) -> ColumnElement[_CT]:
         """Return the column without BINARY cast for comparisons."""
         return self.expr
 
-    def _binary_compare(self, other, operator):
+    def _binary_compare(self, other: Any, operator: Any) -> Any:
         """Helper to encode the comparison value and use binary comparison."""
         if isinstance(other, str):
             # Encode the string to bytes using UTF-8
@@ -31,7 +33,7 @@ class BinaryStringComparator(UserDefinedType.Comparator):
         # Compare using BINARY cast on both sides
         return operator(func.binary(self.expr), func.binary(other))
 
-    def contains(self, other, **kwargs):
+    def contains(self, other: Any, **kwargs: Any) -> Any:
         """Override contains to work with binary data."""
         if isinstance(other, str):
             other = other.encode('utf-8')
@@ -39,14 +41,14 @@ class BinaryStringComparator(UserDefinedType.Comparator):
         pattern = b'%' + other + b'%'
         return func.binary(self.expr).like(func.binary(pattern))
 
-    def startswith(self, other, **kwargs):
+    def startswith(self, other: Any, escape: Optional[str] = None, autoescape: bool = False) -> Any:
         """Override startswith to work with binary data."""
         if isinstance(other, str):
             other = other.encode('utf-8')
         pattern = other + b'%'
         return func.binary(self.expr).like(func.binary(pattern))
 
-    def endswith(self, other, **kwargs):
+    def endswith(self, other: Any, escape: Optional[str] = None, autoescape: bool = False) -> Any:
         """Override endswith to work with binary data."""
         if isinstance(other, str):
             other = other.encode('utf-8')
@@ -70,10 +72,12 @@ class BinaryStringType(TypeDecorator):
     impl = String
     cache_ok = False  # column_expression/bind_expression modify SQL generation
 
+    comparator_factory: Type[BinaryStringComparator] = BinaryStringComparator
+
     def __init__(self, length: Optional[int] = None,
                  charset: Optional[str] = None,
                  fallback_charset: str = 'utf-8',
-                 **kwargs):
+                 **kwargs: Any) -> None:
         """
         Args:
             length: Maximum string length (for VARCHAR)
@@ -86,18 +90,13 @@ class BinaryStringType(TypeDecorator):
         self.charset = charset
         self.fallback_charset = fallback_charset
 
-    @property
-    def comparator_factory(self):
-        """Use custom comparator for binary string operations."""
-        return BinaryStringComparator
-
-    def load_dialect_impl(self, dialect):
+    def load_dialect_impl(self, dialect: Dialect) -> TypeEngine[Any]:
         """Use MySQL-specific VARCHAR type."""
         if dialect.name == 'mysql':
             return dialect.type_descriptor(mysql.VARCHAR(length=self.length))
         return dialect.type_descriptor(String(length=self.length))
 
-    def process_result_value(self, value: Any, dialect) -> Optional[str]:
+    def process_result_value(self, value: Any, dialect: Dialect) -> Optional[str]:
         """Convert bytes from database to string.
 
         When use_unicode=False, MySQL connector returns bytes.
@@ -112,7 +111,7 @@ class BinaryStringType(TypeDecorator):
 
         # Not bytes, return as-is
         if not isinstance(value, bytes):
-            return value
+            return str(value)
 
         # Transcode bytes to string
         if self.charset:
@@ -129,7 +128,7 @@ class BinaryStringType(TypeDecorator):
             except UnicodeDecodeError:
                 return value.decode(self.fallback_charset, errors='replace')
 
-    def process_bind_param(self, value: Any, dialect) -> Optional[bytes]:
+    def process_bind_param(self, value: Any, dialect: Dialect) -> Optional[bytes]:
         """Handle encoding for INSERT/UPDATE.
 
         When use_unicode=False, we encode strings to bytes using the target charset.
@@ -146,18 +145,17 @@ class BinaryStringType(TypeDecorator):
             return value
 
         # Convert to string first if needed
-        if not isinstance(value, str):
-            value = str(value)
+        str_value: str = value if isinstance(value, str) else str(value)
 
         # Encode to bytes using the target charset
         target_charset = self.charset or 'utf8'
         try:
-            return value.encode(target_charset)
+            return str_value.encode(target_charset)
         except UnicodeEncodeError as e:
             logger.warning(f"Failed to encode with {target_charset}, using utf8 with replace: {e}")
-            return value.encode('utf8', errors='replace')
+            return str_value.encode('utf8', errors='replace')
 
-    def bind_expression(self, bindvalue):
+    def bind_expression(self, bindvalue: Any) -> Any:
         """Wrap bind parameters with MySQL's BINARY() function.
 
         This makes SQLAlchemy generate SQL like:
@@ -170,7 +168,7 @@ class BinaryStringType(TypeDecorator):
         """
         return func.binary(bindvalue)
 
-    def column_expression(self, col):
+    def column_expression(self, col: Any) -> Any:
         """Wrap column in BINARY cast for SELECT queries.
 
         This makes SQLAlchemy generate SQL like:
@@ -199,9 +197,11 @@ class TranscodedText(TypeDecorator):
     impl = Text
     cache_ok = False  # column_expression/bind_expression modify SQL generation
 
+    comparator_factory: Type[BinaryStringComparator] = BinaryStringComparator
+
     def __init__(self, charset: Optional[str] = None,
                  fallback_charset: str = 'latin1',
-                 **kwargs):
+                 **kwargs: Any) -> None:
         """
         Args:
             charset: Expected character set ('utf8mb3', 'utf8mb4', 'latin1', etc.)
@@ -213,18 +213,13 @@ class TranscodedText(TypeDecorator):
         self.charset = charset
         self.fallback_charset = fallback_charset
 
-    @property
-    def comparator_factory(self):
-        """Use custom comparator for binary string operations."""
-        return BinaryStringComparator
-
-    def load_dialect_impl(self, dialect):
+    def load_dialect_impl(self, dialect: Dialect) -> TypeEngine[Any]:
         """Use MySQL-specific TEXT type."""
         if dialect.name == 'mysql':
             return dialect.type_descriptor(mysql.TEXT())
         return dialect.type_descriptor(Text())
 
-    def process_result_value(self, value: Any, dialect) -> Optional[str]:
+    def process_result_value(self, value: Any, dialect: Dialect) -> Optional[str]:
         """Convert bytes from database to string."""
         if value is None:
             return None
@@ -233,7 +228,7 @@ class TranscodedText(TypeDecorator):
             return value
 
         if not isinstance(value, bytes):
-            return value
+            return str(value)
 
         # Transcode bytes to string
         if self.charset:
@@ -249,7 +244,7 @@ class TranscodedText(TypeDecorator):
             except UnicodeDecodeError:
                 return value.decode(self.fallback_charset, errors='replace')
 
-    def process_bind_param(self, value: Any, dialect) -> Optional[bytes]:
+    def process_bind_param(self, value: Any, dialect: Dialect) -> Optional[bytes]:
         """Handle encoding for INSERT/UPDATE.
 
         When use_unicode=False, we encode strings to bytes using the target charset.
@@ -266,18 +261,17 @@ class TranscodedText(TypeDecorator):
             return value
 
         # Convert to string first if needed
-        if not isinstance(value, str):
-            value = str(value)
+        str_value: str = value if isinstance(value, str) else str(value)
 
         # Encode to bytes using the target charset
         target_charset = self.charset or 'utf8'
         try:
-            return value.encode(target_charset)
+            return str_value.encode(target_charset)
         except UnicodeEncodeError as e:
             logger.warning(f"Failed to encode with {target_charset}, using utf8 with replace: {e}")
-            return value.encode('utf8', errors='replace')
+            return str_value.encode('utf8', errors='replace')
 
-    def bind_expression(self, bindvalue):
+    def bind_expression(self, bindvalue: Any) -> Any:
         """Wrap bind parameters with MySQL's BINARY() function.
 
         This makes SQLAlchemy generate SQL like:
@@ -290,7 +284,7 @@ class TranscodedText(TypeDecorator):
         """
         return func.binary(bindvalue)
 
-    def column_expression(self, col):
+    def column_expression(self, col: Any) -> Any:
         """Wrap column in BINARY cast for SELECT queries.
 
         This makes SQLAlchemy generate SQL like:
@@ -311,12 +305,12 @@ class Utf8String(BinaryStringType):
     """VARCHAR column with utf8mb3 encoding."""
     cache_ok = False
 
-    def __init__(self, length: Optional[int] = None, **kwargs):
+    def __init__(self, length: Optional[int] = None, **kwargs: Any) -> None:
         super().__init__(length=length, charset='utf-8', **kwargs)
 
     @classmethod
-    def class_factory(cls, length: Optional[int] = None, **kwargs):
-        """Return Utf8String with a plain String fallback for SQLite."""
+    def column_factory(cls, length: Optional[int] = None, **kwargs: Any) -> "Utf8String":
+        """Return Utf8String for MySQL with a plain String fallback for SQLite."""
         return cls(length=length, **kwargs).with_variant(String(length=length), "sqlite")
 
 
@@ -324,11 +318,10 @@ class Utf8Text(TranscodedText):
     """TEXT column with utf8mb3 encoding."""
     cache_ok = False
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(charset='utf-8', **kwargs)
 
     @classmethod
-    def class_factory(cls, **kwargs):
-        """Return Utf8Text with a plain Text fallback for SQLite."""
+    def column_factory(cls, **kwargs: Any) -> "Utf8Text":
+        """Return Utf8Text for MySQL with a plain Text fallback for SQLite."""
         return cls(**kwargs).with_variant(Text, "sqlite")
-

--- a/arxiv/db/column_types.py
+++ b/arxiv/db/column_types.py
@@ -5,10 +5,11 @@ These TypeDecorators handle transcoding from bytes to strings based on the colum
 
 from typing import Optional, Any, Type
 from sqlalchemy import TypeDecorator, String, Text, LargeBinary, func
-from sqlalchemy.sql.type_api import _CT, ColumnElement, TypeEngine
+from sqlalchemy.sql.type_api import TypeEngine, _CT
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.dialects import mysql
 from sqlalchemy.types import UserDefinedType
+from sqlalchemy.sql.elements import ColumnElement
 from logging import getLogger
 
 logger = getLogger(__name__)

--- a/arxiv/db/column_types.py
+++ b/arxiv/db/column_types.py
@@ -314,6 +314,11 @@ class Utf8String(BinaryStringType):
     def __init__(self, length: Optional[int] = None, **kwargs):
         super().__init__(length=length, charset='utf-8', **kwargs)
 
+    @classmethod
+    def class_factory(cls, length: Optional[int] = None, **kwargs):
+        """Return Utf8String with a plain String fallback for SQLite."""
+        return cls(length=length, **kwargs).with_variant(String(length=length), "sqlite")
+
 
 class Utf8Text(TranscodedText):
     """TEXT column with utf8mb3 encoding."""
@@ -321,4 +326,9 @@ class Utf8Text(TranscodedText):
 
     def __init__(self, **kwargs):
         super().__init__(charset='utf-8', **kwargs)
+
+    @classmethod
+    def class_factory(cls, **kwargs):
+        """Return Utf8Text with a plain Text fallback for SQLite."""
+        return cls(**kwargs).with_variant(Text, "sqlite")
 

--- a/arxiv/db/models.py
+++ b/arxiv/db/models.py
@@ -124,7 +124,7 @@ class AdminLog(Base):
     host: Mapped[Optional[str]] = mapped_column(String(64))
     program: Mapped[Optional[str]] = mapped_column(String(20))
     command: Mapped[Optional[str]] = mapped_column(String(20), index=True)
-    logtext: Mapped[Optional[str]] = mapped_column(Utf8Text.class_factory())
+    logtext: Mapped[Optional[str]] = mapped_column(Utf8Text.column_factory())
     document_id: Mapped[Optional[int]] = mapped_column(Integer)
     submission_id: Mapped[Optional[int]] = mapped_column(Integer, index=True)
     notify: Mapped[Optional[int]] = mapped_column(Integer, server_default=FetchedValue())
@@ -1625,10 +1625,10 @@ class TapirEmailTemplate(Base):
     __table_args__ = (Index("short_name", "short_name", "lang", unique=True), {"mysql_charset": "latin1"})
 
     template_id: Mapped[intpk]
-    short_name: Mapped[str] = mapped_column(Utf8String.class_factory(32), nullable=False, server_default=FetchedValue())
+    short_name: Mapped[str] = mapped_column(Utf8String.column_factory(32), nullable=False, server_default=FetchedValue())
     lang: Mapped[str] = mapped_column(String(2), nullable=False, server_default=FetchedValue())
-    long_name: Mapped[str] = mapped_column(Utf8String.class_factory(255), nullable=False, server_default=FetchedValue())
-    data: Mapped[str] = mapped_column(Utf8Text.class_factory(), nullable=False)
+    long_name: Mapped[str] = mapped_column(Utf8String.column_factory(255), nullable=False, server_default=FetchedValue())
+    data: Mapped[str] = mapped_column(Utf8Text.column_factory(), nullable=False)
     sql_statement: Mapped[str] = mapped_column(Text, nullable=False)
     update_date: Mapped[int] = mapped_column(Integer, nullable=False, index=True, server_default=FetchedValue())
     created_by: Mapped[int] = mapped_column(ForeignKey("tapir_users.user_id"), nullable=False, index=True, server_default=FetchedValue())

--- a/arxiv/db/models.py
+++ b/arxiv/db/models.py
@@ -124,7 +124,7 @@ class AdminLog(Base):
     host: Mapped[Optional[str]] = mapped_column(String(64))
     program: Mapped[Optional[str]] = mapped_column(String(20))
     command: Mapped[Optional[str]] = mapped_column(String(20), index=True)
-    logtext: Mapped[Optional[str]] = mapped_column(Text)
+    logtext: Mapped[Optional[str]] = mapped_column(Utf8Text.class_factory())
     document_id: Mapped[Optional[int]] = mapped_column(Integer)
     submission_id: Mapped[Optional[int]] = mapped_column(Integer, index=True)
     notify: Mapped[Optional[int]] = mapped_column(Integer, server_default=FetchedValue())
@@ -1625,10 +1625,10 @@ class TapirEmailTemplate(Base):
     __table_args__ = (Index("short_name", "short_name", "lang", unique=True), {"mysql_charset": "latin1"})
 
     template_id: Mapped[intpk]
-    short_name: Mapped[str] = mapped_column(Utf8String(32), nullable=False, server_default=FetchedValue())
+    short_name: Mapped[str] = mapped_column(Utf8String.class_factory(32), nullable=False, server_default=FetchedValue())
     lang: Mapped[str] = mapped_column(String(2), nullable=False, server_default=FetchedValue())
-    long_name: Mapped[str] = mapped_column(Utf8String(255), nullable=False, server_default=FetchedValue())
-    data: Mapped[str] = mapped_column(Utf8Text, nullable=False)
+    long_name: Mapped[str] = mapped_column(Utf8String.class_factory(255), nullable=False, server_default=FetchedValue())
+    data: Mapped[str] = mapped_column(Utf8Text.class_factory(), nullable=False)
     sql_statement: Mapped[str] = mapped_column(Text, nullable=False)
     update_date: Mapped[int] = mapped_column(Integer, nullable=False, index=True, server_default=FetchedValue())
     created_by: Mapped[int] = mapped_column(ForeignKey("tapir_users.user_id"), nullable=False, index=True, server_default=FetchedValue())

--- a/development/db_codegen.py
+++ b/development/db_codegen.py
@@ -498,12 +498,15 @@ def is_port_open(host: str, port: int):
 def run_mysql_container(port: int):
     """Start a mysql docker"""
     mysql_image = "mysql:8.4.5"
+    codegen_db_container_name = "mysql-codegen-db"
     try:
+        subprocess.run(["docker", "rm", "-f", codegen_db_container_name],
+                       capture_output=True)
         subprocess.run(["docker", "pull", mysql_image], check=True)
 
         subprocess.run(
             [
-                "docker", "run", "-d", "--name", "mysql-test",
+                "docker", "run", "-d", "--name", codegen_db_container_name,
                 "-e", "MYSQL_ROOT_PASSWORD=testpassword",
                 "-e", "MYSQL_USER=testuser",
                 "-e", "MYSQL_PASSWORD=testpassword",
@@ -579,7 +582,9 @@ def main() -> None:
     p_outfile = os.path.join(arxiv_dir, "db/autogen_models.py")
     db_metadata = os.path.join(arxiv_dir, "db/arxiv-db-metadata.yaml")
 
-    codegen_dir = os.path.join(arxiv_base_dir, "development/sqlacodegen")
+    dev_dir = os.path.join(arxiv_base_dir, "development")
+    codegen_dir = os.path.join(dev_dir, "sqlacodegen")
+    logging.info(f"codegen_dir - {codegen_dir}")
 
     # If there is no MySQL up and running, start a container
     if not is_port_open("127.0.0.1", mysql_port):
@@ -589,7 +594,6 @@ def main() -> None:
                 break
             time.sleep(1)
 
-
     # Load the arxiv_db_schema.sql to the database.
     load_sql_file(os.path.join(arxiv_dir, "db/arxiv_db_schema.sql"), mysql_port, ssl_enabled)
 
@@ -597,9 +601,13 @@ def main() -> None:
     ssl_flags = "" if ssl_enabled else "?ssl=false&ssl_mode=DISABLED"
     p_url = f"mysql://testuser:testpassword@127.0.0.1:{mysql_port}/testdb" + ssl_flags
 
-    sys.path.append(os.path.join(codegen_dir, "src"))
+    env = os.environ.copy()
+    pythonpath = os.path.join(codegen_dir, "src")
+    if env.get("PYTHONPATH"):
+        pythonpath = pythonpath + os.pathsep + env["PYTHONPATH"]
+    env["PYTHONPATH"] = pythonpath
     subprocess.run(['venv/bin/python', '-m', 'sqlacodegen', p_url, '--outfile', p_outfile,
-                    '--model-metadata', db_metadata], check=True, cwd=arxiv_base_dir)
+                    '--model-metadata', db_metadata], check=True, cwd=arxiv_base_dir, env=env)
 
     # autogen_models.py
     with open(p_outfile, 'r') as src:

--- a/development/db_codegen_app.py
+++ b/development/db_codegen_app.py
@@ -4,7 +4,7 @@ Interactive Database Code Generator Application
 
 A multi-stage TUI application for generating code from database schemas.
 """
-
+import os
 import sys
 import subprocess
 import socket
@@ -685,7 +685,9 @@ class Stage5Screen(Container):
             self.show_status(f"[red]Error: Invalid port number: {mysql_port}[/red]")
             return
 
-        script_path = Path(codegen_script)
+        dev_dir_path = Path(os.path.abspath(__file__)).parent
+        arxiv_base_dir_path = dev_dir_path.parent
+        script_path = arxiv_base_dir_path / codegen_script
         if not script_path.exists():
             self.show_status(f"[red]Error: Script '{codegen_script}' does not exist[/red]")
             return
@@ -710,12 +712,13 @@ class Stage5Screen(Container):
 
         try:
             # Run the code generation script with arguments
+            # db_codegen.py is designed to run in the arxiv-base directory.
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
                 check=True,
-                cwd=Path.cwd()
+                cwd=arxiv_base_dir_path.as_posix()
             )
 
             # Display and save stdout

--- a/development/sqlacodegen/src/sqlacodegen/cli.py
+++ b/development/sqlacodegen/src/sqlacodegen/cli.py
@@ -27,13 +27,26 @@ except ImportError:
     pgvector = None
 
 if sys.version_info < (3, 10):
-    from importlib_metadata import entry_points, version
+    from importlib_metadata import version
 else:
-    from importlib.metadata import entry_points, version
+    from importlib.metadata import version
+
+
+def _discover_generators() -> dict[str, type]:
+    """Discover generator classes by introspecting the generators module."""
+    from . import generators as gen_module
+    from .generators import CodeGenerator
+    return {
+        cls.__name__.removesuffix("Generator").lower(): cls
+        for name in dir(gen_module)
+        if isinstance(cls := getattr(gen_module, name), type)
+        and issubclass(cls, CodeGenerator)
+        and cls is not CodeGenerator
+    }
 
 
 def main() -> None:
-    generators = {ep.name: ep for ep in entry_points(group="sqlacodegen.generators")}
+    generators = _discover_generators()
     parser = argparse.ArgumentParser(
         description="Generates SQLAlchemy model code from an existing database."
     )
@@ -111,7 +124,7 @@ def main() -> None:
                 raise Exception("not supported")
 
     # Instantiate the generator
-    generator_class = generators[args.generator].load()
+    generator_class = generators[args.generator]
 
     generator = generator_class(metadata, engine, options, **kwargs)
 

--- a/tests/test_utf8_columns.py
+++ b/tests/test_utf8_columns.py
@@ -8,6 +8,7 @@ The test fixture automatically manages the Docker MySQL container.
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import os
 import socket
 import subprocess
@@ -18,7 +19,7 @@ import pytest
 from sqlalchemy import Engine, create_engine, NullPool
 from sqlalchemy.orm import Session
 
-from arxiv.db.models import TapirEmailTemplate
+from arxiv.db.models import TapirEmailTemplate, AdminLog
 
 
 # Test database connection parameters
@@ -91,7 +92,7 @@ def db_engine() -> Generator[Engine, None, None]:
         pytest.fail(f"Failed to start MySQL container: {result.stderr}")
 
     # Wait for MySQL to be ready
-    if not wait_for_mysql(DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME, timeout=60):
+    if not wait_for_mysql(DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME, timeout=120):
         # Clean up on failure
         subprocess.run(
             ["docker", "compose", "-f", DOCKER_COMPOSE_FILE, "down", "-v"],
@@ -209,6 +210,45 @@ class TestTapirEmailTemplateUtf8:
 
         assert fetched is not None
         assert fetched.data == boundary_data
+
+        # Clean up
+        db_session.delete(fetched)
+        db_session.commit()
+
+
+class TestAdminLogUtf8:
+
+    def test_insert_and_read_utf8_data(self, db_session: Session) -> None:
+        """Test that UTF-8 characters can be stored and retrieved correctly."""
+        log_text = "ASCII: Hello 2-byte: é ñ ü ß 3-byte: 日本語"
+
+        # Create the template using the test_user (user_id=1)
+        timestamp = datetime.now(tz=timezone.utc)
+        log_entry = AdminLog(
+            logtime=timestamp.isoformat()[:24],
+            created=timestamp,
+            logtext=log_text,
+            old_created = timestamp,
+            updated=timestamp,
+        )
+
+        db_session.add(log_entry)
+        db_session.commit()
+
+        # Refresh to get the auto-generated template_id
+        db_session.refresh(log_entry)
+        log_id = log_entry.id
+
+        # Clear the session cache and re-fetch from database
+        db_session.expire_all()
+
+        # Query the template back
+        fetched = db_session.get(AdminLog, log_id)
+
+        # Verify the UTF-8 data was stored and retrieved correctly
+        assert fetched is not None
+        assert isinstance(fetched.logtext, str)
+        assert fetched.logtext == log_text
 
         # Clean up
         db_session.delete(fetched)


### PR DESCRIPTION
- Utf8Strig, Utf8Text's column type definition is factored out as `column_factory`  The factory function takes care of mysql/sqlite3 column type generation. 
- db_codegen: Instead of relying on installing sqlacodegen, use the checked out code for convenience
- fixed mypy warnings of column_types.py
- Running github action testing skips the GCP access while running locally
