### PR TITLE
Config of servers in `arxiv.base.config.settings.URLS` fixed

### DIFF
--- a/arxiv/base/config.py
+++ b/arxiv/base/config.py
@@ -42,49 +42,49 @@ Usually the same as BASE_SERVER but can be configured.
 HELP_SERVER = os.environ.get("HELP_SERVER", "info.arxiv.org")
 
 URLS = [
-    ("a11y", "/help/web_accessibility.html", HELP_SERVER),
-    ("about", "/about", HELP_SERVER),
-    ("about_give", "/about/give.html", HELP_SERVER),
-    ("about_people", "/about/people/index.html", HELP_SERVER),
-    ("acknowledgment", "/about/ourmembers.html", HELP_SERVER),
-    ("contact", "/help/contact.html", HELP_SERVER),
-    ("copyright", "/help/license/index.html", HELP_SERVER),
-    ("faq", "/help/faq/index.html", HELP_SERVER),
-    ("help", "/help", HELP_SERVER),
-    ("help_archive_description", "/help/<archive>/index.html", HELP_SERVER),
-    ("help_identifier", "/help/arxiv_identifier.html", HELP_SERVER),
-    ("help_mathjax", "/help/mathjax.html", HELP_SERVER),
-    ("help_social_bookmarking", "/help/social_bookmarking", HELP_SERVER), # Does not resolve
-    ("help_submit", "/help/submit/index.html", HELP_SERVER),
-    ("help_trackback", "/help/trackback.html", HELP_SERVER),
-    ("new", "/", HELP_SERVER),    # this help page might be gone, use to go to very old news
-    ("privacy_policy", "/help/policies/privacy_policy.html", HELP_SERVER),
-    ("subscribe", "/help/subscribe", HELP_SERVER),
-    ("team", "/about/people/leadership_team.html", HELP_SERVER),
+    ("a11y", "/help/web_accessibility.html", "HELP_SERVER"),
+    ("about", "/about", "HELP_SERVER"),
+    ("about_give", "/about/give.html", "HELP_SERVER"),
+    ("about_people", "/about/people/index.html", "HELP_SERVER"),
+    ("acknowledgment", "/about/ourmembers.html", "HELP_SERVER"),
+    ("contact", "/help/contact.html", "HELP_SERVER"),
+    ("copyright", "/help/license/index.html", "HELP_SERVER"),
+    ("faq", "/help/faq/index.html", "HELP_SERVER"),
+    ("help", "/help", "HELP_SERVER"),
+    ("help_archive_description", "/help/<archive>/index.html", "HELP_SERVER"),
+    ("help_identifier", "/help/arxiv_identifier.html", "HELP_SERVER"),
+    ("help_mathjax", "/help/mathjax.html", "HELP_SERVER"),
+    ("help_social_bookmarking", "/help/social_bookmarking", "HELP_SERVER"), # Does not resolve
+    ("help_submit", "/help/submit/index.html", "HELP_SERVER"),
+    ("help_trackback", "/help/trackback.html", "HELP_SERVER"),
+    ("new", "/", "HELP_SERVER"),    # this help page might be gone, use to go to very old news
+    ("privacy_policy", "/help/policies/privacy_policy.html", "HELP_SERVER"),
+    ("subscribe", "/help/subscribe", "HELP_SERVER"),
+    ("team", "/about/people/leadership_team.html", "HELP_SERVER"),
 
-    ("abs", "/abs/<arxiv:paper_id>v<string:version>", BASE_SERVER),
-    ("abs_by_id", "/abs/<arxiv:paper_id>", BASE_SERVER),
-    ("pdf", "/pdf/<arxiv:paper_id>", BASE_SERVER),
+    ("abs", "/abs/<arxiv:paper_id>v<string:version>", "BASE_SERVER"),
+    ("abs_by_id", "/abs/<arxiv:paper_id>", "BASE_SERVER"),
+    ("pdf", "/pdf/<arxiv:paper_id>", "BASE_SERVER"),
 
-    ("canonical_pdf", "/pdf/<arxiv:paper_id>v<string:version>", CANONICAL_SERVER),
-    ("canonical_pdf_by_id", "/pdf/<arxiv:paper_id>", CANONICAL_SERVER),
-    ("canonical_abs", "/abs/<arxiv:paper_id>v<string:version>", CANONICAL_SERVER),
-    ("canonical_abs_by_id", "/abs/<arxiv:paper_id>", CANONICAL_SERVER),
+    ("canonical_pdf", "/pdf/<arxiv:paper_id>v<string:version>", "CANONICAL_SERVER"),
+    ("canonical_pdf_by_id", "/pdf/<arxiv:paper_id>", "CANONICAL_SERVER"),
+    ("canonical_abs", "/abs/<arxiv:paper_id>v<string:version>", "CANONICAL_SERVER"),
+    ("canonical_abs_by_id", "/abs/<arxiv:paper_id>", "CANONICAL_SERVER"),
 
-    ("clickthrough", "/ct", BASE_SERVER),
-    ("home", "/", BASE_SERVER),
-    ("ignore_me", "/IgnoreMe", BASE_SERVER),  # Anti-robot honneypot.
+    ("clickthrough", "/ct", "BASE_SERVER"),
+    ("home", "/", "BASE_SERVER"),
+    ("ignore_me", "/IgnoreMe", "BASE_SERVER"),  # Anti-robot honneypot.
 
-    ("account", "/user", AUTH_SERVER),
-    ("login", "/login", AUTH_SERVER),
-    ("logout", "/logout", AUTH_SERVER),
+    ("account", "/user", "AUTH_SERVER"),
+    ("login", "/login", "AUTH_SERVER"),
+    ("logout", "/logout", "AUTH_SERVER"),
 
-    ("create", "/user/create", SUBMIT_SERVER),
-    ("submit", "/submit", SUBMIT_SERVER),
+    ("create", "/user/create", "SUBMIT_SERVER"),
+    ("submit", "/submit", "SUBMIT_SERVER"),
 
-    ("search_advanced", "/search/advanced", SEARCH_SERVER),
-    ("search_archive", "/search/<archive>", SEARCH_SERVER),
-    ("search_box", "/search", SEARCH_SERVER),
+    ("search_advanced", "/search/advanced", "SEARCH_SERVER"),
+    ("search_archive", "/search/<archive>", "SEARCH_SERVER"),
+    ("search_box", "/search", "SEARCH_SERVER"),
 
     ("blog", "/arxiv", "blogs.cornell.edu"),
     ("library", "/", "library.cornell.edu"),
@@ -95,6 +95,10 @@ URLS = [
 """URLs for external services, for use with :func:`flask.url_for`.
 
 For details, see :mod:`arxiv.base.urls`.
+
+Note that the third item in the tuple is either a host name or a config var
+ending with _SERVER. To avoid having static values from import time, ones ending
+with _SERVER will be evaulated to values when the URL map is built.
 """
 
 # In order to provide something close to the config_url behavior, this will

--- a/arxiv/base/tests/test_urls_config.py
+++ b/arxiv/base/tests/test_urls_config.py
@@ -1,13 +1,11 @@
 """Tests for URLS config via env vars in :class:`.Base`."""
+import importlib
 from _pytest import monkeypatch
 import pytest
-from unittest import TestCase
 
 from flask import Flask, url_for
 
-from arxiv.base.config import CANONICAL_SERVER
 
-from .. import Base
 
 AUTH_SERVER_VALUE="auth.example.com"
 HELP_SERVER_VALUE="help.example.com"
@@ -16,24 +14,65 @@ SUBMIT_SERVER_VALUE="submit.example.com"
 SEARCH_SERVER_VALUE="search.example.com"
 
 @pytest.fixture
-def app(monkeypatch):
+def app_with_envvars(monkeypatch):
     monkeypatch.setenv("AUTH_SERVER", AUTH_SERVER_VALUE)
     monkeypatch.setenv("HELP_SERVER", HELP_SERVER_VALUE)
     monkeypatch.setenv("CANONICAL_SERVER", CANONICAL_SERVER_VALUE)
     monkeypatch.setenv("SUBMIT_SERVER", SUBMIT_SERVER_VALUE)
     monkeypatch.setenv("SEARCH_SERVER", SEARCH_SERVER_VALUE)
-    app = Flask(__name__)
-    Base(app)
-    return app
 
+    import os
+    assert os.environ.get("AUTH_SERVER") == AUTH_SERVER_VALUE
+
+    import arxiv.config
+    importlib.reload(arxiv.config)
+    from arxiv.config import settings
+
+    from .. import Base
+    app_with_envvars = Flask(__name__)
+    app_with_envvars.config.from_object(settings)
+    Base(app_with_envvars)
+    return app_with_envvars
+
+def test_monkeypatch_set_envvars(app_with_envvars):
+    with app_with_envvars.test_request_context('/home', method='GET'):
+        import os
+        assert os.environ.get("AUTH_SERVER") == AUTH_SERVER_VALUE
+
+def test_settings_gets_envvar(app_with_envvars):
+    with app_with_envvars.test_request_context('/home', method='GET'):
+        import arxiv.config
+        importlib.reload(arxiv.config)
+        from arxiv.config import settings
+        assert settings.AUTH_SERVER == AUTH_SERVER_VALUE
+        assert settings.HELP_SERVER == HELP_SERVER_VALUE
+        assert settings.CANONICAL_SERVER == CANONICAL_SERVER_VALUE
+        assert settings.SUBMIT_SERVER == SUBMIT_SERVER_VALUE
+        assert settings.SEARCH_SERVER == SEARCH_SERVER_VALUE
 
 @pytest.mark.parametrize("urlfor, path, server", [
     ('about','/about',HELP_SERVER_VALUE),
     ('login', '/login', AUTH_SERVER_VALUE),
     ('create','/user/create', SUBMIT_SERVER_VALUE),
-    ('search_box', 'search', SEARCH_SERVER_VALUE),
+    ('search_box', '/search', SEARCH_SERVER_VALUE),
 ])
-
-def test_server_configed_urls(app, urlfor, path, server):
-    with app.test_request_context('/home', method='GET'):
+def test_server_configed_urls(app_with_envvars, urlfor, path, server):
+    with app_with_envvars.test_request_context('/home', method='GET'):
         assert "https://" + server + path == url_for(urlfor)
+
+
+def test_w_base_server(monkeypatch):
+    BASE = "base.arxiv.org"
+    monkeypatch.setenv("BASE_SERVER", BASE)
+    import arxiv.config
+    importlib.reload(arxiv.config)
+    from arxiv.config import settings
+    app = Flask(__name__)
+    app.config.from_object(settings)
+    from .. import Base
+    Base(app)
+    with app.test_request_context('/home', method='GET'):
+        import os
+        assert os.environ.get("BASE_SERVER") == BASE
+        from arxiv.config import settings
+        assert settings.BASE_SERVER == BASE

--- a/arxiv/base/tests/test_urls_config.py
+++ b/arxiv/base/tests/test_urls_config.py
@@ -1,0 +1,39 @@
+"""Tests for URLS config via env vars in :class:`.Base`."""
+from _pytest import monkeypatch
+import pytest
+from unittest import TestCase
+
+from flask import Flask, url_for
+
+from arxiv.base.config import CANONICAL_SERVER
+
+from .. import Base
+
+AUTH_SERVER_VALUE="auth.example.com"
+HELP_SERVER_VALUE="help.example.com"
+CANONICAL_SERVER_VALUE="canonical.example.com"
+SUBMIT_SERVER_VALUE="submit.example.com"
+SEARCH_SERVER_VALUE="search.example.com"
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("AUTH_SERVER", AUTH_SERVER_VALUE)
+    monkeypatch.setenv("HELP_SERVER", HELP_SERVER_VALUE)
+    monkeypatch.setenv("CANONICAL_SERVER", CANONICAL_SERVER_VALUE)
+    monkeypatch.setenv("SUBMIT_SERVER", SUBMIT_SERVER_VALUE)
+    monkeypatch.setenv("SEARCH_SERVER", SEARCH_SERVER_VALUE)
+    app = Flask(__name__)
+    Base(app)
+    return app
+
+
+@pytest.mark.parametrize("urlfor, path, server", [
+    ('about','/about',HELP_SERVER_VALUE),
+    ('login', '/login', AUTH_SERVER_VALUE),
+    ('create','/user/create', SUBMIT_SERVER_VALUE),
+    ('search_box', 'search', SEARCH_SERVER_VALUE),
+])
+
+def test_server_configed_urls(app, urlfor, path, server):
+    with app.test_request_context('/home', method='GET'):
+        assert "https://" + server + path == url_for(urlfor)

--- a/arxiv/base/urls/__init__.py
+++ b/arxiv/base/urls/__init__.py
@@ -57,27 +57,34 @@ See ARXIVNG-2085.
 """
 import os
 import sys
-from typing import Dict, Any, List, Optional
-from urllib.parse import parse_qs, urlparse
+from typing import Dict, Optional
+from urllib.parse import urlparse
 from werkzeug.routing import Map, Rule, BuildError, MapAdapter
-from flask import current_app, g, Flask
+from flask import current_app, Flask
 
-from arxiv.base.exceptions import ConfigurationError
 from arxiv.base.converter import ArXivConverter
 from arxiv.base import logging
 from arxiv.base import config as base_config
+from arxiv.config import settings
 
 from .clickthrough import clickthrough_url
 from .links import urlize, urlizer, url_for_doi
 
 logger = logging.getLogger(__name__)
 
+def _server_name(app: Flask, host: str)-> str:
+    """Gets `host` with from `app.config[host]`.
+
+    Used to avoid static host values from import time."""
+    if host.endswith("_SERVER"):
+        return app.config.get(host, getattr(settings, host))
+    else:
+        return host
+
 
 def build_adapter(app: Flask) -> MapAdapter:
-    """Build a :class:`.MapAdapter` from configured URLs."""
-    # Get the base URLs (configured in this package).
+    """Build a :class:`werkzeug.routing.MapAdapter` from configured URLs."""
     configured_urls = {url[0]: url for url in base_config.URLS}
-
 
     # In order to provide something close to the config_url behavior, this will
     # look for ARXIV_{endpoint}_URL variables in the environ, and update `URLS`
@@ -85,8 +92,8 @@ def build_adapter(app: Flask) -> MapAdapter:
     for key, value in os.environ.items():
         if key.startswith("ARXIV_") and key.endswith("_URL"):
             endpoint = "_".join(key.split("_")[1:-1]).lower()
-            o = urlparse(value)
-            if not o.netloc:  # Doesn't raise an exception.
+            url = urlparse(value)
+            if not url.netloc:  # Doesn't raise an exception.
                 continue
             i: Optional[int]
             try:
@@ -96,15 +103,13 @@ def build_adapter(app: Flask) -> MapAdapter:
             if i is not None:
                 configured_urls[i] = (endpoint, o.path, o.netloc)
 
-    # Privilege ARXIV_URLs set on the application config.
-    current_urls = app.config.get('URLS', [])
-    if current_urls:
-        configured_urls.update({url[0]: url for url in current_urls})
+    # Privilege URLs already set on the app config
+    configured_urls.update({url[0]: url for url in app.config.get('URLS', [])})
+
     url_map = Map([
-        Rule(pattern, endpoint=name, host=host, build_only=True)
+        Rule(pattern, endpoint=name, host=_server_name(app, host), build_only=True)
         for name, pattern, host in configured_urls.values()
     ], converters={'arxiv': ArXivConverter}, host_matching=True)
-
     scheme = app.config.get('EXTERNAL_URL_SCHEME', 'https')
     base_host = app.config.get('BASE_SERVER', 'arxiv.org')
     adapter: MapAdapter = url_map.bind(base_host, url_scheme=scheme)

--- a/arxiv/config/__init__.py
+++ b/arxiv/config/__init__.py
@@ -1,10 +1,8 @@
 """Flask configuration."""
 import importlib.metadata
 from typing import Optional, List, Tuple
-import os
 from sqlalchemy.engine.interfaces import IsolationLevel
 from secrets import token_hex
-from urllib.parse import urlparse
 from pydantic import SecretStr
 from pydantic_settings import BaseSettings
 
@@ -60,49 +58,49 @@ class Settings(BaseSettings):
     HELP_SERVER: str = "info.arxiv.org"
 
     URLS: List[Tuple[str, str, str]] = [
-        ("a11y", "/help/web_accessibility.html", HELP_SERVER),
-        ("about", "/about", HELP_SERVER),
-        ("about_give", "/about/give.html", HELP_SERVER),
-        ("about_people", "/about/people/index.html", HELP_SERVER),
-        ("acknowledgment", "/about/ourmembers.html", HELP_SERVER),
-        ("contact", "/help/contact.html", HELP_SERVER),
-        ("copyright", "/help/license/index.html", HELP_SERVER),
-        ("faq", "/help/faq/index.html", HELP_SERVER),
-        ("help", "/help", HELP_SERVER),
-        ("help_archive_description", "/help/<archive>/index.html", HELP_SERVER),
-        ("help_identifier", "/help/arxiv_identifier.html", HELP_SERVER),
-        ("help_mathjax", "/help/mathjax.html", HELP_SERVER),
-        ("help_social_bookmarking", "/help/social_bookmarking", HELP_SERVER), # Does not resolve
-        ("help_submit", "/help/submit/index.html", HELP_SERVER),
-        ("help_trackback", "/help/trackback.html", HELP_SERVER),
-        ("new", "/", HELP_SERVER),    # this help page might be gone, use to go to very old news
-        ("privacy_policy", "/help/policies/privacy_policy.html", HELP_SERVER),
-        ("subscribe", "/help/subscribe", HELP_SERVER),
-        ("team", "/about/people/leadership_team.html", HELP_SERVER),
+        ("a11y", "/help/web_accessibility.html", "HELP_SERVER"),
+        ("about", "/about", "HELP_SERVER"),
+        ("about_give", "/about/give.html", "HELP_SERVER"),
+        ("about_people", "/about/people/index.html", "HELP_SERVER"),
+        ("acknowledgment", "/about/ourmembers.html", "HELP_SERVER"),
+        ("contact", "/help/contact.html", "HELP_SERVER"),
+        ("copyright", "/help/license/index.html", "HELP_SERVER"),
+        ("faq", "/help/faq/index.html", "HELP_SERVER"),
+        ("help", "/help", "HELP_SERVER"),
+        ("help_archive_description", "/help/<archive>/index.html", "HELP_SERVER"),
+        ("help_identifier", "/help/arxiv_identifier.html", "HELP_SERVER"),
+        ("help_mathjax", "/help/mathjax.html", "HELP_SERVER"),
+        ("help_social_bookmarking", "/help/social_bookmarking", "HELP_SERVER"), # Does not resolve
+        ("help_submit", "/help/submit/index.html", "HELP_SERVER"),
+        ("help_trackback", "/help/trackback.html", "HELP_SERVER"),
+        ("new", "/", "HELP_SERVER"),    # this help page might be gone, use to go to very old news
+        ("privacy_policy", "/help/policies/privacy_policy.html", "HELP_SERVER"),
+        ("subscribe", "/help/subscribe", "HELP_SERVER"),
+        ("team", "/about/people/leadership_team.html", "HELP_SERVER"),
 
-        ("abs", "/abs/<arxiv:paper_id>v<string:version>", BASE_SERVER),
-        ("abs_by_id", "/abs/<arxiv:paper_id>", BASE_SERVER),
-        ("pdf", "/pdf/<arxiv:paper_id>", BASE_SERVER),
+        ("abs", "/abs/<arxiv:paper_id>v<string:version>", "BASE_SERVER"),
+        ("abs_by_id", "/abs/<arxiv:paper_id>", "BASE_SERVER"),
+        ("pdf", "/pdf/<arxiv:paper_id>", "BASE_SERVER"),
 
-        ("canonical_pdf", "/pdf/<arxiv:paper_id>v<string:version>", CANONICAL_SERVER),
-        ("canonical_pdf_by_id", "/pdf/<arxiv:paper_id>", CANONICAL_SERVER),
-        ("canonical_abs", "/abs/<arxiv:paper_id>v<string:version>", CANONICAL_SERVER),
-        ("canonical_abs_by_id", "/abs/<arxiv:paper_id>", CANONICAL_SERVER),
+        ("canonical_pdf", "/pdf/<arxiv:paper_id>v<string:version>", "CANONICAL_SERVER"),
+        ("canonical_pdf_by_id", "/pdf/<arxiv:paper_id>", "CANONICAL_SERVER"),
+        ("canonical_abs", "/abs/<arxiv:paper_id>v<string:version>", "CANONICAL_SERVER"),
+        ("canonical_abs_by_id", "/abs/<arxiv:paper_id>", "CANONICAL_SERVER"),
 
-        ("clickthrough", "/ct", BASE_SERVER),
-        ("home", "/", BASE_SERVER),
-        ("ignore_me", "/IgnoreMe", BASE_SERVER),  # Anti-robot honneypot.
+        ("clickthrough", "/ct", "BASE_SERVER"),
+        ("home", "/", "BASE_SERVER"),
+        ("ignore_me", "/IgnoreMe", "BASE_SERVER"),  # Anti-robot honneypot.
 
-        ("account", "/user", AUTH_SERVER),
-        ("login", "/login", AUTH_SERVER),
-        ("logout", "/logout", AUTH_SERVER),
+        ("account", "/user", "AUTH_SERVER"),
+        ("login", "/login", "AUTH_SERVER"),
+        ("logout", "/logout", "AUTH_SERVER"),
 
-        ("create", "/user/create", SUBMIT_SERVER),
-        ("submit", "/submit", SUBMIT_SERVER),
+        ("create", "/user/create", "SUBMIT_SERVER"),
+        ("submit", "/submit", "SUBMIT_SERVER"),
 
-        ("search_advanced", "/search/advanced", SEARCH_SERVER),
-        ("search_archive", "/search/<archive>", SEARCH_SERVER),
-        ("search_box", "/search", SEARCH_SERVER),
+        ("search_advanced", "/search/advanced", "SEARCH_SERVER"),
+        ("search_archive", "/search/<archive>", "SEARCH_SERVER"),
+        ("search_box", "/search", "SEARCH_SERVER"),
 
         ("blog", "/arxiv", "blogs.cornell.edu"),
         ("library", "/", "library.cornell.edu"),


### PR DESCRIPTION

In browse, setting `AUTH_SERVER` env var did not work to alter the host set for /login.

This is due to the value for `AUTH_SERVER` used in `URLS` being fixed at class definition time. The values in the list of tuples in `settings.URLS` never got updated with any new values if `setting.AUTH_SERVER` was later set with the value from the env var.


