### PR TITLE
Adds proxy and sword to legacy auth scope

### DIFF
--- a/arxiv/auth/auth/scopes.py
+++ b/arxiv/auth/auth/scopes.py
@@ -44,6 +44,8 @@ class domains:
         """Fulltext extraction."""
         PREVIEW = 'preview'
         """Submission previews."""
+        SWORD = 'sword'
+        """Use and submit via SWORD."""
 
 class actions:
         """Known authorization actions."""
@@ -149,6 +151,9 @@ READ_PREVIEW = _scope_str(domains.PREVIEW, actions.READ)
 
 CREATE_PREVIEW = _scope_str(domains.PREVIEW, actions.CREATE)
 """Can create a new submission preview."""
+
+SWORD = _scope_str(domains.SWORD, actions.CREATE)
+"""Can create SWORD submissions."""
 
 GENERAL_USER = [
     READ_PUBLIC,    # Access to public APIs.

--- a/arxiv/auth/legacy/accounts.py
+++ b/arxiv/auth/legacy/accounts.py
@@ -121,6 +121,26 @@ def get_user_by_id(user_id: str) -> domain.User:
     return user
 
 
+def get_user_by_id_with_auths(user_id: str) -> Tuple[domain.User, domain.Authorizations]:
+    db_user, db_nick, db_profile = _get_user_data(user_id)
+    user = domain.User(
+        user_id=str(db_user.user_id),
+        username=db_nick.nickname,
+        email=db_user.email,
+        name=domain.UserFullName(
+            forename=db_user.first_name,
+            surname=db_user.last_name,
+            suffix=db_user.suffix_name
+        ),
+        profile=domain.UserProfile.from_orm(db_profile) if db_profile is not None else None
+    )
+    auths = domain.Authorizations(
+        classic=util.compute_capabilities(db_user),
+        scopes=util.get_scopes(db_user),
+    )
+    return user, auths
+
+
 def update(user: domain.User) -> Tuple[domain.User, domain.Authorizations]:
     """Update a user in the database."""
     if user.user_id is None:

--- a/arxiv/auth/legacy/tests/test_accounts.py
+++ b/arxiv/auth/legacy/tests/test_accounts.py
@@ -8,7 +8,7 @@ from arxiv.db import models
 from .. import authenticate, exceptions
 from .. import accounts
 from ... import domain
-
+from ...auth import scopes
 
 def get_user(session, user_id):
     """Helper to get user database objects by user id."""
@@ -242,3 +242,35 @@ def test_update_profile(app):
             assert db_profile.flag_group_physics == 1
             assert db_profile.archive == 'cs'
             assert db_profile.subject_class == 'IR'
+
+
+
+def test_proxy_and_xml(app):
+    profile = domain.UserProfile(
+        affiliation='Liar',
+        country='de',
+        rank=1,
+        submission_groups=['grp_cs', 'grp_q-bio'],
+        default_category=definitions.CATEGORIES['cs.DL'],
+        homepage_url='https://example.com'
+    )
+    name = domain.UserFullName(forename='J', surname='Lizard', suffix='i')
+    user = domain.User(username='goat', email='JL@example.edu',
+                       name=name, profile=profile)
+    ip = '1.2.3.4'
+    with app.app_context():
+        user, _ = accounts.register(user, 'apassword1', ip=ip, remote_host=ip)
+        _, auths = accounts.get_user_by_id_with_auths(user.user_id)
+        assert scopes.PROXY_SUBMISSION not in auths.scopes
+        assert scopes.SWORD not in auths.scopes
+        with transaction() as session:
+            _, _, db_profile = get_user(session, user.user_id)
+            assert db_profile
+            assert db_profile.flag_proxy==0
+            db_profile.flag_proxy=1
+            db_profile.flag_xml=1
+            session.commit()
+
+        _, auths = accounts.get_user_by_id_with_auths(user.user_id)
+        assert scopes.PROXY_SUBMISSION in auths.scopes
+        #assert scopes.SWORD in auths.scopes

--- a/arxiv/auth/legacy/util.py
+++ b/arxiv/auth/legacy/util.py
@@ -107,11 +107,17 @@ def _compute_capabilities(is_admin: int | bool, email_verified: int | bool, is_g
 
 def get_scopes(db_user: TapirUser) -> List[domain.Scope]:
     """Generate a list of authz scopes for a legacy user based on class."""
+    scps = []
     if db_user.policy_class == TapirPolicyClass.PUBLIC_USER:
-        return scopes.GENERAL_USER
-    if db_user.policy_class == TapirPolicyClass.ADMIN:
-        return scopes.ADMIN_USER
-    return []
+        scps.extend(scopes.GENERAL_USER)
+    elif db_user.policy_class == TapirPolicyClass.ADMIN:
+        scps.extend(scopes.ADMIN_USER)
+    if db_user.demographics:
+        if db_user.demographics.flag_proxy:
+            scps.append(scopes.PROXY_SUBMISSION)
+        if db_user.demographics.flag_xml:
+            scps.append(scopes.SWORD)
+    return scps
 
 
 def is_configured() -> bool:


### PR DESCRIPTION
Adds missing proxy and sword to scope provided by arxiv.auth.legacy