### PR TITLE
QA-100 checksum metadata

### DIFF
--- a/arxiv/metadata/__init__.py
+++ b/arxiv/metadata/__init__.py
@@ -1,7 +1,20 @@
 # placeholder
 
-from enum import StrEnum
-from enum import IntEnum
+from enum import IntEnum, StrEnum
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class MetadataProtocol(Protocol):
+    title: str
+    authors: str
+    abstract: str
+    comments: str
+    report_num: str
+    journal_ref: str
+    doi: str
+    msc_class: str
+    acm_class: str
 
 
 class Color(StrEnum):

--- a/arxiv/metadata/checksum.py
+++ b/arxiv/metadata/checksum.py
@@ -1,0 +1,24 @@
+"""checksum for arXiv metadata for use with QA."""
+import zlib
+
+from arxiv.metadata import MetadataProtocol
+
+_DIVIDER="𒑰"
+
+
+def checksum_metadata(submission: MetadataProtocol) -> int:
+    """Make a checksum using the fields of `MetadataProtocol`.
+
+    If this is the only function used from arxiv-base it can be installed
+    without other dependenices.
+    """
+    value= f"{submission.title}{_DIVIDER}"\
+        f"{submission.authors}{_DIVIDER}"\
+        f"{submission.abstract}{_DIVIDER}"\
+        f"{submission.comments}{_DIVIDER}"\
+        f"{submission.report_num}{_DIVIDER}"\
+        f"{submission.journal_ref}{_DIVIDER}"\
+        f"{submission.doi}{_DIVIDER}"\
+        f"{submission.msc_class}{_DIVIDER}"\
+        f"{submission.acm_class}"
+    return zlib.adler32(value.encode("utf-8"))

--- a/arxiv/metadata/metacheck.py
+++ b/arxiv/metadata/metacheck.py
@@ -1069,3 +1069,4 @@ def check_acm_class(v: str) -> MetadataCheckReport:
 # Check for \n but not \n<space><space> (a paragraph break) in abstract?
 # \n is not allowed in fields other than the abstract, right?
 
+

--- a/arxiv/metadata/metacheck.py
+++ b/arxiv/metadata/metacheck.py
@@ -1,27 +1,17 @@
-
 import re
-
+from collections import defaultdict
+from dataclasses import dataclass
 from typing import (
     Dict,
     Optional,
-    Protocol,
     Set,
     Tuple,
-    TypedDict,
-    runtime_checkable,
 )
-
-from dataclasses import dataclass
-
-from collections import defaultdict
 
 import gcld3
 
 from arxiv.authors import parse_author_affil
-
-from arxiv.metadata import FieldName
-from arxiv.metadata import Disposition
-from arxiv.metadata import Complaint
+from arxiv.metadata import Complaint, Disposition, FieldName, MetadataProtocol
 from arxiv.metadata.all_caps_words import KNOWN_WORDS_IN_ALL_CAPS
 
 ############################################################
@@ -271,18 +261,6 @@ class MetadataCheckReport:
 
 
 ############################################################
-
-@runtime_checkable
-class MetadataProtocol(Protocol):
-    title: str
-    authors: str
-    abstract: str
-    comments: str
-    report_num: str
-    journal_ref: str
-    doi: str
-    msc_class: str
-    acm_class: str
 
 @dataclass
 class Metadata:      # implements MetadataProtocol

--- a/arxiv/metadata/tests/test_checksum.py
+++ b/arxiv/metadata/tests/test_checksum.py
@@ -1,0 +1,16 @@
+from arxiv.metadata.checksum import checksum_metadata
+
+def test_checksum_metadata():
+    class Md1:
+        def __init__(self):
+                self.title="bogus value"
+                self.authors="bogus value"
+                self.abstract="bogus value"
+                self.comments="bogus value"
+                self.report_num="bogus value"
+                self.journal_ref="bogus value"
+                self.doi="bogus value"
+                self.msc_class="bogus value"
+                self.acm_class="bogus value"
+
+    assert checksum_metadata(Md1())

--- a/arxiv/metadata/tests/test_checksum.py
+++ b/arxiv/metadata/tests/test_checksum.py
@@ -13,4 +13,18 @@ def test_checksum_metadata():
                 self.msc_class="bogus value"
                 self.acm_class="bogus value"
 
-    assert checksum_metadata(Md1())
+    class Md2:
+        def __init__(self):
+                self.title="another value"
+                self.authors="another value"
+                self.abstract="another value"
+                self.comments="another value"
+                self.report_num="another value"
+                self.journal_ref="another value"
+                self.doi="another value"
+                self.msc_class="another value"
+                self.acm_class="another value"
+                
+    assert checksum_metadata(Md1()) == checksum_metadata(Md1())
+    assert checksum_metadata(Md2()) == checksum_metadata(Md2())
+    assert checksum_metadata(Md1()) != checksum_metadata(Md2())


### PR DESCRIPTION
Adds `checksum_metadata` and a test.

Moves a Protocol to __init__.py for sharing.

Removes \r from some files. This change is what is causing the large diffs that seem to be nothing. 

https://arxiv-org.atlassian.net/browse/QA-100