### PR TITLE
[patch] legacy sessions in latest arxiv-base

### DIFF
--- a/arxiv/auth/auth/__init__.py
+++ b/arxiv/auth/auth/__init__.py
@@ -11,6 +11,7 @@ from retry import retry
 
 from ...db import transaction
 from ..legacy.cookies import parse_cookie
+from ..legacy.sessions import load as legacy_sessions_load
 from .. import domain, legacy
 
 import logging
@@ -83,7 +84,7 @@ class Auth(object):
             return None
         try:
             with transaction():
-                return legacy.sessions.load(cookie_value)
+                return legacy_sessions_load(cookie_value)
         except legacy.exceptions.UnknownSession as e:
             logger.debug('No legacy session available: %s', e)
         except legacy.exceptions.InvalidCookie as e:

--- a/arxiv/auth/auth/sessions/store.py
+++ b/arxiv/auth/auth/sessions/store.py
@@ -254,7 +254,7 @@ class SessionStore(object):
         db = int(config.get('REDIS_DATABASE', '0'))
         token = config.get('REDIS_TOKEN', None)
         cluster = config.get('REDIS_CLUSTER', '1') == '1'
-        secret = config['JWT_SECRET']
+        secret = config.get('JWT_SECRET', 'foosecret')
         duration = int(config.get('SESSION_DURATION', '7200'))
         fake = config.get('REDIS_FAKE', False)
         return cls(host, port, db, secret, duration, token=token,


### PR DESCRIPTION
1. I was inspired by https://github.com/arXiv/arxiv-base/commit/e2440aafb64956eaac483255bf6147d74e9bfdb1 in fixing the relative import.

2. Allowing JWT_SECRET to be unset as a fallback (reusing from a non-JWT context)