### PR TITLE
ARXIVCE-4340: Update link color and inline underlines for a11y

### DIFF
--- a/arxiv/base/static/css/arxivstyle.css
+++ b/arxiv/base/static/css/arxivstyle.css
@@ -1,15 +1,12 @@
-@charset "UTF-8";
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,700");
 /* changed when base text size is 14px */
 /*! bulma.io v0.7.2 | MIT License | github.com/jgthms/bulma */
 @keyframes spinAround {
   from {
-    transform: rotate(0deg);
-  }
+    transform: rotate(0deg); }
   to {
-    transform: rotate(359deg);
-  }
-}
+    transform: rotate(359deg); } }
+
 .tabs, .pagination-previous,
 .pagination-next,
 .pagination-link,
@@ -18,8 +15,7 @@
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;
-}
+  user-select: none; }
 
 .navbar-link:not(.is-arrowless)::after, .select:not(.is-multiple):not(.is-loading)::after {
   border: 3px solid transparent;
@@ -35,13 +31,11 @@
   top: 50%;
   transform: rotate(-45deg);
   transform-origin: center;
-  width: 0.625em;
-}
+  width: 0.625em; }
 
 .tabs:not(:last-child), .message:not(:last-child), .list:not(:last-child), .level:not(:last-child), .breadcrumb:not(:last-child), .highlight:not(:last-child), .block:not(:last-child), .title:not(:last-child),
 .subtitle:not(:last-child), .table-container:not(:last-child), .table:not(:last-child), .progress:not(:last-child), .notification:not(:last-child), .content:not(:last-child), .box:not(:last-child) {
-  margin-bottom: 1.5rem;
-}
+  margin-bottom: 1.5rem; }
 
 .modal-close, .delete {
   -moz-appearance: none;
@@ -63,60 +57,51 @@
   outline: none;
   position: relative;
   vertical-align: top;
-  width: 20px;
-}
-.modal-close::before, .delete::before, .modal-close::after, .delete::after {
-  background-color: hsl(0deg, 0%, 100%);
-  content: "";
-  display: block;
-  left: 50%;
-  position: absolute;
-  top: 50%;
-  transform: translateX(-50%) translateY(-50%) rotate(45deg);
-  transform-origin: center center;
-}
-.modal-close::before, .delete::before {
-  height: 2px;
-  width: 50%;
-}
-.modal-close::after, .delete::after {
-  height: 50%;
-  width: 2px;
-}
-.modal-close:hover, .delete:hover, .modal-close:focus, .delete:focus {
-  background-color: rgba(10, 10, 10, 0.3);
-}
-.modal-close:active, .delete:active {
-  background-color: rgba(10, 10, 10, 0.4);
-}
-.is-small.modal-close, .is-small.delete {
-  height: 16px;
-  max-height: 16px;
-  max-width: 16px;
-  min-height: 16px;
-  min-width: 16px;
-  width: 16px;
-}
-.is-medium.modal-close, .is-medium.delete {
-  height: 24px;
-  max-height: 24px;
-  max-width: 24px;
-  min-height: 24px;
-  min-width: 24px;
-  width: 24px;
-}
-.is-large.modal-close, .is-large.delete {
-  height: 32px;
-  max-height: 32px;
-  max-width: 32px;
-  min-height: 32px;
-  min-width: 32px;
-  width: 32px;
-}
+  width: 20px; }
+  .modal-close::before, .delete::before, .modal-close::after, .delete::after {
+    background-color: white;
+    content: "";
+    display: block;
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translateX(-50%) translateY(-50%) rotate(45deg);
+    transform-origin: center center; }
+  .modal-close::before, .delete::before {
+    height: 2px;
+    width: 50%; }
+  .modal-close::after, .delete::after {
+    height: 50%;
+    width: 2px; }
+  .modal-close:hover, .delete:hover, .modal-close:focus, .delete:focus {
+    background-color: rgba(10, 10, 10, 0.3); }
+  .modal-close:active, .delete:active {
+    background-color: rgba(10, 10, 10, 0.4); }
+  .is-small.modal-close, .is-small.delete {
+    height: 16px;
+    max-height: 16px;
+    max-width: 16px;
+    min-height: 16px;
+    min-width: 16px;
+    width: 16px; }
+  .is-medium.modal-close, .is-medium.delete {
+    height: 24px;
+    max-height: 24px;
+    max-width: 24px;
+    min-height: 24px;
+    min-width: 24px;
+    width: 24px; }
+  .is-large.modal-close, .is-large.delete {
+    height: 32px;
+    max-height: 32px;
+    max-width: 32px;
+    min-height: 32px;
+    min-width: 32px;
+    width: 32px; }
 
 .loader, .control.is-loading::after, .select.is-loading::after, .button.is-loading::after {
   animation: spinAround 500ms infinite linear;
-  border: 2px solid hsl(0deg, 0%, 80%);
+  border: 2px solid #cccccc;
   border-radius: 290486px;
   border-right-color: transparent;
   border-top-color: transparent;
@@ -124,16 +109,14 @@
   display: block;
   height: 1em;
   position: relative;
-  width: 1em;
-}
+  width: 1em; }
 
 .hero-video, .modal-background, .modal, .image.is-square img, .image.is-1by1 img, .image.is-5by4 img, .image.is-4by3 img, .image.is-3by2 img, .image.is-5by3 img, .image.is-16by9 img, .image.is-2by1 img, .image.is-3by1 img, .image.is-4by5 img, .image.is-3by4 img, .image.is-2by3 img, .image.is-3by5 img, .image.is-9by16 img, .image.is-1by2 img, .image.is-1by3 img, .is-overlay {
   bottom: 0;
   left: 0;
   position: absolute;
   right: 0;
-  top: 0;
-}
+  top: 0; }
 
 .pagination-previous,
 .pagination-next,
@@ -157,39 +140,36 @@
   padding-right: calc(0.625em - 1px);
   padding-top: calc(0.375em - 1px);
   position: relative;
-  vertical-align: top;
-}
-.pagination-previous:focus,
-.pagination-next:focus,
-.pagination-link:focus,
-.pagination-ellipsis:focus, .file-cta:focus,
-.file-name:focus, .select select:focus, .input:focus,
-.textarea:focus, .button:focus, .is-focused.pagination-previous,
-.is-focused.pagination-next,
-.is-focused.pagination-link,
-.is-focused.pagination-ellipsis, .is-focused.file-cta,
-.is-focused.file-name, .select select.is-focused, .is-focused.input,
-.is-focused.textarea, .is-focused.button, .pagination-previous:active,
-.pagination-next:active,
-.pagination-link:active,
-.pagination-ellipsis:active, .file-cta:active,
-.file-name:active, .select select:active, .input:active,
-.textarea:active, .button:active, .is-active.pagination-previous,
-.is-active.pagination-next,
-.is-active.pagination-link,
-.is-active.pagination-ellipsis, .is-active.file-cta,
-.is-active.file-name, .select select.is-active, .is-active.input,
-.is-active.textarea, .is-active.button {
-  outline: none;
-}
-[disabled].pagination-previous,
-[disabled].pagination-next,
-[disabled].pagination-link,
-[disabled].pagination-ellipsis, [disabled].file-cta,
-[disabled].file-name, .select select[disabled], [disabled].input,
-[disabled].textarea, [disabled].button {
-  cursor: not-allowed;
-}
+  vertical-align: top; }
+  .pagination-previous:focus,
+  .pagination-next:focus,
+  .pagination-link:focus,
+  .pagination-ellipsis:focus, .file-cta:focus,
+  .file-name:focus, .select select:focus, .input:focus,
+  .textarea:focus, .button:focus, .is-focused.pagination-previous,
+  .is-focused.pagination-next,
+  .is-focused.pagination-link,
+  .is-focused.pagination-ellipsis, .is-focused.file-cta,
+  .is-focused.file-name, .select select.is-focused, .is-focused.input,
+  .is-focused.textarea, .is-focused.button, .pagination-previous:active,
+  .pagination-next:active,
+  .pagination-link:active,
+  .pagination-ellipsis:active, .file-cta:active,
+  .file-name:active, .select select:active, .input:active,
+  .textarea:active, .button:active, .is-active.pagination-previous,
+  .is-active.pagination-next,
+  .is-active.pagination-link,
+  .is-active.pagination-ellipsis, .is-active.file-cta,
+  .is-active.file-name, .select select.is-active, .is-active.input,
+  .is-active.textarea, .is-active.button {
+    outline: none; }
+  [disabled].pagination-previous,
+  [disabled].pagination-next,
+  [disabled].pagination-link,
+  [disabled].pagination-ellipsis, [disabled].file-cta,
+  [disabled].file-name, .select select[disabled], [disabled].input,
+  [disabled].textarea, [disabled].button {
+    cursor: not-allowed; }
 
 /*! minireset.css v0.0.3 | MIT License | github.com/jgthms/minireset.css */
 html,
@@ -216,8 +196,7 @@ h4,
 h5,
 h6 {
   margin: 0;
-  padding: 0;
-}
+  padding: 0; }
 
 h1,
 h2,
@@ -226,52 +205,43 @@ h4,
 h5,
 h6 {
   font-size: 100%;
-  font-weight: normal;
-}
+  font-weight: normal; }
 
 ul {
-  list-style: none;
-}
+  list-style: none; }
 
 button,
 input,
 select,
 textarea {
-  margin: 0;
-}
+  margin: 0; }
 
 html {
-  box-sizing: border-box;
-}
+  box-sizing: border-box; }
 
 *, *::before, *::after {
-  box-sizing: inherit;
-}
+  box-sizing: inherit; }
 
 img,
 audio,
 video {
   height: auto;
-  max-width: 100%;
-}
+  max-width: 100%; }
 
 iframe {
-  border: 0;
-}
+  border: 0; }
 
 table {
   border-collapse: collapse;
-  border-spacing: 0;
-}
+  border-spacing: 0; }
 
 td,
 th {
   padding: 0;
-  text-align: left;
-}
+  text-align: left; }
 
 html {
-  background-color: hsl(0deg, 0%, 100%);
+  background-color: white;
   font-size: 16px;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
@@ -279,8 +249,7 @@ html {
   overflow-x: hidden;
   overflow-y: scroll;
   text-rendering: optimizeLegibility;
-  text-size-adjust: 100%;
-}
+  text-size-adjust: 100%; }
 
 article,
 aside,
@@ -289,961 +258,744 @@ footer,
 header,
 hgroup,
 section {
-  display: block;
-}
+  display: block; }
 
 body,
 button,
 input,
 select,
 textarea {
-  font-family: "Open Sans", "Lucida Grande", "Helvetica Neue", Helvetica, Arial, sans-serif;
-}
+  font-family: "Open Sans", "Lucida Grande", "Helvetica Neue", Helvetica, Arial, sans-serif; }
 
 code,
 pre {
   -moz-osx-font-smoothing: auto;
   -webkit-font-smoothing: auto;
-  font-family: monospace;
-}
+  font-family: monospace; }
 
 body {
   color: #333;
   font-size: 1rem;
   font-weight: 400;
-  line-height: 1.5;
-}
+  line-height: 1.5; }
 
 a {
-  color: #086db1;
+  color: #1565c0;
   cursor: pointer;
-  text-decoration: none;
-}
-a strong {
-  color: currentColor;
-}
-a:hover {
-  color: #2d2d2d;
-}
+  text-decoration: none; }
+  a strong {
+    color: currentColor; }
+  a:hover {
+    color: #2d2d2d; }
 
 code {
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   color: #cd0200;
   font-size: 0.875em;
   font-weight: normal;
-  padding: 0.25em 0.5em 0.25em;
-}
+  padding: 0.25em 0.5em 0.25em; }
 
 hr {
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   border: none;
   display: block;
   height: 2px;
-  margin: 1.5rem 0;
-}
+  margin: 1.5rem 0; }
 
 img {
   height: auto;
-  max-width: 100%;
-}
+  max-width: 100%; }
 
-input[type=checkbox],
-input[type=radio] {
-  vertical-align: baseline;
-}
+input[type="checkbox"],
+input[type="radio"] {
+  vertical-align: baseline; }
 
 small {
-  font-size: 0.875em;
-}
+  font-size: 0.875em; }
 
 span {
   font-style: inherit;
-  font-weight: inherit;
-}
+  font-weight: inherit; }
 
 strong {
   color: #2d2d2d;
-  font-weight: 700;
-}
+  font-weight: 700; }
 
 pre {
   -webkit-overflow-scrolling: touch;
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   color: #333;
   font-size: 0.875em;
   overflow-x: auto;
   padding: 1.25rem 1.5rem;
   white-space: pre;
-  word-wrap: normal;
-}
-pre code {
-  background-color: transparent;
-  color: currentColor;
-  font-size: 1em;
-  padding: 0;
-}
+  word-wrap: normal; }
+  pre code {
+    background-color: transparent;
+    color: currentColor;
+    font-size: 1em;
+    padding: 0; }
 
 table td,
 table th {
   text-align: left;
-  vertical-align: top;
-}
+  vertical-align: top; }
+
 table th {
-  color: #2d2d2d;
-}
+  color: #2d2d2d; }
 
 .is-clearfix::after {
   clear: both;
   content: " ";
-  display: table;
-}
+  display: table; }
 
 .is-pulled-left {
-  float: left !important;
-}
+  float: left !important; }
 
 .is-pulled-right {
-  float: right !important;
-}
+  float: right !important; }
 
 .is-clipped {
-  overflow: hidden !important;
-}
+  overflow: hidden !important; }
 
 .is-size-1 {
-  font-size: 3rem !important;
-}
+  font-size: 3rem !important; }
 
 .is-size-2 {
-  font-size: 2.5rem !important;
-}
+  font-size: 2.5rem !important; }
 
 .is-size-3 {
-  font-size: 2rem !important;
-}
+  font-size: 2rem !important; }
 
 .is-size-4 {
-  font-size: 1.5rem !important;
-}
+  font-size: 1.5rem !important; }
 
 .is-size-5 {
-  font-size: 1.25rem !important;
-}
+  font-size: 1.25rem !important; }
 
 .is-size-6 {
-  font-size: 1rem !important;
-}
+  font-size: 1rem !important; }
 
 .is-size-7 {
-  font-size: 0.85rem !important;
-}
+  font-size: 0.85rem !important; }
 
 @media screen and (max-width: 768px) {
   .is-size-1-mobile {
-    font-size: 3rem !important;
-  }
+    font-size: 3rem !important; }
   .is-size-2-mobile {
-    font-size: 2.5rem !important;
-  }
+    font-size: 2.5rem !important; }
   .is-size-3-mobile {
-    font-size: 2rem !important;
-  }
+    font-size: 2rem !important; }
   .is-size-4-mobile {
-    font-size: 1.5rem !important;
-  }
+    font-size: 1.5rem !important; }
   .is-size-5-mobile {
-    font-size: 1.25rem !important;
-  }
+    font-size: 1.25rem !important; }
   .is-size-6-mobile {
-    font-size: 1rem !important;
-  }
+    font-size: 1rem !important; }
   .is-size-7-mobile {
-    font-size: 0.85rem !important;
-  }
-}
+    font-size: 0.85rem !important; } }
+
 @media screen and (min-width: 769px), print {
   .is-size-1-tablet {
-    font-size: 3rem !important;
-  }
+    font-size: 3rem !important; }
   .is-size-2-tablet {
-    font-size: 2.5rem !important;
-  }
+    font-size: 2.5rem !important; }
   .is-size-3-tablet {
-    font-size: 2rem !important;
-  }
+    font-size: 2rem !important; }
   .is-size-4-tablet {
-    font-size: 1.5rem !important;
-  }
+    font-size: 1.5rem !important; }
   .is-size-5-tablet {
-    font-size: 1.25rem !important;
-  }
+    font-size: 1.25rem !important; }
   .is-size-6-tablet {
-    font-size: 1rem !important;
-  }
+    font-size: 1rem !important; }
   .is-size-7-tablet {
-    font-size: 0.85rem !important;
-  }
-}
+    font-size: 0.85rem !important; } }
+
 @media screen and (max-width: 1087px) {
   .is-size-1-touch {
-    font-size: 3rem !important;
-  }
+    font-size: 3rem !important; }
   .is-size-2-touch {
-    font-size: 2.5rem !important;
-  }
+    font-size: 2.5rem !important; }
   .is-size-3-touch {
-    font-size: 2rem !important;
-  }
+    font-size: 2rem !important; }
   .is-size-4-touch {
-    font-size: 1.5rem !important;
-  }
+    font-size: 1.5rem !important; }
   .is-size-5-touch {
-    font-size: 1.25rem !important;
-  }
+    font-size: 1.25rem !important; }
   .is-size-6-touch {
-    font-size: 1rem !important;
-  }
+    font-size: 1rem !important; }
   .is-size-7-touch {
-    font-size: 0.85rem !important;
-  }
-}
+    font-size: 0.85rem !important; } }
+
 @media screen and (min-width: 1088px) {
   .is-size-1-desktop {
-    font-size: 3rem !important;
-  }
+    font-size: 3rem !important; }
   .is-size-2-desktop {
-    font-size: 2.5rem !important;
-  }
+    font-size: 2.5rem !important; }
   .is-size-3-desktop {
-    font-size: 2rem !important;
-  }
+    font-size: 2rem !important; }
   .is-size-4-desktop {
-    font-size: 1.5rem !important;
-  }
+    font-size: 1.5rem !important; }
   .is-size-5-desktop {
-    font-size: 1.25rem !important;
-  }
+    font-size: 1.25rem !important; }
   .is-size-6-desktop {
-    font-size: 1rem !important;
-  }
+    font-size: 1rem !important; }
   .is-size-7-desktop {
-    font-size: 0.85rem !important;
-  }
-}
+    font-size: 0.85rem !important; } }
+
 @media screen and (min-width: 1280px) {
   .is-size-1-widescreen {
-    font-size: 3rem !important;
-  }
+    font-size: 3rem !important; }
   .is-size-2-widescreen {
-    font-size: 2.5rem !important;
-  }
+    font-size: 2.5rem !important; }
   .is-size-3-widescreen {
-    font-size: 2rem !important;
-  }
+    font-size: 2rem !important; }
   .is-size-4-widescreen {
-    font-size: 1.5rem !important;
-  }
+    font-size: 1.5rem !important; }
   .is-size-5-widescreen {
-    font-size: 1.25rem !important;
-  }
+    font-size: 1.25rem !important; }
   .is-size-6-widescreen {
-    font-size: 1rem !important;
-  }
+    font-size: 1rem !important; }
   .is-size-7-widescreen {
-    font-size: 0.85rem !important;
-  }
-}
+    font-size: 0.85rem !important; } }
+
 @media screen and (min-width: 1472px) {
   .is-size-1-fullhd {
-    font-size: 3rem !important;
-  }
+    font-size: 3rem !important; }
   .is-size-2-fullhd {
-    font-size: 2.5rem !important;
-  }
+    font-size: 2.5rem !important; }
   .is-size-3-fullhd {
-    font-size: 2rem !important;
-  }
+    font-size: 2rem !important; }
   .is-size-4-fullhd {
-    font-size: 1.5rem !important;
-  }
+    font-size: 1.5rem !important; }
   .is-size-5-fullhd {
-    font-size: 1.25rem !important;
-  }
+    font-size: 1.25rem !important; }
   .is-size-6-fullhd {
-    font-size: 1rem !important;
-  }
+    font-size: 1rem !important; }
   .is-size-7-fullhd {
-    font-size: 0.85rem !important;
-  }
-}
+    font-size: 0.85rem !important; } }
+
 .has-text-centered {
-  text-align: center !important;
-}
+  text-align: center !important; }
 
 .has-text-justified {
-  text-align: justify !important;
-}
+  text-align: justify !important; }
 
 .has-text-left {
-  text-align: left !important;
-}
+  text-align: left !important; }
 
 .has-text-right {
-  text-align: right !important;
-}
+  text-align: right !important; }
 
 @media screen and (max-width: 768px) {
   .has-text-centered-mobile {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
+
 @media screen and (min-width: 769px), print {
   .has-text-centered-tablet {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .has-text-centered-tablet-only {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
+
 @media screen and (max-width: 1087px) {
   .has-text-centered-touch {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
+
 @media screen and (min-width: 1088px) {
   .has-text-centered-desktop {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .has-text-centered-desktop-only {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
+
 @media screen and (min-width: 1280px) {
   .has-text-centered-widescreen {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .has-text-centered-widescreen-only {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
+
 @media screen and (min-width: 1472px) {
   .has-text-centered-fullhd {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
+
 @media screen and (max-width: 768px) {
   .has-text-justified-mobile {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
+
 @media screen and (min-width: 769px), print {
   .has-text-justified-tablet {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .has-text-justified-tablet-only {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
+
 @media screen and (max-width: 1087px) {
   .has-text-justified-touch {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
+
 @media screen and (min-width: 1088px) {
   .has-text-justified-desktop {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .has-text-justified-desktop-only {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
+
 @media screen and (min-width: 1280px) {
   .has-text-justified-widescreen {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .has-text-justified-widescreen-only {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
+
 @media screen and (min-width: 1472px) {
   .has-text-justified-fullhd {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
+
 @media screen and (max-width: 768px) {
   .has-text-left-mobile {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
+
 @media screen and (min-width: 769px), print {
   .has-text-left-tablet {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .has-text-left-tablet-only {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
+
 @media screen and (max-width: 1087px) {
   .has-text-left-touch {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
+
 @media screen and (min-width: 1088px) {
   .has-text-left-desktop {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .has-text-left-desktop-only {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
+
 @media screen and (min-width: 1280px) {
   .has-text-left-widescreen {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .has-text-left-widescreen-only {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
+
 @media screen and (min-width: 1472px) {
   .has-text-left-fullhd {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
+
 @media screen and (max-width: 768px) {
   .has-text-right-mobile {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
+
 @media screen and (min-width: 769px), print {
   .has-text-right-tablet {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .has-text-right-tablet-only {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
+
 @media screen and (max-width: 1087px) {
   .has-text-right-touch {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
+
 @media screen and (min-width: 1088px) {
   .has-text-right-desktop {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .has-text-right-desktop-only {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
+
 @media screen and (min-width: 1280px) {
   .has-text-right-widescreen {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .has-text-right-widescreen-only {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
+
 @media screen and (min-width: 1472px) {
   .has-text-right-fullhd {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
+
 .is-capitalized {
-  text-transform: capitalize !important;
-}
+  text-transform: capitalize !important; }
 
 .is-lowercase {
-  text-transform: lowercase !important;
-}
+  text-transform: lowercase !important; }
 
 .is-uppercase {
-  text-transform: uppercase !important;
-}
+  text-transform: uppercase !important; }
 
 .is-italic {
-  font-style: italic !important;
-}
+  font-style: italic !important; }
 
 .has-text-white {
-  color: hsl(0deg, 0%, 100%) !important;
-}
+  color: white !important; }
 
 a.has-text-white:hover, a.has-text-white:focus {
-  color: #e6e6e6 !important;
-}
+  color: #e6e6e6 !important; }
 
 .has-background-white {
-  background-color: hsl(0deg, 0%, 100%) !important;
-}
+  background-color: white !important; }
 
 .has-text-black {
-  color: hsl(0deg, 0%, 4%) !important;
-}
+  color: #0a0a0a !important; }
 
 a.has-text-black:hover, a.has-text-black:focus {
-  color: black !important;
-}
+  color: black !important; }
 
 .has-background-black {
-  background-color: hsl(0deg, 0%, 4%) !important;
-}
+  background-color: #0a0a0a !important; }
 
 .has-text-light {
-  color: hsl(0deg, 0%, 96%) !important;
-}
+  color: whitesmoke !important; }
 
 a.has-text-light:hover, a.has-text-light:focus {
-  color: #dbdbdb !important;
-}
+  color: #dbdbdb !important; }
 
 .has-background-light {
-  background-color: hsl(0deg, 0%, 96%) !important;
-}
+  background-color: whitesmoke !important; }
 
 .has-text-dark {
-  color: #2d2d2d !important;
-}
+  color: #2d2d2d !important; }
 
 a.has-text-dark:hover, a.has-text-dark:focus {
-  color: #141414 !important;
-}
+  color: #141414 !important; }
 
 .has-background-dark {
-  background-color: #2d2d2d !important;
-}
+  background-color: #2d2d2d !important; }
 
 .has-text-primary {
-  color: #b31b1b !important;
-}
+  color: #b31b1b !important; }
 
 a.has-text-primary:hover, a.has-text-primary:focus {
-  color: #871414 !important;
-}
+  color: #871414 !important; }
 
 .has-background-primary {
-  background-color: #b31b1b !important;
-}
+  background-color: #b31b1b !important; }
 
 .has-text-link {
-  color: #086db1 !important;
-}
+  color: #1565c0 !important; }
 
 a.has-text-link:hover, a.has-text-link:focus {
-  color: #064f80 !important;
-}
+  color: #104d92 !important; }
 
 .has-background-link {
-  background-color: #086db1 !important;
-}
+  background-color: #1565c0 !important; }
 
 .has-text-info {
-  color: hsl(204deg, 86%, 53%) !important;
-}
+  color: #209cee !important; }
 
 a.has-text-info:hover, a.has-text-info:focus {
-  color: #0f81cc !important;
-}
+  color: #0f81cc !important; }
 
 .has-background-info {
-  background-color: hsl(204deg, 86%, 53%) !important;
-}
+  background-color: #209cee !important; }
 
 .has-text-success {
-  color: #008412 !important;
-}
+  color: #008412 !important; }
 
 a.has-text-success:hover, a.has-text-success:focus {
-  color: #00510b !important;
-}
+  color: #00510b !important; }
 
 .has-background-success {
-  background-color: #008412 !important;
-}
+  background-color: #008412 !important; }
 
 .has-text-warning {
-  color: #b55c06 !important;
-}
+  color: #b55c06 !important; }
 
 a.has-text-warning:hover, a.has-text-warning:focus {
-  color: #844304 !important;
-}
+  color: #844304 !important; }
 
 .has-background-warning {
-  background-color: #b55c06 !important;
-}
+  background-color: #b55c06 !important; }
 
 .has-text-danger {
-  color: #cd0200 !important;
-}
+  color: #cd0200 !important; }
 
 a.has-text-danger:hover, a.has-text-danger:focus {
-  color: #9a0200 !important;
-}
+  color: #9a0200 !important; }
 
 .has-background-danger {
-  background-color: #cd0200 !important;
-}
+  background-color: #cd0200 !important; }
 
 .has-text-black-bis {
-  color: hsl(0deg, 0%, 7%) !important;
-}
+  color: #121212 !important; }
 
 .has-background-black-bis {
-  background-color: hsl(0deg, 0%, 7%) !important;
-}
+  background-color: #121212 !important; }
 
 .has-text-black-ter {
-  color: hsl(0deg, 0%, 14%) !important;
-}
+  color: #242424 !important; }
 
 .has-background-black-ter {
-  background-color: hsl(0deg, 0%, 14%) !important;
-}
+  background-color: #242424 !important; }
 
 .has-text-grey-darker {
-  color: #2d2d2d !important;
-}
+  color: #2d2d2d !important; }
 
 .has-background-grey-darker {
-  background-color: #2d2d2d !important;
-}
+  background-color: #2d2d2d !important; }
 
 .has-text-grey-dark {
-  color: #333 !important;
-}
+  color: #333 !important; }
 
 .has-background-grey-dark {
-  background-color: #333 !important;
-}
+  background-color: #333 !important; }
 
 .has-text-grey {
-  color: #757575 !important;
-}
+  color: #757575 !important; }
 
 .has-background-grey {
-  background-color: #757575 !important;
-}
+  background-color: #757575 !important; }
 
 .has-text-grey-light {
-  color: hsl(0deg, 0%, 60%) !important;
-}
+  color: #999999 !important; }
 
 .has-background-grey-light {
-  background-color: hsl(0deg, 0%, 60%) !important;
-}
+  background-color: #999999 !important; }
 
 .has-text-grey-lighter {
-  color: hsl(0deg, 0%, 80%) !important;
-}
+  color: #cccccc !important; }
 
 .has-background-grey-lighter {
-  background-color: hsl(0deg, 0%, 80%) !important;
-}
+  background-color: #cccccc !important; }
 
 .has-text-white-ter {
-  color: hsl(0deg, 0%, 96%) !important;
-}
+  color: whitesmoke !important; }
 
 .has-background-white-ter {
-  background-color: hsl(0deg, 0%, 96%) !important;
-}
+  background-color: whitesmoke !important; }
 
 .has-text-white-bis {
-  color: hsl(0deg, 0%, 98%) !important;
-}
+  color: #fafafa !important; }
 
 .has-background-white-bis {
-  background-color: hsl(0deg, 0%, 98%) !important;
-}
+  background-color: #fafafa !important; }
 
 .has-text-weight-light {
-  font-weight: 300 !important;
-}
+  font-weight: 300 !important; }
 
 .has-text-weight-normal {
-  font-weight: 400 !important;
-}
+  font-weight: 400 !important; }
 
 .has-text-weight-semibold {
-  font-weight: 600 !important;
-}
+  font-weight: 600 !important; }
 
 .has-text-weight-bold {
-  font-weight: 700 !important;
-}
+  font-weight: 700 !important; }
 
 .is-block {
-  display: block !important;
-}
+  display: block !important; }
 
 @media screen and (max-width: 768px) {
   .is-block-mobile {
-    display: block !important;
-  }
-}
+    display: block !important; } }
+
 @media screen and (min-width: 769px), print {
   .is-block-tablet {
-    display: block !important;
-  }
-}
+    display: block !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .is-block-tablet-only {
-    display: block !important;
-  }
-}
+    display: block !important; } }
+
 @media screen and (max-width: 1087px) {
   .is-block-touch {
-    display: block !important;
-  }
-}
+    display: block !important; } }
+
 @media screen and (min-width: 1088px) {
   .is-block-desktop {
-    display: block !important;
-  }
-}
+    display: block !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .is-block-desktop-only {
-    display: block !important;
-  }
-}
+    display: block !important; } }
+
 @media screen and (min-width: 1280px) {
   .is-block-widescreen {
-    display: block !important;
-  }
-}
+    display: block !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .is-block-widescreen-only {
-    display: block !important;
-  }
-}
+    display: block !important; } }
+
 @media screen and (min-width: 1472px) {
   .is-block-fullhd {
-    display: block !important;
-  }
-}
+    display: block !important; } }
+
 .is-flex {
-  display: flex !important;
-}
+  display: flex !important; }
 
 @media screen and (max-width: 768px) {
   .is-flex-mobile {
-    display: flex !important;
-  }
-}
+    display: flex !important; } }
+
 @media screen and (min-width: 769px), print {
   .is-flex-tablet {
-    display: flex !important;
-  }
-}
+    display: flex !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .is-flex-tablet-only {
-    display: flex !important;
-  }
-}
+    display: flex !important; } }
+
 @media screen and (max-width: 1087px) {
   .is-flex-touch {
-    display: flex !important;
-  }
-}
+    display: flex !important; } }
+
 @media screen and (min-width: 1088px) {
   .is-flex-desktop {
-    display: flex !important;
-  }
-}
+    display: flex !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .is-flex-desktop-only {
-    display: flex !important;
-  }
-}
+    display: flex !important; } }
+
 @media screen and (min-width: 1280px) {
   .is-flex-widescreen {
-    display: flex !important;
-  }
-}
+    display: flex !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .is-flex-widescreen-only {
-    display: flex !important;
-  }
-}
+    display: flex !important; } }
+
 @media screen and (min-width: 1472px) {
   .is-flex-fullhd {
-    display: flex !important;
-  }
-}
+    display: flex !important; } }
+
 .is-inline {
-  display: inline !important;
-}
+  display: inline !important; }
 
 @media screen and (max-width: 768px) {
   .is-inline-mobile {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
+
 @media screen and (min-width: 769px), print {
   .is-inline-tablet {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .is-inline-tablet-only {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
+
 @media screen and (max-width: 1087px) {
   .is-inline-touch {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
+
 @media screen and (min-width: 1088px) {
   .is-inline-desktop {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .is-inline-desktop-only {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
+
 @media screen and (min-width: 1280px) {
   .is-inline-widescreen {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .is-inline-widescreen-only {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
+
 @media screen and (min-width: 1472px) {
   .is-inline-fullhd {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
+
 .is-inline-block {
-  display: inline-block !important;
-}
+  display: inline-block !important; }
 
 @media screen and (max-width: 768px) {
   .is-inline-block-mobile {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
+
 @media screen and (min-width: 769px), print {
   .is-inline-block-tablet {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .is-inline-block-tablet-only {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
+
 @media screen and (max-width: 1087px) {
   .is-inline-block-touch {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
+
 @media screen and (min-width: 1088px) {
   .is-inline-block-desktop {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .is-inline-block-desktop-only {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
+
 @media screen and (min-width: 1280px) {
   .is-inline-block-widescreen {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .is-inline-block-widescreen-only {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
+
 @media screen and (min-width: 1472px) {
   .is-inline-block-fullhd {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
+
 .is-inline-flex {
-  display: inline-flex !important;
-}
+  display: inline-flex !important; }
 
 @media screen and (max-width: 768px) {
   .is-inline-flex-mobile {
-    display: inline-flex !important;
-  }
-}
+    display: inline-flex !important; } }
+
 @media screen and (min-width: 769px), print {
   .is-inline-flex-tablet {
-    display: inline-flex !important;
-  }
-}
+    display: inline-flex !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .is-inline-flex-tablet-only {
-    display: inline-flex !important;
-  }
-}
+    display: inline-flex !important; } }
+
 @media screen and (max-width: 1087px) {
   .is-inline-flex-touch {
-    display: inline-flex !important;
-  }
-}
+    display: inline-flex !important; } }
+
 @media screen and (min-width: 1088px) {
   .is-inline-flex-desktop {
-    display: inline-flex !important;
-  }
-}
+    display: inline-flex !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .is-inline-flex-desktop-only {
-    display: inline-flex !important;
-  }
-}
+    display: inline-flex !important; } }
+
 @media screen and (min-width: 1280px) {
   .is-inline-flex-widescreen {
-    display: inline-flex !important;
-  }
-}
+    display: inline-flex !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .is-inline-flex-widescreen-only {
-    display: inline-flex !important;
-  }
-}
+    display: inline-flex !important; } }
+
 @media screen and (min-width: 1472px) {
   .is-inline-flex-fullhd {
-    display: inline-flex !important;
-  }
-}
+    display: inline-flex !important; } }
+
 .is-hidden {
-  display: none !important;
-}
+  display: none !important; }
 
 .is-sr-only {
   border: none !important;
@@ -1253,138 +1005,112 @@ a.has-text-danger:hover, a.has-text-danger:focus {
   padding: 0 !important;
   position: absolute !important;
   white-space: nowrap !important;
-  width: 0.01em !important;
-}
+  width: 0.01em !important; }
 
 @media screen and (max-width: 768px) {
   .is-hidden-mobile {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media screen and (min-width: 769px), print {
   .is-hidden-tablet {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .is-hidden-tablet-only {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media screen and (max-width: 1087px) {
   .is-hidden-touch {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media screen and (min-width: 1088px) {
   .is-hidden-desktop {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .is-hidden-desktop-only {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media screen and (min-width: 1280px) {
   .is-hidden-widescreen {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .is-hidden-widescreen-only {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media screen and (min-width: 1472px) {
   .is-hidden-fullhd {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 .is-invisible {
-  visibility: hidden !important;
-}
+  visibility: hidden !important; }
 
 @media screen and (max-width: 768px) {
   .is-invisible-mobile {
-    visibility: hidden !important;
-  }
-}
+    visibility: hidden !important; } }
+
 @media screen and (min-width: 769px), print {
   .is-invisible-tablet {
-    visibility: hidden !important;
-  }
-}
+    visibility: hidden !important; } }
+
 @media screen and (min-width: 769px) and (max-width: 1087px) {
   .is-invisible-tablet-only {
-    visibility: hidden !important;
-  }
-}
+    visibility: hidden !important; } }
+
 @media screen and (max-width: 1087px) {
   .is-invisible-touch {
-    visibility: hidden !important;
-  }
-}
+    visibility: hidden !important; } }
+
 @media screen and (min-width: 1088px) {
   .is-invisible-desktop {
-    visibility: hidden !important;
-  }
-}
+    visibility: hidden !important; } }
+
 @media screen and (min-width: 1088px) and (max-width: 1279px) {
   .is-invisible-desktop-only {
-    visibility: hidden !important;
-  }
-}
+    visibility: hidden !important; } }
+
 @media screen and (min-width: 1280px) {
   .is-invisible-widescreen {
-    visibility: hidden !important;
-  }
-}
+    visibility: hidden !important; } }
+
 @media screen and (min-width: 1280px) and (max-width: 1471px) {
   .is-invisible-widescreen-only {
-    visibility: hidden !important;
-  }
-}
+    visibility: hidden !important; } }
+
 @media screen and (min-width: 1472px) {
   .is-invisible-fullhd {
-    visibility: hidden !important;
-  }
-}
+    visibility: hidden !important; } }
+
 .is-marginless {
-  margin: 0 !important;
-}
+  margin: 0 !important; }
 
 .is-paddingless {
-  padding: 0 !important;
-}
+  padding: 0 !important; }
 
 .is-radiusless {
-  border-radius: 0 !important;
-}
+  border-radius: 0 !important; }
 
 .is-shadowless {
-  box-shadow: none !important;
-}
+  box-shadow: none !important; }
 
 .box {
-  background-color: hsl(0deg, 0%, 100%);
+  background-color: white;
   border-radius: 2px;
   box-shadow: 0 2px 3px rgba(10, 10, 10, 0.1), 0 0 0 1px rgba(10, 10, 10, 0.1);
   color: #333;
   display: block;
-  padding: 0.75rem;
-}
+  padding: 0.75rem; }
 
 a.box:hover, a.box:focus {
-  box-shadow: 0 2px 3px rgba(10, 10, 10, 0.1), 0 0 0 1px #086db1;
-}
+  box-shadow: 0 2px 3px rgba(10, 10, 10, 0.1), 0 0 0 1px #1565c0; }
+
 a.box:active {
-  box-shadow: inset 0 1px 2px rgba(10, 10, 10, 0.2), 0 0 0 1px #086db1;
-}
+  box-shadow: inset 0 1px 2px rgba(10, 10, 10, 0.2), 0 0 0 1px #1565c0; }
 
 .button {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: hsl(0deg, 0%, 80%);
+  background-color: white;
+  border-color: #cccccc;
   border-width: 1px;
   color: #2d2d2d;
   cursor: pointer;
@@ -1394,967 +1120,747 @@ a.box:active {
   padding-right: 0.75em;
   padding-top: calc(0.375em - 1px);
   text-align: center;
-  white-space: nowrap;
-}
-.button strong {
-  color: inherit;
-}
-.button .icon, .button .icon.is-small, .button .icon.is-medium, .button .icon.is-large {
-  height: 1.5em;
-  width: 1.5em;
-}
-.button .icon:first-child:not(:last-child) {
-  margin-left: calc(-0.375em - 1px);
-  margin-right: 0.1875em;
-}
-.button .icon:last-child:not(:first-child) {
-  margin-left: 0.1875em;
-  margin-right: calc(-0.375em - 1px);
-}
-.button .icon:first-child:last-child {
-  margin-left: calc(-0.375em - 1px);
-  margin-right: calc(-0.375em - 1px);
-}
-.button:hover, .button.is-hovered {
-  border-color: hsl(0deg, 0%, 60%);
-  color: hsl(0deg, 0%, 50%);
-}
-.button:focus, .button.is-focused {
-  border-color: #086db1;
-  color: #2d2d2d;
-}
-.button:focus:not(:active), .button.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(8, 109, 177, 0.25);
-}
-.button:active, .button.is-active {
-  border-color: #333;
-  color: #2d2d2d;
-}
-.button.is-text {
-  background-color: transparent;
-  border-color: transparent;
-  color: #333;
-  text-decoration: underline;
-}
-.button.is-text:hover, .button.is-text.is-hovered, .button.is-text:focus, .button.is-text.is-focused {
-  background-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.button.is-text:active, .button.is-text.is-active {
-  background-color: #e8e8e8;
-  color: #2d2d2d;
-}
-.button.is-text[disabled] {
-  background-color: transparent;
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-white {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-white:hover, .button.is-white.is-hovered {
-  background-color: #f9f9f9;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-white:focus, .button.is-white.is-focused {
-  border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-white:focus:not(:active), .button.is-white.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25);
-}
-.button.is-white:active, .button.is-white.is-active {
-  background-color: #f2f2f2;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-white[disabled] {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-white.is-inverted {
-  background-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-white.is-inverted:hover {
-  background-color: black;
-}
-.button.is-white.is-inverted[disabled] {
-  background-color: hsl(0deg, 0%, 4%);
-  border-color: transparent;
-  box-shadow: none;
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-white.is-loading::after {
-  border-color: transparent transparent hsl(0deg, 0%, 4%) hsl(0deg, 0%, 4%) !important;
-}
-.button.is-white.is-outlined {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-white.is-outlined:hover, .button.is-white.is-outlined:focus {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-white.is-outlined.is-loading::after {
-  border-color: transparent transparent hsl(0deg, 0%, 100%) hsl(0deg, 0%, 100%) !important;
-}
-.button.is-white.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 100%);
-  box-shadow: none;
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-white.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-white.is-inverted.is-outlined:hover, .button.is-white.is-inverted.is-outlined:focus {
-  background-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-white.is-inverted.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 4%);
-  box-shadow: none;
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-black {
-  background-color: hsl(0deg, 0%, 4%);
-  border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-black:hover, .button.is-black.is-hovered {
-  background-color: #040404;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-black:focus, .button.is-black.is-focused {
-  border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-black:focus:not(:active), .button.is-black.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.25);
-}
-.button.is-black:active, .button.is-black.is-active {
-  background-color: black;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-black[disabled] {
-  background-color: hsl(0deg, 0%, 4%);
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-black.is-inverted {
-  background-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-black.is-inverted:hover {
-  background-color: #f2f2f2;
-}
-.button.is-black.is-inverted[disabled] {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: transparent;
-  box-shadow: none;
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-black.is-loading::after {
-  border-color: transparent transparent hsl(0deg, 0%, 100%) hsl(0deg, 0%, 100%) !important;
-}
-.button.is-black.is-outlined {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-black.is-outlined:hover, .button.is-black.is-outlined:focus {
-  background-color: hsl(0deg, 0%, 4%);
-  border-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-black.is-outlined.is-loading::after {
-  border-color: transparent transparent hsl(0deg, 0%, 4%) hsl(0deg, 0%, 4%) !important;
-}
-.button.is-black.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 4%);
-  box-shadow: none;
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-black.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-black.is-inverted.is-outlined:hover, .button.is-black.is-inverted.is-outlined:focus {
-  background-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-black.is-inverted.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 100%);
-  box-shadow: none;
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-light {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: transparent;
-  color: #2d2d2d;
-}
-.button.is-light:hover, .button.is-light.is-hovered {
-  background-color: #eeeeee;
-  border-color: transparent;
-  color: #2d2d2d;
-}
-.button.is-light:focus, .button.is-light.is-focused {
-  border-color: transparent;
-  color: #2d2d2d;
-}
-.button.is-light:focus:not(:active), .button.is-light.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
-}
-.button.is-light:active, .button.is-light.is-active {
-  background-color: #e8e8e8;
-  border-color: transparent;
-  color: #2d2d2d;
-}
-.button.is-light[disabled] {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-light.is-inverted {
-  background-color: #2d2d2d;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-light.is-inverted:hover {
-  background-color: #202020;
-}
-.button.is-light.is-inverted[disabled] {
-  background-color: #2d2d2d;
-  border-color: transparent;
-  box-shadow: none;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-light.is-loading::after {
-  border-color: transparent transparent #2d2d2d #2d2d2d !important;
-}
-.button.is-light.is-outlined {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 96%);
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-light.is-outlined:hover, .button.is-light.is-outlined:focus {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.button.is-light.is-outlined.is-loading::after {
-  border-color: transparent transparent hsl(0deg, 0%, 96%) hsl(0deg, 0%, 96%) !important;
-}
-.button.is-light.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 96%);
-  box-shadow: none;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-light.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #2d2d2d;
-  color: #2d2d2d;
-}
-.button.is-light.is-inverted.is-outlined:hover, .button.is-light.is-inverted.is-outlined:focus {
-  background-color: #2d2d2d;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-light.is-inverted.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #2d2d2d;
-  box-shadow: none;
-  color: #2d2d2d;
-}
-.button.is-dark {
-  background-color: #2d2d2d;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-dark:hover, .button.is-dark.is-hovered {
-  background-color: #272727;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-dark:focus, .button.is-dark.is-focused {
-  border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-dark:focus:not(:active), .button.is-dark.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(45, 45, 45, 0.25);
-}
-.button.is-dark:active, .button.is-dark.is-active {
-  background-color: #202020;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-dark[disabled] {
-  background-color: #2d2d2d;
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-dark.is-inverted {
-  background-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.button.is-dark.is-inverted:hover {
-  background-color: #e8e8e8;
-}
-.button.is-dark.is-inverted[disabled] {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: transparent;
-  box-shadow: none;
-  color: #2d2d2d;
-}
-.button.is-dark.is-loading::after {
-  border-color: transparent transparent hsl(0deg, 0%, 96%) hsl(0deg, 0%, 96%) !important;
-}
-.button.is-dark.is-outlined {
-  background-color: transparent;
-  border-color: #2d2d2d;
-  color: #2d2d2d;
-}
-.button.is-dark.is-outlined:hover, .button.is-dark.is-outlined:focus {
-  background-color: #2d2d2d;
-  border-color: #2d2d2d;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-dark.is-outlined.is-loading::after {
-  border-color: transparent transparent #2d2d2d #2d2d2d !important;
-}
-.button.is-dark.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #2d2d2d;
-  box-shadow: none;
-  color: #2d2d2d;
-}
-.button.is-dark.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 96%);
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-dark.is-inverted.is-outlined:hover, .button.is-dark.is-inverted.is-outlined:focus {
-  background-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.button.is-dark.is-inverted.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 96%);
-  box-shadow: none;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-primary {
-  background-color: #b31b1b;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-primary:hover, .button.is-primary.is-hovered {
-  background-color: #a81919;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-primary:focus, .button.is-primary.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-primary:focus:not(:active), .button.is-primary.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(179, 27, 27, 0.25);
-}
-.button.is-primary:active, .button.is-primary.is-active {
-  background-color: #9d1818;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-primary[disabled] {
-  background-color: #b31b1b;
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-primary.is-inverted {
-  background-color: #fff;
-  color: #b31b1b;
-}
-.button.is-primary.is-inverted:hover {
-  background-color: #f2f2f2;
-}
-.button.is-primary.is-inverted[disabled] {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: #b31b1b;
-}
-.button.is-primary.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-primary.is-outlined {
-  background-color: transparent;
-  border-color: #b31b1b;
-  color: #b31b1b;
-}
-.button.is-primary.is-outlined:hover, .button.is-primary.is-outlined:focus {
-  background-color: #b31b1b;
-  border-color: #b31b1b;
-  color: #fff;
-}
-.button.is-primary.is-outlined.is-loading::after {
-  border-color: transparent transparent #b31b1b #b31b1b !important;
-}
-.button.is-primary.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #b31b1b;
-  box-shadow: none;
-  color: #b31b1b;
-}
-.button.is-primary.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-primary.is-inverted.is-outlined:hover, .button.is-primary.is-inverted.is-outlined:focus {
-  background-color: #fff;
-  color: #b31b1b;
-}
-.button.is-primary.is-inverted.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-link {
-  background-color: #086db1;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-link:hover, .button.is-link.is-hovered {
-  background-color: #0765a5;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-link:focus, .button.is-link.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-link:focus:not(:active), .button.is-link.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(8, 109, 177, 0.25);
-}
-.button.is-link:active, .button.is-link.is-active {
-  background-color: #075e99;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-link[disabled] {
-  background-color: #086db1;
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-link.is-inverted {
-  background-color: #fff;
-  color: #086db1;
-}
-.button.is-link.is-inverted:hover {
-  background-color: #f2f2f2;
-}
-.button.is-link.is-inverted[disabled] {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: #086db1;
-}
-.button.is-link.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-link.is-outlined {
-  background-color: transparent;
-  border-color: #086db1;
-  color: #086db1;
-}
-.button.is-link.is-outlined:hover, .button.is-link.is-outlined:focus {
-  background-color: #086db1;
-  border-color: #086db1;
-  color: #fff;
-}
-.button.is-link.is-outlined.is-loading::after {
-  border-color: transparent transparent #086db1 #086db1 !important;
-}
-.button.is-link.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #086db1;
-  box-shadow: none;
-  color: #086db1;
-}
-.button.is-link.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-link.is-inverted.is-outlined:hover, .button.is-link.is-inverted.is-outlined:focus {
-  background-color: #fff;
-  color: #086db1;
-}
-.button.is-link.is-inverted.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-info {
-  background-color: hsl(204deg, 86%, 53%);
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-info:hover, .button.is-info.is-hovered {
-  background-color: #1496ed;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-info:focus, .button.is-info.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-info:focus:not(:active), .button.is-info.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(32, 156, 238, 0.25);
-}
-.button.is-info:active, .button.is-info.is-active {
-  background-color: #118fe4;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-info[disabled] {
-  background-color: hsl(204deg, 86%, 53%);
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-info.is-inverted {
-  background-color: #fff;
-  color: hsl(204deg, 86%, 53%);
-}
-.button.is-info.is-inverted:hover {
-  background-color: #f2f2f2;
-}
-.button.is-info.is-inverted[disabled] {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: hsl(204deg, 86%, 53%);
-}
-.button.is-info.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-info.is-outlined {
-  background-color: transparent;
-  border-color: hsl(204deg, 86%, 53%);
-  color: hsl(204deg, 86%, 53%);
-}
-.button.is-info.is-outlined:hover, .button.is-info.is-outlined:focus {
-  background-color: hsl(204deg, 86%, 53%);
-  border-color: hsl(204deg, 86%, 53%);
-  color: #fff;
-}
-.button.is-info.is-outlined.is-loading::after {
-  border-color: transparent transparent hsl(204deg, 86%, 53%) hsl(204deg, 86%, 53%) !important;
-}
-.button.is-info.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: hsl(204deg, 86%, 53%);
-  box-shadow: none;
-  color: hsl(204deg, 86%, 53%);
-}
-.button.is-info.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-info.is-inverted.is-outlined:hover, .button.is-info.is-inverted.is-outlined:focus {
-  background-color: #fff;
-  color: hsl(204deg, 86%, 53%);
-}
-.button.is-info.is-inverted.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-success {
-  background-color: #008412;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-success:hover, .button.is-success.is-hovered {
-  background-color: #007710;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-success:focus, .button.is-success.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-success:focus:not(:active), .button.is-success.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(0, 132, 18, 0.25);
-}
-.button.is-success:active, .button.is-success.is-active {
-  background-color: #006b0f;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-success[disabled] {
-  background-color: #008412;
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-success.is-inverted {
-  background-color: #fff;
-  color: #008412;
-}
-.button.is-success.is-inverted:hover {
-  background-color: #f2f2f2;
-}
-.button.is-success.is-inverted[disabled] {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: #008412;
-}
-.button.is-success.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-success.is-outlined {
-  background-color: transparent;
-  border-color: #008412;
-  color: #008412;
-}
-.button.is-success.is-outlined:hover, .button.is-success.is-outlined:focus {
-  background-color: #008412;
-  border-color: #008412;
-  color: #fff;
-}
-.button.is-success.is-outlined.is-loading::after {
-  border-color: transparent transparent #008412 #008412 !important;
-}
-.button.is-success.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #008412;
-  box-shadow: none;
-  color: #008412;
-}
-.button.is-success.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-success.is-inverted.is-outlined:hover, .button.is-success.is-inverted.is-outlined:focus {
-  background-color: #fff;
-  color: #008412;
-}
-.button.is-success.is-inverted.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-warning {
-  background-color: #b55c06;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-warning:hover, .button.is-warning.is-hovered {
-  background-color: #a95606;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-warning:focus, .button.is-warning.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-warning:focus:not(:active), .button.is-warning.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(181, 92, 6, 0.25);
-}
-.button.is-warning:active, .button.is-warning.is-active {
-  background-color: #9c4f05;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-warning[disabled] {
-  background-color: #b55c06;
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-warning.is-inverted {
-  background-color: #fff;
-  color: #b55c06;
-}
-.button.is-warning.is-inverted:hover {
-  background-color: #f2f2f2;
-}
-.button.is-warning.is-inverted[disabled] {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: #b55c06;
-}
-.button.is-warning.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-warning.is-outlined {
-  background-color: transparent;
-  border-color: #b55c06;
-  color: #b55c06;
-}
-.button.is-warning.is-outlined:hover, .button.is-warning.is-outlined:focus {
-  background-color: #b55c06;
-  border-color: #b55c06;
-  color: #fff;
-}
-.button.is-warning.is-outlined.is-loading::after {
-  border-color: transparent transparent #b55c06 #b55c06 !important;
-}
-.button.is-warning.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #b55c06;
-  box-shadow: none;
-  color: #b55c06;
-}
-.button.is-warning.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-warning.is-inverted.is-outlined:hover, .button.is-warning.is-inverted.is-outlined:focus {
-  background-color: #fff;
-  color: #b55c06;
-}
-.button.is-warning.is-inverted.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-danger {
-  background-color: #cd0200;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-danger:hover, .button.is-danger.is-hovered {
-  background-color: #c00200;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-danger:focus, .button.is-danger.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-danger:focus:not(:active), .button.is-danger.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(205, 2, 0, 0.25);
-}
-.button.is-danger:active, .button.is-danger.is-active {
-  background-color: #b40200;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-danger[disabled] {
-  background-color: #cd0200;
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-danger.is-inverted {
-  background-color: #fff;
-  color: #cd0200;
-}
-.button.is-danger.is-inverted:hover {
-  background-color: #f2f2f2;
-}
-.button.is-danger.is-inverted[disabled] {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: #cd0200;
-}
-.button.is-danger.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-danger.is-outlined {
-  background-color: transparent;
-  border-color: #cd0200;
-  color: #cd0200;
-}
-.button.is-danger.is-outlined:hover, .button.is-danger.is-outlined:focus {
-  background-color: #cd0200;
-  border-color: #cd0200;
-  color: #fff;
-}
-.button.is-danger.is-outlined.is-loading::after {
-  border-color: transparent transparent #cd0200 #cd0200 !important;
-}
-.button.is-danger.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #cd0200;
-  box-shadow: none;
-  color: #cd0200;
-}
-.button.is-danger.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-danger.is-inverted.is-outlined:hover, .button.is-danger.is-inverted.is-outlined:focus {
-  background-color: #fff;
-  color: #cd0200;
-}
-.button.is-danger.is-inverted.is-outlined[disabled] {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-small {
-  border-radius: 2px;
-  font-size: 0.85rem;
-}
-.button.is-medium {
-  font-size: 1.25rem;
-}
-.button.is-large {
-  font-size: 1.5rem;
-}
-.button[disabled] {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: hsl(0deg, 0%, 80%);
-  box-shadow: none;
-  opacity: 0.5;
-}
-.button.is-fullwidth {
-  display: flex;
-  width: 100%;
-}
-.button.is-loading {
-  color: transparent !important;
-  pointer-events: none;
-}
-.button.is-loading::after {
-  position: absolute;
-  left: calc(50% - (1em / 2));
-  top: calc(50% - (1em / 2));
-  position: absolute !important;
-}
-.button.is-static {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: hsl(0deg, 0%, 80%);
-  color: #757575;
-  box-shadow: none;
-  pointer-events: none;
-}
-.button.is-rounded {
-  border-radius: 290486px;
-  padding-left: 1em;
-  padding-right: 1em;
-}
+  white-space: nowrap; }
+  .button strong {
+    color: inherit; }
+  .button .icon, .button .icon.is-small, .button .icon.is-medium, .button .icon.is-large {
+    height: 1.5em;
+    width: 1.5em; }
+  .button .icon:first-child:not(:last-child) {
+    margin-left: calc(-0.375em - 1px);
+    margin-right: 0.1875em; }
+  .button .icon:last-child:not(:first-child) {
+    margin-left: 0.1875em;
+    margin-right: calc(-0.375em - 1px); }
+  .button .icon:first-child:last-child {
+    margin-left: calc(-0.375em - 1px);
+    margin-right: calc(-0.375em - 1px); }
+  .button:hover, .button.is-hovered {
+    border-color: #999999;
+    color: gray; }
+  .button:focus, .button.is-focused {
+    border-color: #1565c0;
+    color: #2d2d2d; }
+    .button:focus:not(:active), .button.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(21, 101, 192, 0.25); }
+  .button:active, .button.is-active {
+    border-color: #333;
+    color: #2d2d2d; }
+  .button.is-text {
+    background-color: transparent;
+    border-color: transparent;
+    color: #333;
+    text-decoration: underline; }
+    .button.is-text:hover, .button.is-text.is-hovered, .button.is-text:focus, .button.is-text.is-focused {
+      background-color: whitesmoke;
+      color: #2d2d2d; }
+    .button.is-text:active, .button.is-text.is-active {
+      background-color: #e8e8e8;
+      color: #2d2d2d; }
+    .button.is-text[disabled] {
+      background-color: transparent;
+      border-color: transparent;
+      box-shadow: none; }
+  .button.is-white {
+    background-color: white;
+    border-color: transparent;
+    color: #0a0a0a; }
+    .button.is-white:hover, .button.is-white.is-hovered {
+      background-color: #f9f9f9;
+      border-color: transparent;
+      color: #0a0a0a; }
+    .button.is-white:focus, .button.is-white.is-focused {
+      border-color: transparent;
+      color: #0a0a0a; }
+      .button.is-white:focus:not(:active), .button.is-white.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25); }
+    .button.is-white:active, .button.is-white.is-active {
+      background-color: #f2f2f2;
+      border-color: transparent;
+      color: #0a0a0a; }
+    .button.is-white[disabled] {
+      background-color: white;
+      border-color: transparent;
+      box-shadow: none; }
+    .button.is-white.is-inverted {
+      background-color: #0a0a0a;
+      color: white; }
+      .button.is-white.is-inverted:hover {
+        background-color: black; }
+      .button.is-white.is-inverted[disabled] {
+        background-color: #0a0a0a;
+        border-color: transparent;
+        box-shadow: none;
+        color: white; }
+    .button.is-white.is-loading::after {
+      border-color: transparent transparent #0a0a0a #0a0a0a !important; }
+    .button.is-white.is-outlined {
+      background-color: transparent;
+      border-color: white;
+      color: white; }
+      .button.is-white.is-outlined:hover, .button.is-white.is-outlined:focus {
+        background-color: white;
+        border-color: white;
+        color: #0a0a0a; }
+      .button.is-white.is-outlined.is-loading::after {
+        border-color: transparent transparent white white !important; }
+      .button.is-white.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: white;
+        box-shadow: none;
+        color: white; }
+    .button.is-white.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #0a0a0a;
+      color: #0a0a0a; }
+      .button.is-white.is-inverted.is-outlined:hover, .button.is-white.is-inverted.is-outlined:focus {
+        background-color: #0a0a0a;
+        color: white; }
+      .button.is-white.is-inverted.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #0a0a0a;
+        box-shadow: none;
+        color: #0a0a0a; }
+  .button.is-black {
+    background-color: #0a0a0a;
+    border-color: transparent;
+    color: white; }
+    .button.is-black:hover, .button.is-black.is-hovered {
+      background-color: #040404;
+      border-color: transparent;
+      color: white; }
+    .button.is-black:focus, .button.is-black.is-focused {
+      border-color: transparent;
+      color: white; }
+      .button.is-black:focus:not(:active), .button.is-black.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.25); }
+    .button.is-black:active, .button.is-black.is-active {
+      background-color: black;
+      border-color: transparent;
+      color: white; }
+    .button.is-black[disabled] {
+      background-color: #0a0a0a;
+      border-color: transparent;
+      box-shadow: none; }
+    .button.is-black.is-inverted {
+      background-color: white;
+      color: #0a0a0a; }
+      .button.is-black.is-inverted:hover {
+        background-color: #f2f2f2; }
+      .button.is-black.is-inverted[disabled] {
+        background-color: white;
+        border-color: transparent;
+        box-shadow: none;
+        color: #0a0a0a; }
+    .button.is-black.is-loading::after {
+      border-color: transparent transparent white white !important; }
+    .button.is-black.is-outlined {
+      background-color: transparent;
+      border-color: #0a0a0a;
+      color: #0a0a0a; }
+      .button.is-black.is-outlined:hover, .button.is-black.is-outlined:focus {
+        background-color: #0a0a0a;
+        border-color: #0a0a0a;
+        color: white; }
+      .button.is-black.is-outlined.is-loading::after {
+        border-color: transparent transparent #0a0a0a #0a0a0a !important; }
+      .button.is-black.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #0a0a0a;
+        box-shadow: none;
+        color: #0a0a0a; }
+    .button.is-black.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: white;
+      color: white; }
+      .button.is-black.is-inverted.is-outlined:hover, .button.is-black.is-inverted.is-outlined:focus {
+        background-color: white;
+        color: #0a0a0a; }
+      .button.is-black.is-inverted.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: white;
+        box-shadow: none;
+        color: white; }
+  .button.is-light {
+    background-color: whitesmoke;
+    border-color: transparent;
+    color: #2d2d2d; }
+    .button.is-light:hover, .button.is-light.is-hovered {
+      background-color: #eeeeee;
+      border-color: transparent;
+      color: #2d2d2d; }
+    .button.is-light:focus, .button.is-light.is-focused {
+      border-color: transparent;
+      color: #2d2d2d; }
+      .button.is-light:focus:not(:active), .button.is-light.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25); }
+    .button.is-light:active, .button.is-light.is-active {
+      background-color: #e8e8e8;
+      border-color: transparent;
+      color: #2d2d2d; }
+    .button.is-light[disabled] {
+      background-color: whitesmoke;
+      border-color: transparent;
+      box-shadow: none; }
+    .button.is-light.is-inverted {
+      background-color: #2d2d2d;
+      color: whitesmoke; }
+      .button.is-light.is-inverted:hover {
+        background-color: #202020; }
+      .button.is-light.is-inverted[disabled] {
+        background-color: #2d2d2d;
+        border-color: transparent;
+        box-shadow: none;
+        color: whitesmoke; }
+    .button.is-light.is-loading::after {
+      border-color: transparent transparent #2d2d2d #2d2d2d !important; }
+    .button.is-light.is-outlined {
+      background-color: transparent;
+      border-color: whitesmoke;
+      color: whitesmoke; }
+      .button.is-light.is-outlined:hover, .button.is-light.is-outlined:focus {
+        background-color: whitesmoke;
+        border-color: whitesmoke;
+        color: #2d2d2d; }
+      .button.is-light.is-outlined.is-loading::after {
+        border-color: transparent transparent whitesmoke whitesmoke !important; }
+      .button.is-light.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: whitesmoke;
+        box-shadow: none;
+        color: whitesmoke; }
+    .button.is-light.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #2d2d2d;
+      color: #2d2d2d; }
+      .button.is-light.is-inverted.is-outlined:hover, .button.is-light.is-inverted.is-outlined:focus {
+        background-color: #2d2d2d;
+        color: whitesmoke; }
+      .button.is-light.is-inverted.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #2d2d2d;
+        box-shadow: none;
+        color: #2d2d2d; }
+  .button.is-dark {
+    background-color: #2d2d2d;
+    border-color: transparent;
+    color: whitesmoke; }
+    .button.is-dark:hover, .button.is-dark.is-hovered {
+      background-color: #272727;
+      border-color: transparent;
+      color: whitesmoke; }
+    .button.is-dark:focus, .button.is-dark.is-focused {
+      border-color: transparent;
+      color: whitesmoke; }
+      .button.is-dark:focus:not(:active), .button.is-dark.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(45, 45, 45, 0.25); }
+    .button.is-dark:active, .button.is-dark.is-active {
+      background-color: #202020;
+      border-color: transparent;
+      color: whitesmoke; }
+    .button.is-dark[disabled] {
+      background-color: #2d2d2d;
+      border-color: transparent;
+      box-shadow: none; }
+    .button.is-dark.is-inverted {
+      background-color: whitesmoke;
+      color: #2d2d2d; }
+      .button.is-dark.is-inverted:hover {
+        background-color: #e8e8e8; }
+      .button.is-dark.is-inverted[disabled] {
+        background-color: whitesmoke;
+        border-color: transparent;
+        box-shadow: none;
+        color: #2d2d2d; }
+    .button.is-dark.is-loading::after {
+      border-color: transparent transparent whitesmoke whitesmoke !important; }
+    .button.is-dark.is-outlined {
+      background-color: transparent;
+      border-color: #2d2d2d;
+      color: #2d2d2d; }
+      .button.is-dark.is-outlined:hover, .button.is-dark.is-outlined:focus {
+        background-color: #2d2d2d;
+        border-color: #2d2d2d;
+        color: whitesmoke; }
+      .button.is-dark.is-outlined.is-loading::after {
+        border-color: transparent transparent #2d2d2d #2d2d2d !important; }
+      .button.is-dark.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #2d2d2d;
+        box-shadow: none;
+        color: #2d2d2d; }
+    .button.is-dark.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: whitesmoke;
+      color: whitesmoke; }
+      .button.is-dark.is-inverted.is-outlined:hover, .button.is-dark.is-inverted.is-outlined:focus {
+        background-color: whitesmoke;
+        color: #2d2d2d; }
+      .button.is-dark.is-inverted.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: whitesmoke;
+        box-shadow: none;
+        color: whitesmoke; }
+  .button.is-primary {
+    background-color: #b31b1b;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-primary:hover, .button.is-primary.is-hovered {
+      background-color: #a81919;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-primary:focus, .button.is-primary.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-primary:focus:not(:active), .button.is-primary.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(179, 27, 27, 0.25); }
+    .button.is-primary:active, .button.is-primary.is-active {
+      background-color: #9d1818;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-primary[disabled] {
+      background-color: #b31b1b;
+      border-color: transparent;
+      box-shadow: none; }
+    .button.is-primary.is-inverted {
+      background-color: #fff;
+      color: #b31b1b; }
+      .button.is-primary.is-inverted:hover {
+        background-color: #f2f2f2; }
+      .button.is-primary.is-inverted[disabled] {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #b31b1b; }
+    .button.is-primary.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-primary.is-outlined {
+      background-color: transparent;
+      border-color: #b31b1b;
+      color: #b31b1b; }
+      .button.is-primary.is-outlined:hover, .button.is-primary.is-outlined:focus {
+        background-color: #b31b1b;
+        border-color: #b31b1b;
+        color: #fff; }
+      .button.is-primary.is-outlined.is-loading::after {
+        border-color: transparent transparent #b31b1b #b31b1b !important; }
+      .button.is-primary.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #b31b1b;
+        box-shadow: none;
+        color: #b31b1b; }
+    .button.is-primary.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-primary.is-inverted.is-outlined:hover, .button.is-primary.is-inverted.is-outlined:focus {
+        background-color: #fff;
+        color: #b31b1b; }
+      .button.is-primary.is-inverted.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+  .button.is-link {
+    background-color: #1565c0;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-link:hover, .button.is-link.is-hovered {
+      background-color: #145fb5;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-link:focus, .button.is-link.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-link:focus:not(:active), .button.is-link.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(21, 101, 192, 0.25); }
+    .button.is-link:active, .button.is-link.is-active {
+      background-color: #1259a9;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-link[disabled] {
+      background-color: #1565c0;
+      border-color: transparent;
+      box-shadow: none; }
+    .button.is-link.is-inverted {
+      background-color: #fff;
+      color: #1565c0; }
+      .button.is-link.is-inverted:hover {
+        background-color: #f2f2f2; }
+      .button.is-link.is-inverted[disabled] {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #1565c0; }
+    .button.is-link.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-link.is-outlined {
+      background-color: transparent;
+      border-color: #1565c0;
+      color: #1565c0; }
+      .button.is-link.is-outlined:hover, .button.is-link.is-outlined:focus {
+        background-color: #1565c0;
+        border-color: #1565c0;
+        color: #fff; }
+      .button.is-link.is-outlined.is-loading::after {
+        border-color: transparent transparent #1565c0 #1565c0 !important; }
+      .button.is-link.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #1565c0;
+        box-shadow: none;
+        color: #1565c0; }
+    .button.is-link.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-link.is-inverted.is-outlined:hover, .button.is-link.is-inverted.is-outlined:focus {
+        background-color: #fff;
+        color: #1565c0; }
+      .button.is-link.is-inverted.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+  .button.is-info {
+    background-color: #209cee;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-info:hover, .button.is-info.is-hovered {
+      background-color: #1496ed;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-info:focus, .button.is-info.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-info:focus:not(:active), .button.is-info.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(32, 156, 238, 0.25); }
+    .button.is-info:active, .button.is-info.is-active {
+      background-color: #118fe4;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-info[disabled] {
+      background-color: #209cee;
+      border-color: transparent;
+      box-shadow: none; }
+    .button.is-info.is-inverted {
+      background-color: #fff;
+      color: #209cee; }
+      .button.is-info.is-inverted:hover {
+        background-color: #f2f2f2; }
+      .button.is-info.is-inverted[disabled] {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #209cee; }
+    .button.is-info.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-info.is-outlined {
+      background-color: transparent;
+      border-color: #209cee;
+      color: #209cee; }
+      .button.is-info.is-outlined:hover, .button.is-info.is-outlined:focus {
+        background-color: #209cee;
+        border-color: #209cee;
+        color: #fff; }
+      .button.is-info.is-outlined.is-loading::after {
+        border-color: transparent transparent #209cee #209cee !important; }
+      .button.is-info.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #209cee;
+        box-shadow: none;
+        color: #209cee; }
+    .button.is-info.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-info.is-inverted.is-outlined:hover, .button.is-info.is-inverted.is-outlined:focus {
+        background-color: #fff;
+        color: #209cee; }
+      .button.is-info.is-inverted.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+  .button.is-success {
+    background-color: #008412;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-success:hover, .button.is-success.is-hovered {
+      background-color: #007710;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-success:focus, .button.is-success.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-success:focus:not(:active), .button.is-success.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(0, 132, 18, 0.25); }
+    .button.is-success:active, .button.is-success.is-active {
+      background-color: #006b0f;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-success[disabled] {
+      background-color: #008412;
+      border-color: transparent;
+      box-shadow: none; }
+    .button.is-success.is-inverted {
+      background-color: #fff;
+      color: #008412; }
+      .button.is-success.is-inverted:hover {
+        background-color: #f2f2f2; }
+      .button.is-success.is-inverted[disabled] {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #008412; }
+    .button.is-success.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-success.is-outlined {
+      background-color: transparent;
+      border-color: #008412;
+      color: #008412; }
+      .button.is-success.is-outlined:hover, .button.is-success.is-outlined:focus {
+        background-color: #008412;
+        border-color: #008412;
+        color: #fff; }
+      .button.is-success.is-outlined.is-loading::after {
+        border-color: transparent transparent #008412 #008412 !important; }
+      .button.is-success.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #008412;
+        box-shadow: none;
+        color: #008412; }
+    .button.is-success.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-success.is-inverted.is-outlined:hover, .button.is-success.is-inverted.is-outlined:focus {
+        background-color: #fff;
+        color: #008412; }
+      .button.is-success.is-inverted.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+  .button.is-warning {
+    background-color: #b55c06;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-warning:hover, .button.is-warning.is-hovered {
+      background-color: #a95606;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-warning:focus, .button.is-warning.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-warning:focus:not(:active), .button.is-warning.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(181, 92, 6, 0.25); }
+    .button.is-warning:active, .button.is-warning.is-active {
+      background-color: #9c4f05;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-warning[disabled] {
+      background-color: #b55c06;
+      border-color: transparent;
+      box-shadow: none; }
+    .button.is-warning.is-inverted {
+      background-color: #fff;
+      color: #b55c06; }
+      .button.is-warning.is-inverted:hover {
+        background-color: #f2f2f2; }
+      .button.is-warning.is-inverted[disabled] {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #b55c06; }
+    .button.is-warning.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-warning.is-outlined {
+      background-color: transparent;
+      border-color: #b55c06;
+      color: #b55c06; }
+      .button.is-warning.is-outlined:hover, .button.is-warning.is-outlined:focus {
+        background-color: #b55c06;
+        border-color: #b55c06;
+        color: #fff; }
+      .button.is-warning.is-outlined.is-loading::after {
+        border-color: transparent transparent #b55c06 #b55c06 !important; }
+      .button.is-warning.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #b55c06;
+        box-shadow: none;
+        color: #b55c06; }
+    .button.is-warning.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-warning.is-inverted.is-outlined:hover, .button.is-warning.is-inverted.is-outlined:focus {
+        background-color: #fff;
+        color: #b55c06; }
+      .button.is-warning.is-inverted.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+  .button.is-danger {
+    background-color: #cd0200;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-danger:hover, .button.is-danger.is-hovered {
+      background-color: #c00200;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-danger:focus, .button.is-danger.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-danger:focus:not(:active), .button.is-danger.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(205, 2, 0, 0.25); }
+    .button.is-danger:active, .button.is-danger.is-active {
+      background-color: #b40200;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-danger[disabled] {
+      background-color: #cd0200;
+      border-color: transparent;
+      box-shadow: none; }
+    .button.is-danger.is-inverted {
+      background-color: #fff;
+      color: #cd0200; }
+      .button.is-danger.is-inverted:hover {
+        background-color: #f2f2f2; }
+      .button.is-danger.is-inverted[disabled] {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #cd0200; }
+    .button.is-danger.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-danger.is-outlined {
+      background-color: transparent;
+      border-color: #cd0200;
+      color: #cd0200; }
+      .button.is-danger.is-outlined:hover, .button.is-danger.is-outlined:focus {
+        background-color: #cd0200;
+        border-color: #cd0200;
+        color: #fff; }
+      .button.is-danger.is-outlined.is-loading::after {
+        border-color: transparent transparent #cd0200 #cd0200 !important; }
+      .button.is-danger.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #cd0200;
+        box-shadow: none;
+        color: #cd0200; }
+    .button.is-danger.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-danger.is-inverted.is-outlined:hover, .button.is-danger.is-inverted.is-outlined:focus {
+        background-color: #fff;
+        color: #cd0200; }
+      .button.is-danger.is-inverted.is-outlined[disabled] {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+  .button.is-small {
+    border-radius: 2px;
+    font-size: 0.85rem; }
+  .button.is-medium {
+    font-size: 1.25rem; }
+  .button.is-large {
+    font-size: 1.5rem; }
+  .button[disabled] {
+    background-color: white;
+    border-color: #cccccc;
+    box-shadow: none;
+    opacity: 0.5; }
+  .button.is-fullwidth {
+    display: flex;
+    width: 100%; }
+  .button.is-loading {
+    color: transparent !important;
+    pointer-events: none; }
+    .button.is-loading::after {
+      position: absolute;
+      left: calc(50% - (1em / 2));
+      top: calc(50% - (1em / 2));
+      position: absolute !important; }
+  .button.is-static {
+    background-color: whitesmoke;
+    border-color: #cccccc;
+    color: #757575;
+    box-shadow: none;
+    pointer-events: none; }
+  .button.is-rounded {
+    border-radius: 290486px;
+    padding-left: 1em;
+    padding-right: 1em; }
 
 .buttons {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-start;
-}
-.buttons .button {
-  margin-bottom: 0.5rem;
-}
-.buttons .button:not(:last-child):not(.is-fullwidth) {
-  margin-right: 0.5rem;
-}
-.buttons:last-child {
-  margin-bottom: -0.5rem;
-}
-.buttons:not(:last-child) {
-  margin-bottom: 1rem;
-}
-.buttons.has-addons .button:not(:first-child) {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-}
-.buttons.has-addons .button:not(:last-child) {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-  margin-right: -1px;
-}
-.buttons.has-addons .button:last-child {
-  margin-right: 0;
-}
-.buttons.has-addons .button:hover, .buttons.has-addons .button.is-hovered {
-  z-index: 2;
-}
-.buttons.has-addons .button:focus, .buttons.has-addons .button.is-focused, .buttons.has-addons .button:active, .buttons.has-addons .button.is-active, .buttons.has-addons .button.is-selected {
-  z-index: 3;
-}
-.buttons.has-addons .button:focus:hover, .buttons.has-addons .button.is-focused:hover, .buttons.has-addons .button:active:hover, .buttons.has-addons .button.is-active:hover, .buttons.has-addons .button.is-selected:hover {
-  z-index: 4;
-}
-.buttons.has-addons .button.is-expanded {
-  flex-grow: 1;
-}
-.buttons.is-centered {
-  justify-content: center;
-}
-.buttons.is-right {
-  justify-content: flex-end;
-}
+  justify-content: flex-start; }
+  .buttons .button {
+    margin-bottom: 0.5rem; }
+    .buttons .button:not(:last-child):not(.is-fullwidth) {
+      margin-right: 0.5rem; }
+  .buttons:last-child {
+    margin-bottom: -0.5rem; }
+  .buttons:not(:last-child) {
+    margin-bottom: 1rem; }
+  .buttons.has-addons .button:not(:first-child) {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0; }
+  .buttons.has-addons .button:not(:last-child) {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+    margin-right: -1px; }
+  .buttons.has-addons .button:last-child {
+    margin-right: 0; }
+  .buttons.has-addons .button:hover, .buttons.has-addons .button.is-hovered {
+    z-index: 2; }
+  .buttons.has-addons .button:focus, .buttons.has-addons .button.is-focused, .buttons.has-addons .button:active, .buttons.has-addons .button.is-active, .buttons.has-addons .button.is-selected {
+    z-index: 3; }
+    .buttons.has-addons .button:focus:hover, .buttons.has-addons .button.is-focused:hover, .buttons.has-addons .button:active:hover, .buttons.has-addons .button.is-active:hover, .buttons.has-addons .button.is-selected:hover {
+      z-index: 4; }
+  .buttons.has-addons .button.is-expanded {
+    flex-grow: 1; }
+  .buttons.is-centered {
+    justify-content: center; }
+  .buttons.is-right {
+    justify-content: flex-end; }
 
 .container {
   margin: 0 auto;
-  position: relative;
-}
-@media screen and (min-width: 1088px) {
-  .container {
-    max-width: 960px;
-    width: 960px;
-  }
-  .container.is-fluid {
-    margin-left: 64px;
-    margin-right: 64px;
-    max-width: none;
-    width: auto;
-  }
-}
-@media screen and (max-width: 1279px) {
-  .container.is-widescreen {
-    max-width: 1152px;
-    width: auto;
-  }
-}
-@media screen and (max-width: 1471px) {
-  .container.is-fullhd {
-    max-width: 1344px;
-    width: auto;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .container {
-    max-width: 1152px;
-    width: 1152px;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .container {
-    max-width: 1344px;
-    width: 1344px;
-  }
-}
-
+  position: relative; }
+  @media screen and (min-width: 1088px) {
+    .container {
+      max-width: 960px;
+      width: 960px; }
+      .container.is-fluid {
+        margin-left: 64px;
+        margin-right: 64px;
+        max-width: none;
+        width: auto; } }
+  @media screen and (max-width: 1279px) {
+    .container.is-widescreen {
+      max-width: 1152px;
+      width: auto; } }
+  @media screen and (max-width: 1471px) {
+    .container.is-fullhd {
+      max-width: 1344px;
+      width: auto; } }
+  @media screen and (min-width: 1280px) {
+    .container {
+      max-width: 1152px;
+      width: 1152px; } }
+  @media screen and (min-width: 1472px) {
+    .container {
+      max-width: 1344px;
+      width: 1344px; } }
 .content li + li {
-  margin-top: 0.25em;
-}
+  margin-top: 0.25em; }
+
 .content p:not(:last-child),
 .content dl:not(:last-child),
 .content ol:not(:last-child),
@@ -2362,8 +1868,8 @@ a.box:active {
 .content blockquote:not(:last-child),
 .content pre:not(:last-child),
 .content table:not(:last-child) {
-  margin-bottom: 1em;
-}
+  margin-bottom: 1em; }
+
 .content h1,
 .content h2,
 .content h3,
@@ -2372,932 +1878,726 @@ a.box:active {
 .content h6 {
   color: #2d2d2d;
   font-weight: 600;
-  line-height: 1.125;
-}
+  line-height: 1.125; }
+
 .content h1 {
   font-size: 2em;
-  margin-bottom: 0.5em;
-}
-.content h1:not(:first-child) {
-  margin-top: 1em;
-}
+  margin-bottom: 0.5em; }
+  .content h1:not(:first-child) {
+    margin-top: 1em; }
+
 .content h2 {
   font-size: 1.75em;
-  margin-bottom: 0.5714em;
-}
-.content h2:not(:first-child) {
-  margin-top: 1.1428em;
-}
+  margin-bottom: 0.5714em; }
+  .content h2:not(:first-child) {
+    margin-top: 1.1428em; }
+
 .content h3 {
   font-size: 1.5em;
-  margin-bottom: 0.6666em;
-}
-.content h3:not(:first-child) {
-  margin-top: 1.3333em;
-}
+  margin-bottom: 0.6666em; }
+  .content h3:not(:first-child) {
+    margin-top: 1.3333em; }
+
 .content h4 {
   font-size: 1.25em;
-  margin-bottom: 0.8em;
-}
+  margin-bottom: 0.8em; }
+
 .content h5 {
   font-size: 1.125em;
-  margin-bottom: 0.8888em;
-}
+  margin-bottom: 0.8888em; }
+
 .content h6 {
   font-size: 1em;
-  margin-bottom: 1em;
-}
+  margin-bottom: 1em; }
+
 .content blockquote {
-  background-color: hsl(0deg, 0%, 96%);
-  border-left: 5px solid hsl(0deg, 0%, 80%);
-  padding: 1.25em 1.5em;
-}
+  background-color: whitesmoke;
+  border-left: 5px solid #cccccc;
+  padding: 1.25em 1.5em; }
+
 .content ol {
   list-style-position: outside;
   margin-left: 2em;
-  margin-top: 1em;
-}
-.content ol:not([type]) {
-  list-style-type: decimal;
-}
-.content ol:not([type]).is-lower-alpha {
-  list-style-type: lower-alpha;
-}
-.content ol:not([type]).is-lower-roman {
-  list-style-type: lower-roman;
-}
-.content ol:not([type]).is-upper-alpha {
-  list-style-type: upper-alpha;
-}
-.content ol:not([type]).is-upper-roman {
-  list-style-type: upper-roman;
-}
+  margin-top: 1em; }
+  .content ol:not([type]) {
+    list-style-type: decimal; }
+    .content ol:not([type]).is-lower-alpha {
+      list-style-type: lower-alpha; }
+    .content ol:not([type]).is-lower-roman {
+      list-style-type: lower-roman; }
+    .content ol:not([type]).is-upper-alpha {
+      list-style-type: upper-alpha; }
+    .content ol:not([type]).is-upper-roman {
+      list-style-type: upper-roman; }
+
 .content ul {
   list-style: disc outside;
   margin-left: 2em;
-  margin-top: 1em;
-}
-.content ul ul {
-  list-style-type: circle;
-  margin-top: 0.5em;
-}
-.content ul ul ul {
-  list-style-type: square;
-}
+  margin-top: 1em; }
+  .content ul ul {
+    list-style-type: circle;
+    margin-top: 0.5em; }
+    .content ul ul ul {
+      list-style-type: square; }
+
 .content dd {
-  margin-left: 2em;
-}
+  margin-left: 2em; }
+
 .content figure {
   margin-left: 2em;
   margin-right: 2em;
-  text-align: center;
-}
-.content figure:not(:first-child) {
-  margin-top: 2em;
-}
-.content figure:not(:last-child) {
-  margin-bottom: 2em;
-}
-.content figure img {
-  display: inline-block;
-}
-.content figure figcaption {
-  font-style: italic;
-}
+  text-align: center; }
+  .content figure:not(:first-child) {
+    margin-top: 2em; }
+  .content figure:not(:last-child) {
+    margin-bottom: 2em; }
+  .content figure img {
+    display: inline-block; }
+  .content figure figcaption {
+    font-style: italic; }
+
 .content pre {
   -webkit-overflow-scrolling: touch;
   overflow-x: auto;
   padding: 1.25em 1.5em;
   white-space: pre;
-  word-wrap: normal;
-}
+  word-wrap: normal; }
+
 .content sup,
 .content sub {
-  font-size: 75%;
-}
+  font-size: 75%; }
+
 .content table {
-  width: 100%;
-}
-.content table td,
-.content table th {
-  border: 1px solid hsl(0deg, 0%, 80%);
-  border-width: 0 0 1px;
-  padding: 0.5em 0.75em;
-  vertical-align: top;
-}
-.content table th {
-  color: #2d2d2d;
-  text-align: left;
-}
-.content table thead td,
-.content table thead th {
-  border-width: 0 0 2px;
-  color: #2d2d2d;
-}
-.content table tfoot td,
-.content table tfoot th {
-  border-width: 2px 0 0;
-  color: #2d2d2d;
-}
-.content table tbody tr:last-child td,
-.content table tbody tr:last-child th {
-  border-bottom-width: 0;
-}
+  width: 100%; }
+  .content table td,
+  .content table th {
+    border: 1px solid #cccccc;
+    border-width: 0 0 1px;
+    padding: 0.5em 0.75em;
+    vertical-align: top; }
+  .content table th {
+    color: #2d2d2d;
+    text-align: left; }
+  .content table thead td,
+  .content table thead th {
+    border-width: 0 0 2px;
+    color: #2d2d2d; }
+  .content table tfoot td,
+  .content table tfoot th {
+    border-width: 2px 0 0;
+    color: #2d2d2d; }
+  .content table tbody tr:last-child td,
+  .content table tbody tr:last-child th {
+    border-bottom-width: 0; }
+
 .content.is-small {
-  font-size: 0.85rem;
-}
+  font-size: 0.85rem; }
+
 .content.is-medium {
-  font-size: 1.25rem;
-}
+  font-size: 1.25rem; }
+
 .content.is-large {
-  font-size: 1.5rem;
-}
+  font-size: 1.5rem; }
 
 .input,
 .textarea {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: hsl(0deg, 0%, 80%);
+  background-color: white;
+  border-color: #cccccc;
   color: #2d2d2d;
   box-shadow: inset 0 1px 2px rgba(10, 10, 10, 0.1);
   max-width: 100%;
-  width: 100%;
-}
-.input::-moz-placeholder,
-.textarea::-moz-placeholder {
-  color: rgba(45, 45, 45, 0.3);
-}
-.input::-webkit-input-placeholder,
-.textarea::-webkit-input-placeholder {
-  color: rgba(45, 45, 45, 0.3);
-}
-.input:-moz-placeholder,
-.textarea:-moz-placeholder {
-  color: rgba(45, 45, 45, 0.3);
-}
-.input:-ms-input-placeholder,
-.textarea:-ms-input-placeholder {
-  color: rgba(45, 45, 45, 0.3);
-}
-.input:hover, .input.is-hovered,
-.textarea:hover,
-.textarea.is-hovered {
-  border-color: hsl(0deg, 0%, 60%);
-}
-.input:focus, .input.is-focused, .input:active, .input.is-active,
-.textarea:focus,
-.textarea.is-focused,
-.textarea:active,
-.textarea.is-active {
-  border-color: #086db1;
-  box-shadow: 0 0 0 0.125em rgba(8, 109, 177, 0.25);
-}
-.input[disabled],
-.textarea[disabled] {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: hsl(0deg, 0%, 96%);
-  box-shadow: none;
-  color: #757575;
-}
-.input[disabled]::-moz-placeholder,
-.textarea[disabled]::-moz-placeholder {
-  color: rgba(117, 117, 117, 0.3);
-}
-.input[disabled]::-webkit-input-placeholder,
-.textarea[disabled]::-webkit-input-placeholder {
-  color: rgba(117, 117, 117, 0.3);
-}
-.input[disabled]:-moz-placeholder,
-.textarea[disabled]:-moz-placeholder {
-  color: rgba(117, 117, 117, 0.3);
-}
-.input[disabled]:-ms-input-placeholder,
-.textarea[disabled]:-ms-input-placeholder {
-  color: rgba(117, 117, 117, 0.3);
-}
-.input[readonly],
-.textarea[readonly] {
-  box-shadow: none;
-}
-.input.is-white,
-.textarea.is-white {
-  border-color: hsl(0deg, 0%, 100%);
-}
-.input.is-white:focus, .input.is-white.is-focused, .input.is-white:active, .input.is-white.is-active,
-.textarea.is-white:focus,
-.textarea.is-white.is-focused,
-.textarea.is-white:active,
-.textarea.is-white.is-active {
-  box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25);
-}
-.input.is-black,
-.textarea.is-black {
-  border-color: hsl(0deg, 0%, 4%);
-}
-.input.is-black:focus, .input.is-black.is-focused, .input.is-black:active, .input.is-black.is-active,
-.textarea.is-black:focus,
-.textarea.is-black.is-focused,
-.textarea.is-black:active,
-.textarea.is-black.is-active {
-  box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.25);
-}
-.input.is-light,
-.textarea.is-light {
-  border-color: hsl(0deg, 0%, 96%);
-}
-.input.is-light:focus, .input.is-light.is-focused, .input.is-light:active, .input.is-light.is-active,
-.textarea.is-light:focus,
-.textarea.is-light.is-focused,
-.textarea.is-light:active,
-.textarea.is-light.is-active {
-  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
-}
-.input.is-dark,
-.textarea.is-dark {
-  border-color: #2d2d2d;
-}
-.input.is-dark:focus, .input.is-dark.is-focused, .input.is-dark:active, .input.is-dark.is-active,
-.textarea.is-dark:focus,
-.textarea.is-dark.is-focused,
-.textarea.is-dark:active,
-.textarea.is-dark.is-active {
-  box-shadow: 0 0 0 0.125em rgba(45, 45, 45, 0.25);
-}
-.input.is-primary,
-.textarea.is-primary {
-  border-color: #b31b1b;
-}
-.input.is-primary:focus, .input.is-primary.is-focused, .input.is-primary:active, .input.is-primary.is-active,
-.textarea.is-primary:focus,
-.textarea.is-primary.is-focused,
-.textarea.is-primary:active,
-.textarea.is-primary.is-active {
-  box-shadow: 0 0 0 0.125em rgba(179, 27, 27, 0.25);
-}
-.input.is-link,
-.textarea.is-link {
-  border-color: #086db1;
-}
-.input.is-link:focus, .input.is-link.is-focused, .input.is-link:active, .input.is-link.is-active,
-.textarea.is-link:focus,
-.textarea.is-link.is-focused,
-.textarea.is-link:active,
-.textarea.is-link.is-active {
-  box-shadow: 0 0 0 0.125em rgba(8, 109, 177, 0.25);
-}
-.input.is-info,
-.textarea.is-info {
-  border-color: hsl(204deg, 86%, 53%);
-}
-.input.is-info:focus, .input.is-info.is-focused, .input.is-info:active, .input.is-info.is-active,
-.textarea.is-info:focus,
-.textarea.is-info.is-focused,
-.textarea.is-info:active,
-.textarea.is-info.is-active {
-  box-shadow: 0 0 0 0.125em rgba(32, 156, 238, 0.25);
-}
-.input.is-success,
-.textarea.is-success {
-  border-color: #008412;
-}
-.input.is-success:focus, .input.is-success.is-focused, .input.is-success:active, .input.is-success.is-active,
-.textarea.is-success:focus,
-.textarea.is-success.is-focused,
-.textarea.is-success:active,
-.textarea.is-success.is-active {
-  box-shadow: 0 0 0 0.125em rgba(0, 132, 18, 0.25);
-}
-.input.is-warning,
-.textarea.is-warning {
-  border-color: #b55c06;
-}
-.input.is-warning:focus, .input.is-warning.is-focused, .input.is-warning:active, .input.is-warning.is-active,
-.textarea.is-warning:focus,
-.textarea.is-warning.is-focused,
-.textarea.is-warning:active,
-.textarea.is-warning.is-active {
-  box-shadow: 0 0 0 0.125em rgba(181, 92, 6, 0.25);
-}
-.input.is-danger,
-.textarea.is-danger {
-  border-color: #cd0200;
-}
-.input.is-danger:focus, .input.is-danger.is-focused, .input.is-danger:active, .input.is-danger.is-active,
-.textarea.is-danger:focus,
-.textarea.is-danger.is-focused,
-.textarea.is-danger:active,
-.textarea.is-danger.is-active {
-  box-shadow: 0 0 0 0.125em rgba(205, 2, 0, 0.25);
-}
-.input.is-small,
-.textarea.is-small {
-  border-radius: 2px;
-  font-size: 0.85rem;
-}
-.input.is-medium,
-.textarea.is-medium {
-  font-size: 1.25rem;
-}
-.input.is-large,
-.textarea.is-large {
-  font-size: 1.5rem;
-}
-.input.is-fullwidth,
-.textarea.is-fullwidth {
-  display: block;
-  width: 100%;
-}
-.input.is-inline,
-.textarea.is-inline {
-  display: inline;
-  width: auto;
-}
+  width: 100%; }
+  .input::-moz-placeholder,
+  .textarea::-moz-placeholder {
+    color: rgba(45, 45, 45, 0.3); }
+  .input::-webkit-input-placeholder,
+  .textarea::-webkit-input-placeholder {
+    color: rgba(45, 45, 45, 0.3); }
+  .input:-moz-placeholder,
+  .textarea:-moz-placeholder {
+    color: rgba(45, 45, 45, 0.3); }
+  .input:-ms-input-placeholder,
+  .textarea:-ms-input-placeholder {
+    color: rgba(45, 45, 45, 0.3); }
+  .input:hover, .input.is-hovered,
+  .textarea:hover,
+  .textarea.is-hovered {
+    border-color: #999999; }
+  .input:focus, .input.is-focused, .input:active, .input.is-active,
+  .textarea:focus,
+  .textarea.is-focused,
+  .textarea:active,
+  .textarea.is-active {
+    border-color: #1565c0;
+    box-shadow: 0 0 0 0.125em rgba(21, 101, 192, 0.25); }
+  .input[disabled],
+  .textarea[disabled] {
+    background-color: whitesmoke;
+    border-color: whitesmoke;
+    box-shadow: none;
+    color: #757575; }
+    .input[disabled]::-moz-placeholder,
+    .textarea[disabled]::-moz-placeholder {
+      color: rgba(117, 117, 117, 0.3); }
+    .input[disabled]::-webkit-input-placeholder,
+    .textarea[disabled]::-webkit-input-placeholder {
+      color: rgba(117, 117, 117, 0.3); }
+    .input[disabled]:-moz-placeholder,
+    .textarea[disabled]:-moz-placeholder {
+      color: rgba(117, 117, 117, 0.3); }
+    .input[disabled]:-ms-input-placeholder,
+    .textarea[disabled]:-ms-input-placeholder {
+      color: rgba(117, 117, 117, 0.3); }
+  .input[readonly],
+  .textarea[readonly] {
+    box-shadow: none; }
+  .input.is-white,
+  .textarea.is-white {
+    border-color: white; }
+    .input.is-white:focus, .input.is-white.is-focused, .input.is-white:active, .input.is-white.is-active,
+    .textarea.is-white:focus,
+    .textarea.is-white.is-focused,
+    .textarea.is-white:active,
+    .textarea.is-white.is-active {
+      box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25); }
+  .input.is-black,
+  .textarea.is-black {
+    border-color: #0a0a0a; }
+    .input.is-black:focus, .input.is-black.is-focused, .input.is-black:active, .input.is-black.is-active,
+    .textarea.is-black:focus,
+    .textarea.is-black.is-focused,
+    .textarea.is-black:active,
+    .textarea.is-black.is-active {
+      box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.25); }
+  .input.is-light,
+  .textarea.is-light {
+    border-color: whitesmoke; }
+    .input.is-light:focus, .input.is-light.is-focused, .input.is-light:active, .input.is-light.is-active,
+    .textarea.is-light:focus,
+    .textarea.is-light.is-focused,
+    .textarea.is-light:active,
+    .textarea.is-light.is-active {
+      box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25); }
+  .input.is-dark,
+  .textarea.is-dark {
+    border-color: #2d2d2d; }
+    .input.is-dark:focus, .input.is-dark.is-focused, .input.is-dark:active, .input.is-dark.is-active,
+    .textarea.is-dark:focus,
+    .textarea.is-dark.is-focused,
+    .textarea.is-dark:active,
+    .textarea.is-dark.is-active {
+      box-shadow: 0 0 0 0.125em rgba(45, 45, 45, 0.25); }
+  .input.is-primary,
+  .textarea.is-primary {
+    border-color: #b31b1b; }
+    .input.is-primary:focus, .input.is-primary.is-focused, .input.is-primary:active, .input.is-primary.is-active,
+    .textarea.is-primary:focus,
+    .textarea.is-primary.is-focused,
+    .textarea.is-primary:active,
+    .textarea.is-primary.is-active {
+      box-shadow: 0 0 0 0.125em rgba(179, 27, 27, 0.25); }
+  .input.is-link,
+  .textarea.is-link {
+    border-color: #1565c0; }
+    .input.is-link:focus, .input.is-link.is-focused, .input.is-link:active, .input.is-link.is-active,
+    .textarea.is-link:focus,
+    .textarea.is-link.is-focused,
+    .textarea.is-link:active,
+    .textarea.is-link.is-active {
+      box-shadow: 0 0 0 0.125em rgba(21, 101, 192, 0.25); }
+  .input.is-info,
+  .textarea.is-info {
+    border-color: #209cee; }
+    .input.is-info:focus, .input.is-info.is-focused, .input.is-info:active, .input.is-info.is-active,
+    .textarea.is-info:focus,
+    .textarea.is-info.is-focused,
+    .textarea.is-info:active,
+    .textarea.is-info.is-active {
+      box-shadow: 0 0 0 0.125em rgba(32, 156, 238, 0.25); }
+  .input.is-success,
+  .textarea.is-success {
+    border-color: #008412; }
+    .input.is-success:focus, .input.is-success.is-focused, .input.is-success:active, .input.is-success.is-active,
+    .textarea.is-success:focus,
+    .textarea.is-success.is-focused,
+    .textarea.is-success:active,
+    .textarea.is-success.is-active {
+      box-shadow: 0 0 0 0.125em rgba(0, 132, 18, 0.25); }
+  .input.is-warning,
+  .textarea.is-warning {
+    border-color: #b55c06; }
+    .input.is-warning:focus, .input.is-warning.is-focused, .input.is-warning:active, .input.is-warning.is-active,
+    .textarea.is-warning:focus,
+    .textarea.is-warning.is-focused,
+    .textarea.is-warning:active,
+    .textarea.is-warning.is-active {
+      box-shadow: 0 0 0 0.125em rgba(181, 92, 6, 0.25); }
+  .input.is-danger,
+  .textarea.is-danger {
+    border-color: #cd0200; }
+    .input.is-danger:focus, .input.is-danger.is-focused, .input.is-danger:active, .input.is-danger.is-active,
+    .textarea.is-danger:focus,
+    .textarea.is-danger.is-focused,
+    .textarea.is-danger:active,
+    .textarea.is-danger.is-active {
+      box-shadow: 0 0 0 0.125em rgba(205, 2, 0, 0.25); }
+  .input.is-small,
+  .textarea.is-small {
+    border-radius: 2px;
+    font-size: 0.85rem; }
+  .input.is-medium,
+  .textarea.is-medium {
+    font-size: 1.25rem; }
+  .input.is-large,
+  .textarea.is-large {
+    font-size: 1.5rem; }
+  .input.is-fullwidth,
+  .textarea.is-fullwidth {
+    display: block;
+    width: 100%; }
+  .input.is-inline,
+  .textarea.is-inline {
+    display: inline;
+    width: auto; }
 
 .input.is-rounded {
   border-radius: 290486px;
   padding-left: 1em;
-  padding-right: 1em;
-}
+  padding-right: 1em; }
+
 .input.is-static {
   background-color: transparent;
   border-color: transparent;
   box-shadow: none;
   padding-left: 0;
-  padding-right: 0;
-}
+  padding-right: 0; }
 
 .textarea {
   display: block;
   max-width: 100%;
   min-width: 100%;
   padding: 0.625em;
-  resize: vertical;
-}
-.textarea:not([rows]) {
-  max-height: 600px;
-  min-height: 120px;
-}
-.textarea[rows] {
-  height: initial;
-}
-.textarea.has-fixed-size {
-  resize: none;
-}
+  resize: vertical; }
+  .textarea:not([rows]) {
+    max-height: 600px;
+    min-height: 120px; }
+  .textarea[rows] {
+    height: initial; }
+  .textarea.has-fixed-size {
+    resize: none; }
 
 .checkbox,
 .radio {
   cursor: pointer;
   display: inline-block;
   line-height: 1.25;
-  position: relative;
-}
-.checkbox input,
-.radio input {
-  cursor: pointer;
-}
-.checkbox:hover,
-.radio:hover {
-  color: #2d2d2d;
-}
-.checkbox[disabled],
-.radio[disabled] {
-  color: #757575;
-  cursor: not-allowed;
-}
+  position: relative; }
+  .checkbox input,
+  .radio input {
+    cursor: pointer; }
+  .checkbox:hover,
+  .radio:hover {
+    color: #2d2d2d; }
+  .checkbox[disabled],
+  .radio[disabled] {
+    color: #757575;
+    cursor: not-allowed; }
 
 .radio + .radio {
-  margin-left: 0.5em;
-}
+  margin-left: 0.5em; }
 
 .select {
   display: inline-block;
   max-width: 100%;
   position: relative;
-  vertical-align: top;
-}
-.select:not(.is-multiple) {
-  height: 2.25em;
-}
-.select:not(.is-multiple):not(.is-loading)::after {
-  border-color: #086db1;
-  right: 1.125em;
-  z-index: 4;
-}
-.select.is-rounded select {
-  border-radius: 290486px;
-  padding-left: 1em;
-}
-.select select {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: hsl(0deg, 0%, 80%);
-  color: #2d2d2d;
-  cursor: pointer;
-  display: block;
-  font-size: 1em;
-  max-width: 100%;
-  outline: none;
-}
-.select select::-moz-placeholder {
-  color: rgba(45, 45, 45, 0.3);
-}
-.select select::-webkit-input-placeholder {
-  color: rgba(45, 45, 45, 0.3);
-}
-.select select:-moz-placeholder {
-  color: rgba(45, 45, 45, 0.3);
-}
-.select select:-ms-input-placeholder {
-  color: rgba(45, 45, 45, 0.3);
-}
-.select select:hover, .select select.is-hovered {
-  border-color: hsl(0deg, 0%, 60%);
-}
-.select select:focus, .select select.is-focused, .select select:active, .select select.is-active {
-  border-color: #086db1;
-  box-shadow: 0 0 0 0.125em rgba(8, 109, 177, 0.25);
-}
-.select select[disabled] {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: hsl(0deg, 0%, 96%);
-  box-shadow: none;
-  color: #757575;
-}
-.select select[disabled]::-moz-placeholder {
-  color: rgba(117, 117, 117, 0.3);
-}
-.select select[disabled]::-webkit-input-placeholder {
-  color: rgba(117, 117, 117, 0.3);
-}
-.select select[disabled]:-moz-placeholder {
-  color: rgba(117, 117, 117, 0.3);
-}
-.select select[disabled]:-ms-input-placeholder {
-  color: rgba(117, 117, 117, 0.3);
-}
-.select select::-ms-expand {
-  display: none;
-}
-.select select[disabled]:hover {
-  border-color: hsl(0deg, 0%, 96%);
-}
-.select select:not([multiple]) {
-  padding-right: 2.5em;
-}
-.select select[multiple] {
-  height: auto;
-  padding: 0;
-}
-.select select[multiple] option {
-  padding: 0.5em 1em;
-}
-.select:not(.is-multiple):not(.is-loading):hover::after {
-  border-color: #2d2d2d;
-}
-.select.is-white:not(:hover)::after {
-  border-color: hsl(0deg, 0%, 100%);
-}
-.select.is-white select {
-  border-color: hsl(0deg, 0%, 100%);
-}
-.select.is-white select:hover, .select.is-white select.is-hovered {
-  border-color: #f2f2f2;
-}
-.select.is-white select:focus, .select.is-white select.is-focused, .select.is-white select:active, .select.is-white select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25);
-}
-.select.is-black:not(:hover)::after {
-  border-color: hsl(0deg, 0%, 4%);
-}
-.select.is-black select {
-  border-color: hsl(0deg, 0%, 4%);
-}
-.select.is-black select:hover, .select.is-black select.is-hovered {
-  border-color: black;
-}
-.select.is-black select:focus, .select.is-black select.is-focused, .select.is-black select:active, .select.is-black select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.25);
-}
-.select.is-light:not(:hover)::after {
-  border-color: hsl(0deg, 0%, 96%);
-}
-.select.is-light select {
-  border-color: hsl(0deg, 0%, 96%);
-}
-.select.is-light select:hover, .select.is-light select.is-hovered {
-  border-color: #e8e8e8;
-}
-.select.is-light select:focus, .select.is-light select.is-focused, .select.is-light select:active, .select.is-light select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
-}
-.select.is-dark:not(:hover)::after {
-  border-color: #2d2d2d;
-}
-.select.is-dark select {
-  border-color: #2d2d2d;
-}
-.select.is-dark select:hover, .select.is-dark select.is-hovered {
-  border-color: #202020;
-}
-.select.is-dark select:focus, .select.is-dark select.is-focused, .select.is-dark select:active, .select.is-dark select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(45, 45, 45, 0.25);
-}
-.select.is-primary:not(:hover)::after {
-  border-color: #b31b1b;
-}
-.select.is-primary select {
-  border-color: #b31b1b;
-}
-.select.is-primary select:hover, .select.is-primary select.is-hovered {
-  border-color: #9d1818;
-}
-.select.is-primary select:focus, .select.is-primary select.is-focused, .select.is-primary select:active, .select.is-primary select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(179, 27, 27, 0.25);
-}
-.select.is-link:not(:hover)::after {
-  border-color: #086db1;
-}
-.select.is-link select {
-  border-color: #086db1;
-}
-.select.is-link select:hover, .select.is-link select.is-hovered {
-  border-color: #075e99;
-}
-.select.is-link select:focus, .select.is-link select.is-focused, .select.is-link select:active, .select.is-link select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(8, 109, 177, 0.25);
-}
-.select.is-info:not(:hover)::after {
-  border-color: hsl(204deg, 86%, 53%);
-}
-.select.is-info select {
-  border-color: hsl(204deg, 86%, 53%);
-}
-.select.is-info select:hover, .select.is-info select.is-hovered {
-  border-color: #118fe4;
-}
-.select.is-info select:focus, .select.is-info select.is-focused, .select.is-info select:active, .select.is-info select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(32, 156, 238, 0.25);
-}
-.select.is-success:not(:hover)::after {
-  border-color: #008412;
-}
-.select.is-success select {
-  border-color: #008412;
-}
-.select.is-success select:hover, .select.is-success select.is-hovered {
-  border-color: #006b0f;
-}
-.select.is-success select:focus, .select.is-success select.is-focused, .select.is-success select:active, .select.is-success select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(0, 132, 18, 0.25);
-}
-.select.is-warning:not(:hover)::after {
-  border-color: #b55c06;
-}
-.select.is-warning select {
-  border-color: #b55c06;
-}
-.select.is-warning select:hover, .select.is-warning select.is-hovered {
-  border-color: #9c4f05;
-}
-.select.is-warning select:focus, .select.is-warning select.is-focused, .select.is-warning select:active, .select.is-warning select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(181, 92, 6, 0.25);
-}
-.select.is-danger:not(:hover)::after {
-  border-color: #cd0200;
-}
-.select.is-danger select {
-  border-color: #cd0200;
-}
-.select.is-danger select:hover, .select.is-danger select.is-hovered {
-  border-color: #b40200;
-}
-.select.is-danger select:focus, .select.is-danger select.is-focused, .select.is-danger select:active, .select.is-danger select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(205, 2, 0, 0.25);
-}
-.select.is-small {
-  border-radius: 2px;
-  font-size: 0.85rem;
-}
-.select.is-medium {
-  font-size: 1.25rem;
-}
-.select.is-large {
-  font-size: 1.5rem;
-}
-.select.is-disabled::after {
-  border-color: #757575;
-}
-.select.is-fullwidth {
-  width: 100%;
-}
-.select.is-fullwidth select {
-  width: 100%;
-}
-.select.is-loading::after {
-  margin-top: 0;
-  position: absolute;
-  right: 0.625em;
-  top: 0.625em;
-  transform: none;
-}
-.select.is-loading.is-small:after {
-  font-size: 0.85rem;
-}
-.select.is-loading.is-medium:after {
-  font-size: 1.25rem;
-}
-.select.is-loading.is-large:after {
-  font-size: 1.5rem;
-}
+  vertical-align: top; }
+  .select:not(.is-multiple) {
+    height: 2.25em; }
+  .select:not(.is-multiple):not(.is-loading)::after {
+    border-color: #1565c0;
+    right: 1.125em;
+    z-index: 4; }
+  .select.is-rounded select {
+    border-radius: 290486px;
+    padding-left: 1em; }
+  .select select {
+    background-color: white;
+    border-color: #cccccc;
+    color: #2d2d2d;
+    cursor: pointer;
+    display: block;
+    font-size: 1em;
+    max-width: 100%;
+    outline: none; }
+    .select select::-moz-placeholder {
+      color: rgba(45, 45, 45, 0.3); }
+    .select select::-webkit-input-placeholder {
+      color: rgba(45, 45, 45, 0.3); }
+    .select select:-moz-placeholder {
+      color: rgba(45, 45, 45, 0.3); }
+    .select select:-ms-input-placeholder {
+      color: rgba(45, 45, 45, 0.3); }
+    .select select:hover, .select select.is-hovered {
+      border-color: #999999; }
+    .select select:focus, .select select.is-focused, .select select:active, .select select.is-active {
+      border-color: #1565c0;
+      box-shadow: 0 0 0 0.125em rgba(21, 101, 192, 0.25); }
+    .select select[disabled] {
+      background-color: whitesmoke;
+      border-color: whitesmoke;
+      box-shadow: none;
+      color: #757575; }
+      .select select[disabled]::-moz-placeholder {
+        color: rgba(117, 117, 117, 0.3); }
+      .select select[disabled]::-webkit-input-placeholder {
+        color: rgba(117, 117, 117, 0.3); }
+      .select select[disabled]:-moz-placeholder {
+        color: rgba(117, 117, 117, 0.3); }
+      .select select[disabled]:-ms-input-placeholder {
+        color: rgba(117, 117, 117, 0.3); }
+    .select select::-ms-expand {
+      display: none; }
+    .select select[disabled]:hover {
+      border-color: whitesmoke; }
+    .select select:not([multiple]) {
+      padding-right: 2.5em; }
+    .select select[multiple] {
+      height: auto;
+      padding: 0; }
+      .select select[multiple] option {
+        padding: 0.5em 1em; }
+  .select:not(.is-multiple):not(.is-loading):hover::after {
+    border-color: #2d2d2d; }
+  .select.is-white:not(:hover)::after {
+    border-color: white; }
+  .select.is-white select {
+    border-color: white; }
+    .select.is-white select:hover, .select.is-white select.is-hovered {
+      border-color: #f2f2f2; }
+    .select.is-white select:focus, .select.is-white select.is-focused, .select.is-white select:active, .select.is-white select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25); }
+  .select.is-black:not(:hover)::after {
+    border-color: #0a0a0a; }
+  .select.is-black select {
+    border-color: #0a0a0a; }
+    .select.is-black select:hover, .select.is-black select.is-hovered {
+      border-color: black; }
+    .select.is-black select:focus, .select.is-black select.is-focused, .select.is-black select:active, .select.is-black select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.25); }
+  .select.is-light:not(:hover)::after {
+    border-color: whitesmoke; }
+  .select.is-light select {
+    border-color: whitesmoke; }
+    .select.is-light select:hover, .select.is-light select.is-hovered {
+      border-color: #e8e8e8; }
+    .select.is-light select:focus, .select.is-light select.is-focused, .select.is-light select:active, .select.is-light select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25); }
+  .select.is-dark:not(:hover)::after {
+    border-color: #2d2d2d; }
+  .select.is-dark select {
+    border-color: #2d2d2d; }
+    .select.is-dark select:hover, .select.is-dark select.is-hovered {
+      border-color: #202020; }
+    .select.is-dark select:focus, .select.is-dark select.is-focused, .select.is-dark select:active, .select.is-dark select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(45, 45, 45, 0.25); }
+  .select.is-primary:not(:hover)::after {
+    border-color: #b31b1b; }
+  .select.is-primary select {
+    border-color: #b31b1b; }
+    .select.is-primary select:hover, .select.is-primary select.is-hovered {
+      border-color: #9d1818; }
+    .select.is-primary select:focus, .select.is-primary select.is-focused, .select.is-primary select:active, .select.is-primary select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(179, 27, 27, 0.25); }
+  .select.is-link:not(:hover)::after {
+    border-color: #1565c0; }
+  .select.is-link select {
+    border-color: #1565c0; }
+    .select.is-link select:hover, .select.is-link select.is-hovered {
+      border-color: #1259a9; }
+    .select.is-link select:focus, .select.is-link select.is-focused, .select.is-link select:active, .select.is-link select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(21, 101, 192, 0.25); }
+  .select.is-info:not(:hover)::after {
+    border-color: #209cee; }
+  .select.is-info select {
+    border-color: #209cee; }
+    .select.is-info select:hover, .select.is-info select.is-hovered {
+      border-color: #118fe4; }
+    .select.is-info select:focus, .select.is-info select.is-focused, .select.is-info select:active, .select.is-info select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(32, 156, 238, 0.25); }
+  .select.is-success:not(:hover)::after {
+    border-color: #008412; }
+  .select.is-success select {
+    border-color: #008412; }
+    .select.is-success select:hover, .select.is-success select.is-hovered {
+      border-color: #006b0f; }
+    .select.is-success select:focus, .select.is-success select.is-focused, .select.is-success select:active, .select.is-success select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(0, 132, 18, 0.25); }
+  .select.is-warning:not(:hover)::after {
+    border-color: #b55c06; }
+  .select.is-warning select {
+    border-color: #b55c06; }
+    .select.is-warning select:hover, .select.is-warning select.is-hovered {
+      border-color: #9c4f05; }
+    .select.is-warning select:focus, .select.is-warning select.is-focused, .select.is-warning select:active, .select.is-warning select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(181, 92, 6, 0.25); }
+  .select.is-danger:not(:hover)::after {
+    border-color: #cd0200; }
+  .select.is-danger select {
+    border-color: #cd0200; }
+    .select.is-danger select:hover, .select.is-danger select.is-hovered {
+      border-color: #b40200; }
+    .select.is-danger select:focus, .select.is-danger select.is-focused, .select.is-danger select:active, .select.is-danger select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(205, 2, 0, 0.25); }
+  .select.is-small {
+    border-radius: 2px;
+    font-size: 0.85rem; }
+  .select.is-medium {
+    font-size: 1.25rem; }
+  .select.is-large {
+    font-size: 1.5rem; }
+  .select.is-disabled::after {
+    border-color: #757575; }
+  .select.is-fullwidth {
+    width: 100%; }
+    .select.is-fullwidth select {
+      width: 100%; }
+  .select.is-loading::after {
+    margin-top: 0;
+    position: absolute;
+    right: 0.625em;
+    top: 0.625em;
+    transform: none; }
+  .select.is-loading.is-small:after {
+    font-size: 0.85rem; }
+  .select.is-loading.is-medium:after {
+    font-size: 1.25rem; }
+  .select.is-loading.is-large:after {
+    font-size: 1.5rem; }
 
 .file {
   align-items: stretch;
   display: flex;
   justify-content: flex-start;
-  position: relative;
-}
-.file.is-white .file-cta {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
-.file.is-white:hover .file-cta, .file.is-white.is-hovered .file-cta {
-  background-color: #f9f9f9;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
-.file.is-white:focus .file-cta, .file.is-white.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(255, 255, 255, 0.25);
-  color: hsl(0deg, 0%, 4%);
-}
-.file.is-white:active .file-cta, .file.is-white.is-active .file-cta {
-  background-color: #f2f2f2;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
-.file.is-black .file-cta {
-  background-color: hsl(0deg, 0%, 4%);
-  border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
-.file.is-black:hover .file-cta, .file.is-black.is-hovered .file-cta {
-  background-color: #040404;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
-.file.is-black:focus .file-cta, .file.is-black.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(10, 10, 10, 0.25);
-  color: hsl(0deg, 0%, 100%);
-}
-.file.is-black:active .file-cta, .file.is-black.is-active .file-cta {
-  background-color: black;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
-.file.is-light .file-cta {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: transparent;
-  color: #2d2d2d;
-}
-.file.is-light:hover .file-cta, .file.is-light.is-hovered .file-cta {
-  background-color: #eeeeee;
-  border-color: transparent;
-  color: #2d2d2d;
-}
-.file.is-light:focus .file-cta, .file.is-light.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(245, 245, 245, 0.25);
-  color: #2d2d2d;
-}
-.file.is-light:active .file-cta, .file.is-light.is-active .file-cta {
-  background-color: #e8e8e8;
-  border-color: transparent;
-  color: #2d2d2d;
-}
-.file.is-dark .file-cta {
-  background-color: #2d2d2d;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
-.file.is-dark:hover .file-cta, .file.is-dark.is-hovered .file-cta {
-  background-color: #272727;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
-.file.is-dark:focus .file-cta, .file.is-dark.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(45, 45, 45, 0.25);
-  color: hsl(0deg, 0%, 96%);
-}
-.file.is-dark:active .file-cta, .file.is-dark.is-active .file-cta {
-  background-color: #202020;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
-.file.is-primary .file-cta {
-  background-color: #b31b1b;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-primary:hover .file-cta, .file.is-primary.is-hovered .file-cta {
-  background-color: #a81919;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-primary:focus .file-cta, .file.is-primary.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(179, 27, 27, 0.25);
-  color: #fff;
-}
-.file.is-primary:active .file-cta, .file.is-primary.is-active .file-cta {
-  background-color: #9d1818;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-link .file-cta {
-  background-color: #086db1;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-link:hover .file-cta, .file.is-link.is-hovered .file-cta {
-  background-color: #0765a5;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-link:focus .file-cta, .file.is-link.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(8, 109, 177, 0.25);
-  color: #fff;
-}
-.file.is-link:active .file-cta, .file.is-link.is-active .file-cta {
-  background-color: #075e99;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-info .file-cta {
-  background-color: hsl(204deg, 86%, 53%);
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-info:hover .file-cta, .file.is-info.is-hovered .file-cta {
-  background-color: #1496ed;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-info:focus .file-cta, .file.is-info.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(32, 156, 238, 0.25);
-  color: #fff;
-}
-.file.is-info:active .file-cta, .file.is-info.is-active .file-cta {
-  background-color: #118fe4;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-success .file-cta {
-  background-color: #008412;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-success:hover .file-cta, .file.is-success.is-hovered .file-cta {
-  background-color: #007710;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-success:focus .file-cta, .file.is-success.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(0, 132, 18, 0.25);
-  color: #fff;
-}
-.file.is-success:active .file-cta, .file.is-success.is-active .file-cta {
-  background-color: #006b0f;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-warning .file-cta {
-  background-color: #b55c06;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-warning:hover .file-cta, .file.is-warning.is-hovered .file-cta {
-  background-color: #a95606;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-warning:focus .file-cta, .file.is-warning.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(181, 92, 6, 0.25);
-  color: #fff;
-}
-.file.is-warning:active .file-cta, .file.is-warning.is-active .file-cta {
-  background-color: #9c4f05;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-danger .file-cta {
-  background-color: #cd0200;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-danger:hover .file-cta, .file.is-danger.is-hovered .file-cta {
-  background-color: #c00200;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-danger:focus .file-cta, .file.is-danger.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(205, 2, 0, 0.25);
-  color: #fff;
-}
-.file.is-danger:active .file-cta, .file.is-danger.is-active .file-cta {
-  background-color: #b40200;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-small {
-  font-size: 0.85rem;
-}
-.file.is-medium {
-  font-size: 1.25rem;
-}
-.file.is-medium .file-icon .fa {
-  font-size: 21px;
-}
-.file.is-large {
-  font-size: 1.5rem;
-}
-.file.is-large .file-icon .fa {
-  font-size: 28px;
-}
-.file.has-name .file-cta {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-}
-.file.has-name .file-name {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-}
-.file.has-name.is-empty .file-cta {
-  border-radius: 4px;
-}
-.file.has-name.is-empty .file-name {
-  display: none;
-}
-.file.is-boxed .file-label {
-  flex-direction: column;
-}
-.file.is-boxed .file-cta {
-  flex-direction: column;
-  height: auto;
-  padding: 1em 3em;
-}
-.file.is-boxed .file-name {
-  border-width: 0 1px 1px;
-}
-.file.is-boxed .file-icon {
-  height: 1.5em;
-  width: 1.5em;
-}
-.file.is-boxed .file-icon .fa {
-  font-size: 21px;
-}
-.file.is-boxed.is-small .file-icon .fa {
-  font-size: 14px;
-}
-.file.is-boxed.is-medium .file-icon .fa {
-  font-size: 28px;
-}
-.file.is-boxed.is-large .file-icon .fa {
-  font-size: 35px;
-}
-.file.is-boxed.has-name .file-cta {
-  border-radius: 4px 4px 0 0;
-}
-.file.is-boxed.has-name .file-name {
-  border-radius: 0 0 4px 4px;
-  border-width: 0 1px 1px;
-}
-.file.is-centered {
-  justify-content: center;
-}
-.file.is-fullwidth .file-label {
-  width: 100%;
-}
-.file.is-fullwidth .file-name {
-  flex-grow: 1;
-  max-width: none;
-}
-.file.is-right {
-  justify-content: flex-end;
-}
-.file.is-right .file-cta {
-  border-radius: 0 4px 4px 0;
-}
-.file.is-right .file-name {
-  border-radius: 4px 0 0 4px;
-  border-width: 1px 0 1px 1px;
-  order: -1;
-}
+  position: relative; }
+  .file.is-white .file-cta {
+    background-color: white;
+    border-color: transparent;
+    color: #0a0a0a; }
+  .file.is-white:hover .file-cta, .file.is-white.is-hovered .file-cta {
+    background-color: #f9f9f9;
+    border-color: transparent;
+    color: #0a0a0a; }
+  .file.is-white:focus .file-cta, .file.is-white.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(255, 255, 255, 0.25);
+    color: #0a0a0a; }
+  .file.is-white:active .file-cta, .file.is-white.is-active .file-cta {
+    background-color: #f2f2f2;
+    border-color: transparent;
+    color: #0a0a0a; }
+  .file.is-black .file-cta {
+    background-color: #0a0a0a;
+    border-color: transparent;
+    color: white; }
+  .file.is-black:hover .file-cta, .file.is-black.is-hovered .file-cta {
+    background-color: #040404;
+    border-color: transparent;
+    color: white; }
+  .file.is-black:focus .file-cta, .file.is-black.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(10, 10, 10, 0.25);
+    color: white; }
+  .file.is-black:active .file-cta, .file.is-black.is-active .file-cta {
+    background-color: black;
+    border-color: transparent;
+    color: white; }
+  .file.is-light .file-cta {
+    background-color: whitesmoke;
+    border-color: transparent;
+    color: #2d2d2d; }
+  .file.is-light:hover .file-cta, .file.is-light.is-hovered .file-cta {
+    background-color: #eeeeee;
+    border-color: transparent;
+    color: #2d2d2d; }
+  .file.is-light:focus .file-cta, .file.is-light.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(245, 245, 245, 0.25);
+    color: #2d2d2d; }
+  .file.is-light:active .file-cta, .file.is-light.is-active .file-cta {
+    background-color: #e8e8e8;
+    border-color: transparent;
+    color: #2d2d2d; }
+  .file.is-dark .file-cta {
+    background-color: #2d2d2d;
+    border-color: transparent;
+    color: whitesmoke; }
+  .file.is-dark:hover .file-cta, .file.is-dark.is-hovered .file-cta {
+    background-color: #272727;
+    border-color: transparent;
+    color: whitesmoke; }
+  .file.is-dark:focus .file-cta, .file.is-dark.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(45, 45, 45, 0.25);
+    color: whitesmoke; }
+  .file.is-dark:active .file-cta, .file.is-dark.is-active .file-cta {
+    background-color: #202020;
+    border-color: transparent;
+    color: whitesmoke; }
+  .file.is-primary .file-cta {
+    background-color: #b31b1b;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-primary:hover .file-cta, .file.is-primary.is-hovered .file-cta {
+    background-color: #a81919;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-primary:focus .file-cta, .file.is-primary.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(179, 27, 27, 0.25);
+    color: #fff; }
+  .file.is-primary:active .file-cta, .file.is-primary.is-active .file-cta {
+    background-color: #9d1818;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-link .file-cta {
+    background-color: #1565c0;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-link:hover .file-cta, .file.is-link.is-hovered .file-cta {
+    background-color: #145fb5;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-link:focus .file-cta, .file.is-link.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(21, 101, 192, 0.25);
+    color: #fff; }
+  .file.is-link:active .file-cta, .file.is-link.is-active .file-cta {
+    background-color: #1259a9;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-info .file-cta {
+    background-color: #209cee;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-info:hover .file-cta, .file.is-info.is-hovered .file-cta {
+    background-color: #1496ed;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-info:focus .file-cta, .file.is-info.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(32, 156, 238, 0.25);
+    color: #fff; }
+  .file.is-info:active .file-cta, .file.is-info.is-active .file-cta {
+    background-color: #118fe4;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-success .file-cta {
+    background-color: #008412;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-success:hover .file-cta, .file.is-success.is-hovered .file-cta {
+    background-color: #007710;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-success:focus .file-cta, .file.is-success.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(0, 132, 18, 0.25);
+    color: #fff; }
+  .file.is-success:active .file-cta, .file.is-success.is-active .file-cta {
+    background-color: #006b0f;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-warning .file-cta {
+    background-color: #b55c06;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-warning:hover .file-cta, .file.is-warning.is-hovered .file-cta {
+    background-color: #a95606;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-warning:focus .file-cta, .file.is-warning.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(181, 92, 6, 0.25);
+    color: #fff; }
+  .file.is-warning:active .file-cta, .file.is-warning.is-active .file-cta {
+    background-color: #9c4f05;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-danger .file-cta {
+    background-color: #cd0200;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-danger:hover .file-cta, .file.is-danger.is-hovered .file-cta {
+    background-color: #c00200;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-danger:focus .file-cta, .file.is-danger.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(205, 2, 0, 0.25);
+    color: #fff; }
+  .file.is-danger:active .file-cta, .file.is-danger.is-active .file-cta {
+    background-color: #b40200;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-small {
+    font-size: 0.85rem; }
+  .file.is-medium {
+    font-size: 1.25rem; }
+    .file.is-medium .file-icon .fa {
+      font-size: 21px; }
+  .file.is-large {
+    font-size: 1.5rem; }
+    .file.is-large .file-icon .fa {
+      font-size: 28px; }
+  .file.has-name .file-cta {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0; }
+  .file.has-name .file-name {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0; }
+  .file.has-name.is-empty .file-cta {
+    border-radius: 4px; }
+  .file.has-name.is-empty .file-name {
+    display: none; }
+  .file.is-boxed .file-label {
+    flex-direction: column; }
+  .file.is-boxed .file-cta {
+    flex-direction: column;
+    height: auto;
+    padding: 1em 3em; }
+  .file.is-boxed .file-name {
+    border-width: 0 1px 1px; }
+  .file.is-boxed .file-icon {
+    height: 1.5em;
+    width: 1.5em; }
+    .file.is-boxed .file-icon .fa {
+      font-size: 21px; }
+  .file.is-boxed.is-small .file-icon .fa {
+    font-size: 14px; }
+  .file.is-boxed.is-medium .file-icon .fa {
+    font-size: 28px; }
+  .file.is-boxed.is-large .file-icon .fa {
+    font-size: 35px; }
+  .file.is-boxed.has-name .file-cta {
+    border-radius: 4px 4px 0 0; }
+  .file.is-boxed.has-name .file-name {
+    border-radius: 0 0 4px 4px;
+    border-width: 0 1px 1px; }
+  .file.is-centered {
+    justify-content: center; }
+  .file.is-fullwidth .file-label {
+    width: 100%; }
+  .file.is-fullwidth .file-name {
+    flex-grow: 1;
+    max-width: none; }
+  .file.is-right {
+    justify-content: flex-end; }
+    .file.is-right .file-cta {
+      border-radius: 0 4px 4px 0; }
+    .file.is-right .file-name {
+      border-radius: 4px 0 0 4px;
+      border-width: 1px 0 1px 1px;
+      order: -1; }
 
 .file-label {
   align-items: stretch;
@@ -3305,22 +2605,17 @@ a.box:active {
   cursor: pointer;
   justify-content: flex-start;
   overflow: hidden;
-  position: relative;
-}
-.file-label:hover .file-cta {
-  background-color: #eeeeee;
-  color: #2d2d2d;
-}
-.file-label:hover .file-name {
-  border-color: #c6c6c6;
-}
-.file-label:active .file-cta {
-  background-color: #e8e8e8;
-  color: #2d2d2d;
-}
-.file-label:active .file-name {
-  border-color: #bfbfbf;
-}
+  position: relative; }
+  .file-label:hover .file-cta {
+    background-color: #eeeeee;
+    color: #2d2d2d; }
+  .file-label:hover .file-name {
+    border-color: #c6c6c6; }
+  .file-label:active .file-cta {
+    background-color: #e8e8e8;
+    color: #2d2d2d; }
+  .file-label:active .file-name {
+    border-color: #bfbfbf; }
 
 .file-input {
   height: 100%;
@@ -3329,34 +2624,30 @@ a.box:active {
   outline: none;
   position: absolute;
   top: 0;
-  width: 100%;
-}
+  width: 100%; }
 
 .file-cta,
 .file-name {
-  border-color: hsl(0deg, 0%, 80%);
+  border-color: #cccccc;
   border-radius: 4px;
   font-size: 1em;
   padding-left: 1em;
   padding-right: 1em;
-  white-space: nowrap;
-}
+  white-space: nowrap; }
 
 .file-cta {
-  background-color: hsl(0deg, 0%, 96%);
-  color: #333;
-}
+  background-color: whitesmoke;
+  color: #333; }
 
 .file-name {
-  border-color: hsl(0deg, 0%, 80%);
+  border-color: #cccccc;
   border-style: solid;
   border-width: 1px 1px 1px 0;
   display: block;
   max-width: 16em;
   overflow: hidden;
   text-align: left;
-  text-overflow: ellipsis;
-}
+  text-overflow: ellipsis; }
 
 .file-icon {
   align-items: center;
@@ -3364,510 +2655,387 @@ a.box:active {
   height: 1em;
   justify-content: center;
   margin-right: 0.5em;
-  width: 1em;
-}
-.file-icon .fa {
-  font-size: 14px;
-}
+  width: 1em; }
+  .file-icon .fa {
+    font-size: 14px; }
 
 .label {
   color: #2d2d2d;
   display: block;
   font-size: 1rem;
-  font-weight: 700;
-}
-.label:not(:last-child) {
-  margin-bottom: 0.5em;
-}
-.label.is-small {
-  font-size: 0.85rem;
-}
-.label.is-medium {
-  font-size: 1.25rem;
-}
-.label.is-large {
-  font-size: 1.5rem;
-}
+  font-weight: 700; }
+  .label:not(:last-child) {
+    margin-bottom: 0.5em; }
+  .label.is-small {
+    font-size: 0.85rem; }
+  .label.is-medium {
+    font-size: 1.25rem; }
+  .label.is-large {
+    font-size: 1.5rem; }
 
 .help {
   display: block;
   font-size: 0.85rem;
-  margin-top: 0.25rem;
-}
-.help.is-white {
-  color: hsl(0deg, 0%, 100%);
-}
-.help.is-black {
-  color: hsl(0deg, 0%, 4%);
-}
-.help.is-light {
-  color: hsl(0deg, 0%, 96%);
-}
-.help.is-dark {
-  color: #2d2d2d;
-}
-.help.is-primary {
-  color: #b31b1b;
-}
-.help.is-link {
-  color: #086db1;
-}
-.help.is-info {
-  color: hsl(204deg, 86%, 53%);
-}
-.help.is-success {
-  color: #008412;
-}
-.help.is-warning {
-  color: #b55c06;
-}
-.help.is-danger {
-  color: #cd0200;
-}
+  margin-top: 0.25rem; }
+  .help.is-white {
+    color: white; }
+  .help.is-black {
+    color: #0a0a0a; }
+  .help.is-light {
+    color: whitesmoke; }
+  .help.is-dark {
+    color: #2d2d2d; }
+  .help.is-primary {
+    color: #b31b1b; }
+  .help.is-link {
+    color: #1565c0; }
+  .help.is-info {
+    color: #209cee; }
+  .help.is-success {
+    color: #008412; }
+  .help.is-warning {
+    color: #b55c06; }
+  .help.is-danger {
+    color: #cd0200; }
 
 .field:not(:last-child) {
-  margin-bottom: 0.75rem;
-}
+  margin-bottom: 0.75rem; }
+
 .field.has-addons {
   display: flex;
-  justify-content: flex-start;
-}
-.field.has-addons .control:not(:last-child) {
-  margin-right: -1px;
-}
-.field.has-addons .control:not(:first-child):not(:last-child) .button,
-.field.has-addons .control:not(:first-child):not(:last-child) .input,
-.field.has-addons .control:not(:first-child):not(:last-child) .select select {
-  border-radius: 0;
-}
-.field.has-addons .control:first-child .button,
-.field.has-addons .control:first-child .input,
-.field.has-addons .control:first-child .select select {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-}
-.field.has-addons .control:last-child .button,
-.field.has-addons .control:last-child .input,
-.field.has-addons .control:last-child .select select {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-}
-.field.has-addons .control .button:not([disabled]):hover, .field.has-addons .control .button:not([disabled]).is-hovered,
-.field.has-addons .control .input:not([disabled]):hover,
-.field.has-addons .control .input:not([disabled]).is-hovered,
-.field.has-addons .control .select select:not([disabled]):hover,
-.field.has-addons .control .select select:not([disabled]).is-hovered {
-  z-index: 2;
-}
-.field.has-addons .control .button:not([disabled]):focus, .field.has-addons .control .button:not([disabled]).is-focused, .field.has-addons .control .button:not([disabled]):active, .field.has-addons .control .button:not([disabled]).is-active,
-.field.has-addons .control .input:not([disabled]):focus,
-.field.has-addons .control .input:not([disabled]).is-focused,
-.field.has-addons .control .input:not([disabled]):active,
-.field.has-addons .control .input:not([disabled]).is-active,
-.field.has-addons .control .select select:not([disabled]):focus,
-.field.has-addons .control .select select:not([disabled]).is-focused,
-.field.has-addons .control .select select:not([disabled]):active,
-.field.has-addons .control .select select:not([disabled]).is-active {
-  z-index: 3;
-}
-.field.has-addons .control .button:not([disabled]):focus:hover, .field.has-addons .control .button:not([disabled]).is-focused:hover, .field.has-addons .control .button:not([disabled]):active:hover, .field.has-addons .control .button:not([disabled]).is-active:hover,
-.field.has-addons .control .input:not([disabled]):focus:hover,
-.field.has-addons .control .input:not([disabled]).is-focused:hover,
-.field.has-addons .control .input:not([disabled]):active:hover,
-.field.has-addons .control .input:not([disabled]).is-active:hover,
-.field.has-addons .control .select select:not([disabled]):focus:hover,
-.field.has-addons .control .select select:not([disabled]).is-focused:hover,
-.field.has-addons .control .select select:not([disabled]):active:hover,
-.field.has-addons .control .select select:not([disabled]).is-active:hover {
-  z-index: 4;
-}
-.field.has-addons .control.is-expanded {
-  flex-grow: 1;
-}
-.field.has-addons.has-addons-centered {
-  justify-content: center;
-}
-.field.has-addons.has-addons-right {
-  justify-content: flex-end;
-}
-.field.has-addons.has-addons-fullwidth .control {
-  flex-grow: 1;
-  flex-shrink: 0;
-}
+  justify-content: flex-start; }
+  .field.has-addons .control:not(:last-child) {
+    margin-right: -1px; }
+  .field.has-addons .control:not(:first-child):not(:last-child) .button,
+  .field.has-addons .control:not(:first-child):not(:last-child) .input,
+  .field.has-addons .control:not(:first-child):not(:last-child) .select select {
+    border-radius: 0; }
+  .field.has-addons .control:first-child .button,
+  .field.has-addons .control:first-child .input,
+  .field.has-addons .control:first-child .select select {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0; }
+  .field.has-addons .control:last-child .button,
+  .field.has-addons .control:last-child .input,
+  .field.has-addons .control:last-child .select select {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0; }
+  .field.has-addons .control .button:not([disabled]):hover, .field.has-addons .control .button:not([disabled]).is-hovered,
+  .field.has-addons .control .input:not([disabled]):hover,
+  .field.has-addons .control .input:not([disabled]).is-hovered,
+  .field.has-addons .control .select select:not([disabled]):hover,
+  .field.has-addons .control .select select:not([disabled]).is-hovered {
+    z-index: 2; }
+  .field.has-addons .control .button:not([disabled]):focus, .field.has-addons .control .button:not([disabled]).is-focused, .field.has-addons .control .button:not([disabled]):active, .field.has-addons .control .button:not([disabled]).is-active,
+  .field.has-addons .control .input:not([disabled]):focus,
+  .field.has-addons .control .input:not([disabled]).is-focused,
+  .field.has-addons .control .input:not([disabled]):active,
+  .field.has-addons .control .input:not([disabled]).is-active,
+  .field.has-addons .control .select select:not([disabled]):focus,
+  .field.has-addons .control .select select:not([disabled]).is-focused,
+  .field.has-addons .control .select select:not([disabled]):active,
+  .field.has-addons .control .select select:not([disabled]).is-active {
+    z-index: 3; }
+    .field.has-addons .control .button:not([disabled]):focus:hover, .field.has-addons .control .button:not([disabled]).is-focused:hover, .field.has-addons .control .button:not([disabled]):active:hover, .field.has-addons .control .button:not([disabled]).is-active:hover,
+    .field.has-addons .control .input:not([disabled]):focus:hover,
+    .field.has-addons .control .input:not([disabled]).is-focused:hover,
+    .field.has-addons .control .input:not([disabled]):active:hover,
+    .field.has-addons .control .input:not([disabled]).is-active:hover,
+    .field.has-addons .control .select select:not([disabled]):focus:hover,
+    .field.has-addons .control .select select:not([disabled]).is-focused:hover,
+    .field.has-addons .control .select select:not([disabled]):active:hover,
+    .field.has-addons .control .select select:not([disabled]).is-active:hover {
+      z-index: 4; }
+  .field.has-addons .control.is-expanded {
+    flex-grow: 1; }
+  .field.has-addons.has-addons-centered {
+    justify-content: center; }
+  .field.has-addons.has-addons-right {
+    justify-content: flex-end; }
+  .field.has-addons.has-addons-fullwidth .control {
+    flex-grow: 1;
+    flex-shrink: 0; }
+
 .field.is-grouped {
   display: flex;
-  justify-content: flex-start;
-}
-.field.is-grouped > .control {
-  flex-shrink: 0;
-}
-.field.is-grouped > .control:not(:last-child) {
-  margin-bottom: 0;
-  margin-right: 0.75rem;
-}
-.field.is-grouped > .control.is-expanded {
-  flex-grow: 1;
-  flex-shrink: 1;
-}
-.field.is-grouped.is-grouped-centered {
-  justify-content: center;
-}
-.field.is-grouped.is-grouped-right {
-  justify-content: flex-end;
-}
-.field.is-grouped.is-grouped-multiline {
-  flex-wrap: wrap;
-}
-.field.is-grouped.is-grouped-multiline > .control:last-child, .field.is-grouped.is-grouped-multiline > .control:not(:last-child) {
-  margin-bottom: 0.75rem;
-}
-.field.is-grouped.is-grouped-multiline:last-child {
-  margin-bottom: -0.75rem;
-}
-.field.is-grouped.is-grouped-multiline:not(:last-child) {
-  margin-bottom: 0;
-}
+  justify-content: flex-start; }
+  .field.is-grouped > .control {
+    flex-shrink: 0; }
+    .field.is-grouped > .control:not(:last-child) {
+      margin-bottom: 0;
+      margin-right: 0.75rem; }
+    .field.is-grouped > .control.is-expanded {
+      flex-grow: 1;
+      flex-shrink: 1; }
+  .field.is-grouped.is-grouped-centered {
+    justify-content: center; }
+  .field.is-grouped.is-grouped-right {
+    justify-content: flex-end; }
+  .field.is-grouped.is-grouped-multiline {
+    flex-wrap: wrap; }
+    .field.is-grouped.is-grouped-multiline > .control:last-child, .field.is-grouped.is-grouped-multiline > .control:not(:last-child) {
+      margin-bottom: 0.75rem; }
+    .field.is-grouped.is-grouped-multiline:last-child {
+      margin-bottom: -0.75rem; }
+    .field.is-grouped.is-grouped-multiline:not(:last-child) {
+      margin-bottom: 0; }
+
 @media screen and (min-width: 769px), print {
   .field.is-horizontal {
-    display: flex;
-  }
-}
+    display: flex; } }
 
 .field-label .label {
-  font-size: inherit;
-}
+  font-size: inherit; }
+
 @media screen and (max-width: 768px) {
   .field-label {
-    margin-bottom: 0.5rem;
-  }
-}
+    margin-bottom: 0.5rem; } }
+
 @media screen and (min-width: 769px), print {
   .field-label {
     flex-basis: 0;
     flex-grow: 1;
     flex-shrink: 0;
     margin-right: 1.5rem;
-    text-align: right;
-  }
-  .field-label.is-small {
-    font-size: 0.85rem;
-    padding-top: 0.375em;
-  }
-  .field-label.is-normal {
-    padding-top: 0.375em;
-  }
-  .field-label.is-medium {
-    font-size: 1.25rem;
-    padding-top: 0.375em;
-  }
-  .field-label.is-large {
-    font-size: 1.5rem;
-    padding-top: 0.375em;
-  }
-}
+    text-align: right; }
+    .field-label.is-small {
+      font-size: 0.85rem;
+      padding-top: 0.375em; }
+    .field-label.is-normal {
+      padding-top: 0.375em; }
+    .field-label.is-medium {
+      font-size: 1.25rem;
+      padding-top: 0.375em; }
+    .field-label.is-large {
+      font-size: 1.5rem;
+      padding-top: 0.375em; } }
 
 .field-body .field .field {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
+
 @media screen and (min-width: 769px), print {
   .field-body {
     display: flex;
     flex-basis: 0;
     flex-grow: 5;
-    flex-shrink: 1;
-  }
-  .field-body .field {
-    margin-bottom: 0;
-  }
-  .field-body > .field {
-    flex-shrink: 1;
-  }
-  .field-body > .field:not(.is-narrow) {
-    flex-grow: 1;
-  }
-  .field-body > .field:not(:last-child) {
-    margin-right: 0.75rem;
-  }
-}
+    flex-shrink: 1; }
+    .field-body .field {
+      margin-bottom: 0; }
+    .field-body > .field {
+      flex-shrink: 1; }
+      .field-body > .field:not(.is-narrow) {
+        flex-grow: 1; }
+      .field-body > .field:not(:last-child) {
+        margin-right: 0.75rem; } }
 
 .control {
   clear: both;
   font-size: 1rem;
   position: relative;
-  text-align: left;
-}
-.control.has-icon .icon {
-  color: hsl(0deg, 0%, 80%);
-  height: 2.25em;
-  pointer-events: none;
-  position: absolute;
-  top: 0;
-  width: 2.25em;
-  z-index: 4;
-}
-.control.has-icon .input:focus + .icon {
-  color: #757575;
-}
-.control.has-icon .input.is-small + .icon {
-  font-size: 0.85rem;
-}
-.control.has-icon .input.is-medium + .icon {
-  font-size: 1.25rem;
-}
-.control.has-icon .input.is-large + .icon {
-  font-size: 1.5rem;
-}
-.control.has-icon:not(.has-icon-right) .icon {
-  left: 0;
-}
-.control.has-icon:not(.has-icon-right) .input {
-  padding-left: 2.25em;
-}
-.control.has-icon.has-icon-right .icon {
-  right: 0;
-}
-.control.has-icon.has-icon-right .input {
-  padding-right: 2.25em;
-}
-.control.has-icons-left .input:focus ~ .icon,
-.control.has-icons-left .select:focus ~ .icon, .control.has-icons-right .input:focus ~ .icon,
-.control.has-icons-right .select:focus ~ .icon {
-  color: #757575;
-}
-.control.has-icons-left .input.is-small ~ .icon,
-.control.has-icons-left .select.is-small ~ .icon, .control.has-icons-right .input.is-small ~ .icon,
-.control.has-icons-right .select.is-small ~ .icon {
-  font-size: 0.85rem;
-}
-.control.has-icons-left .input.is-medium ~ .icon,
-.control.has-icons-left .select.is-medium ~ .icon, .control.has-icons-right .input.is-medium ~ .icon,
-.control.has-icons-right .select.is-medium ~ .icon {
-  font-size: 1.25rem;
-}
-.control.has-icons-left .input.is-large ~ .icon,
-.control.has-icons-left .select.is-large ~ .icon, .control.has-icons-right .input.is-large ~ .icon,
-.control.has-icons-right .select.is-large ~ .icon {
-  font-size: 1.5rem;
-}
-.control.has-icons-left .icon, .control.has-icons-right .icon {
-  color: hsl(0deg, 0%, 80%);
-  height: 2.25em;
-  pointer-events: none;
-  position: absolute;
-  top: 0;
-  width: 2.25em;
-  z-index: 4;
-}
-.control.has-icons-left .input,
-.control.has-icons-left .select select {
-  padding-left: 2.25em;
-}
-.control.has-icons-left .icon.is-left {
-  left: 0;
-}
-.control.has-icons-right .input,
-.control.has-icons-right .select select {
-  padding-right: 2.25em;
-}
-.control.has-icons-right .icon.is-right {
-  right: 0;
-}
-.control.is-loading::after {
-  position: absolute !important;
-  right: 0.625em;
-  top: 0.625em;
-  z-index: 4;
-}
-.control.is-loading.is-small:after {
-  font-size: 0.85rem;
-}
-.control.is-loading.is-medium:after {
-  font-size: 1.25rem;
-}
-.control.is-loading.is-large:after {
-  font-size: 1.5rem;
-}
+  text-align: left; }
+  .control.has-icon .icon {
+    color: #cccccc;
+    height: 2.25em;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 2.25em;
+    z-index: 4; }
+  .control.has-icon .input:focus + .icon {
+    color: #757575; }
+  .control.has-icon .input.is-small + .icon {
+    font-size: 0.85rem; }
+  .control.has-icon .input.is-medium + .icon {
+    font-size: 1.25rem; }
+  .control.has-icon .input.is-large + .icon {
+    font-size: 1.5rem; }
+  .control.has-icon:not(.has-icon-right) .icon {
+    left: 0; }
+  .control.has-icon:not(.has-icon-right) .input {
+    padding-left: 2.25em; }
+  .control.has-icon.has-icon-right .icon {
+    right: 0; }
+  .control.has-icon.has-icon-right .input {
+    padding-right: 2.25em; }
+  .control.has-icons-left .input:focus ~ .icon,
+  .control.has-icons-left .select:focus ~ .icon, .control.has-icons-right .input:focus ~ .icon,
+  .control.has-icons-right .select:focus ~ .icon {
+    color: #757575; }
+  .control.has-icons-left .input.is-small ~ .icon,
+  .control.has-icons-left .select.is-small ~ .icon, .control.has-icons-right .input.is-small ~ .icon,
+  .control.has-icons-right .select.is-small ~ .icon {
+    font-size: 0.85rem; }
+  .control.has-icons-left .input.is-medium ~ .icon,
+  .control.has-icons-left .select.is-medium ~ .icon, .control.has-icons-right .input.is-medium ~ .icon,
+  .control.has-icons-right .select.is-medium ~ .icon {
+    font-size: 1.25rem; }
+  .control.has-icons-left .input.is-large ~ .icon,
+  .control.has-icons-left .select.is-large ~ .icon, .control.has-icons-right .input.is-large ~ .icon,
+  .control.has-icons-right .select.is-large ~ .icon {
+    font-size: 1.5rem; }
+  .control.has-icons-left .icon, .control.has-icons-right .icon {
+    color: #cccccc;
+    height: 2.25em;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 2.25em;
+    z-index: 4; }
+  .control.has-icons-left .input,
+  .control.has-icons-left .select select {
+    padding-left: 2.25em; }
+  .control.has-icons-left .icon.is-left {
+    left: 0; }
+  .control.has-icons-right .input,
+  .control.has-icons-right .select select {
+    padding-right: 2.25em; }
+  .control.has-icons-right .icon.is-right {
+    right: 0; }
+  .control.is-loading::after {
+    position: absolute !important;
+    right: 0.625em;
+    top: 0.625em;
+    z-index: 4; }
+  .control.is-loading.is-small:after {
+    font-size: 0.85rem; }
+  .control.is-loading.is-medium:after {
+    font-size: 1.25rem; }
+  .control.is-loading.is-large:after {
+    font-size: 1.5rem; }
 
 .icon {
   align-items: center;
   display: inline-flex;
   justify-content: center;
   height: 1.5rem;
-  width: 1.5rem;
-}
-.icon.is-small {
-  height: 1rem;
-  width: 1rem;
-}
-.icon.is-medium {
-  height: 2rem;
-  width: 2rem;
-}
-.icon.is-large {
-  height: 3rem;
-  width: 3rem;
-}
+  width: 1.5rem; }
+  .icon.is-small {
+    height: 1rem;
+    width: 1rem; }
+  .icon.is-medium {
+    height: 2rem;
+    width: 2rem; }
+  .icon.is-large {
+    height: 3rem;
+    width: 3rem; }
 
 .image {
   display: block;
-  position: relative;
-}
-.image img {
-  display: block;
-  height: auto;
-  width: 100%;
-}
-.image img.is-rounded {
-  border-radius: 290486px;
-}
-.image.is-square img, .image.is-1by1 img, .image.is-5by4 img, .image.is-4by3 img, .image.is-3by2 img, .image.is-5by3 img, .image.is-16by9 img, .image.is-2by1 img, .image.is-3by1 img, .image.is-4by5 img, .image.is-3by4 img, .image.is-2by3 img, .image.is-3by5 img, .image.is-9by16 img, .image.is-1by2 img, .image.is-1by3 img {
-  height: 100%;
-  width: 100%;
-}
-.image.is-square, .image.is-1by1 {
-  padding-top: 100%;
-}
-.image.is-5by4 {
-  padding-top: 80%;
-}
-.image.is-4by3 {
-  padding-top: 75%;
-}
-.image.is-3by2 {
-  padding-top: 66.6666%;
-}
-.image.is-5by3 {
-  padding-top: 60%;
-}
-.image.is-16by9 {
-  padding-top: 56.25%;
-}
-.image.is-2by1 {
-  padding-top: 50%;
-}
-.image.is-3by1 {
-  padding-top: 33.3333%;
-}
-.image.is-4by5 {
-  padding-top: 125%;
-}
-.image.is-3by4 {
-  padding-top: 133.3333%;
-}
-.image.is-2by3 {
-  padding-top: 150%;
-}
-.image.is-3by5 {
-  padding-top: 166.6666%;
-}
-.image.is-9by16 {
-  padding-top: 177.7777%;
-}
-.image.is-1by2 {
-  padding-top: 200%;
-}
-.image.is-1by3 {
-  padding-top: 300%;
-}
-.image.is-16x16 {
-  height: 16px;
-  width: 16px;
-}
-.image.is-24x24 {
-  height: 24px;
-  width: 24px;
-}
-.image.is-32x32 {
-  height: 32px;
-  width: 32px;
-}
-.image.is-48x48 {
-  height: 48px;
-  width: 48px;
-}
-.image.is-64x64 {
-  height: 64px;
-  width: 64px;
-}
-.image.is-96x96 {
-  height: 96px;
-  width: 96px;
-}
-.image.is-128x128 {
-  height: 128px;
-  width: 128px;
-}
+  position: relative; }
+  .image img {
+    display: block;
+    height: auto;
+    width: 100%; }
+    .image img.is-rounded {
+      border-radius: 290486px; }
+  .image.is-square img, .image.is-1by1 img, .image.is-5by4 img, .image.is-4by3 img, .image.is-3by2 img, .image.is-5by3 img, .image.is-16by9 img, .image.is-2by1 img, .image.is-3by1 img, .image.is-4by5 img, .image.is-3by4 img, .image.is-2by3 img, .image.is-3by5 img, .image.is-9by16 img, .image.is-1by2 img, .image.is-1by3 img {
+    height: 100%;
+    width: 100%; }
+  .image.is-square, .image.is-1by1 {
+    padding-top: 100%; }
+  .image.is-5by4 {
+    padding-top: 80%; }
+  .image.is-4by3 {
+    padding-top: 75%; }
+  .image.is-3by2 {
+    padding-top: 66.6666%; }
+  .image.is-5by3 {
+    padding-top: 60%; }
+  .image.is-16by9 {
+    padding-top: 56.25%; }
+  .image.is-2by1 {
+    padding-top: 50%; }
+  .image.is-3by1 {
+    padding-top: 33.3333%; }
+  .image.is-4by5 {
+    padding-top: 125%; }
+  .image.is-3by4 {
+    padding-top: 133.3333%; }
+  .image.is-2by3 {
+    padding-top: 150%; }
+  .image.is-3by5 {
+    padding-top: 166.6666%; }
+  .image.is-9by16 {
+    padding-top: 177.7777%; }
+  .image.is-1by2 {
+    padding-top: 200%; }
+  .image.is-1by3 {
+    padding-top: 300%; }
+  .image.is-16x16 {
+    height: 16px;
+    width: 16px; }
+  .image.is-24x24 {
+    height: 24px;
+    width: 24px; }
+  .image.is-32x32 {
+    height: 32px;
+    width: 32px; }
+  .image.is-48x48 {
+    height: 48px;
+    width: 48px; }
+  .image.is-64x64 {
+    height: 64px;
+    width: 64px; }
+  .image.is-96x96 {
+    height: 96px;
+    width: 96px; }
+  .image.is-128x128 {
+    height: 128px;
+    width: 128px; }
 
 .notification {
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   border-radius: 4px;
   padding: 0.75rem 1.25rem;
-  position: relative;
-}
-.notification a:not(.button):not(.dropdown-item) {
-  color: currentColor;
-  text-decoration: underline;
-}
-.notification strong {
-  color: currentColor;
-}
-.notification code,
-.notification pre {
-  background: hsl(0deg, 0%, 100%);
-}
-.notification pre code {
-  background: transparent;
-}
-.notification > .delete {
-  position: absolute;
-  right: 0.5rem;
-  top: 0.5rem;
-}
-.notification .title,
-.notification .subtitle,
-.notification .content {
-  color: currentColor;
-}
-.notification.is-white {
-  background-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 4%);
-}
-.notification.is-black {
-  background-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 100%);
-}
-.notification.is-light {
-  background-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.notification.is-dark {
-  background-color: #2d2d2d;
-  color: hsl(0deg, 0%, 96%);
-}
-.notification.is-primary {
-  background-color: #b31b1b;
-  color: #fff;
-}
-.notification.is-link {
-  background-color: #086db1;
-  color: #fff;
-}
-.notification.is-info {
-  background-color: hsl(204deg, 86%, 53%);
-  color: #fff;
-}
-.notification.is-success {
-  background-color: #008412;
-  color: #fff;
-}
-.notification.is-warning {
-  background-color: #b55c06;
-  color: #fff;
-}
-.notification.is-danger {
-  background-color: #cd0200;
-  color: #fff;
-}
+  position: relative; }
+  .notification a:not(.button):not(.dropdown-item) {
+    color: currentColor;
+    text-decoration: underline; }
+  .notification strong {
+    color: currentColor; }
+  .notification code,
+  .notification pre {
+    background: white; }
+  .notification pre code {
+    background: transparent; }
+  .notification > .delete {
+    position: absolute;
+    right: 0.5rem;
+    top: 0.5rem; }
+  .notification .title,
+  .notification .subtitle,
+  .notification .content {
+    color: currentColor; }
+  .notification.is-white {
+    background-color: white;
+    color: #0a0a0a; }
+  .notification.is-black {
+    background-color: #0a0a0a;
+    color: white; }
+  .notification.is-light {
+    background-color: whitesmoke;
+    color: #2d2d2d; }
+  .notification.is-dark {
+    background-color: #2d2d2d;
+    color: whitesmoke; }
+  .notification.is-primary {
+    background-color: #b31b1b;
+    color: #fff; }
+  .notification.is-link {
+    background-color: #1565c0;
+    color: #fff; }
+  .notification.is-info {
+    background-color: #209cee;
+    color: #fff; }
+  .notification.is-success {
+    background-color: #008412;
+    color: #fff; }
+  .notification.is-warning {
+    background-color: #b55c06;
+    color: #fff; }
+  .notification.is-danger {
+    background-color: #cd0200;
+    color: #fff; }
 
 .progress {
   -moz-appearance: none;
@@ -3878,323 +3046,241 @@ a.box:active {
   height: 1rem;
   overflow: hidden;
   padding: 0;
-  width: 100%;
-}
-.progress::-webkit-progress-bar {
-  background-color: hsl(0deg, 0%, 80%);
-}
-.progress::-webkit-progress-value {
-  background-color: #333;
-}
-.progress::-moz-progress-bar {
-  background-color: #333;
-}
-.progress::-ms-fill {
-  background-color: #333;
-  border: none;
-}
-.progress.is-white::-webkit-progress-value {
-  background-color: hsl(0deg, 0%, 100%);
-}
-.progress.is-white::-moz-progress-bar {
-  background-color: hsl(0deg, 0%, 100%);
-}
-.progress.is-white::-ms-fill {
-  background-color: hsl(0deg, 0%, 100%);
-}
-.progress.is-black::-webkit-progress-value {
-  background-color: hsl(0deg, 0%, 4%);
-}
-.progress.is-black::-moz-progress-bar {
-  background-color: hsl(0deg, 0%, 4%);
-}
-.progress.is-black::-ms-fill {
-  background-color: hsl(0deg, 0%, 4%);
-}
-.progress.is-light::-webkit-progress-value {
-  background-color: hsl(0deg, 0%, 96%);
-}
-.progress.is-light::-moz-progress-bar {
-  background-color: hsl(0deg, 0%, 96%);
-}
-.progress.is-light::-ms-fill {
-  background-color: hsl(0deg, 0%, 96%);
-}
-.progress.is-dark::-webkit-progress-value {
-  background-color: #2d2d2d;
-}
-.progress.is-dark::-moz-progress-bar {
-  background-color: #2d2d2d;
-}
-.progress.is-dark::-ms-fill {
-  background-color: #2d2d2d;
-}
-.progress.is-primary::-webkit-progress-value {
-  background-color: #b31b1b;
-}
-.progress.is-primary::-moz-progress-bar {
-  background-color: #b31b1b;
-}
-.progress.is-primary::-ms-fill {
-  background-color: #b31b1b;
-}
-.progress.is-link::-webkit-progress-value {
-  background-color: #086db1;
-}
-.progress.is-link::-moz-progress-bar {
-  background-color: #086db1;
-}
-.progress.is-link::-ms-fill {
-  background-color: #086db1;
-}
-.progress.is-info::-webkit-progress-value {
-  background-color: hsl(204deg, 86%, 53%);
-}
-.progress.is-info::-moz-progress-bar {
-  background-color: hsl(204deg, 86%, 53%);
-}
-.progress.is-info::-ms-fill {
-  background-color: hsl(204deg, 86%, 53%);
-}
-.progress.is-success::-webkit-progress-value {
-  background-color: #008412;
-}
-.progress.is-success::-moz-progress-bar {
-  background-color: #008412;
-}
-.progress.is-success::-ms-fill {
-  background-color: #008412;
-}
-.progress.is-warning::-webkit-progress-value {
-  background-color: #b55c06;
-}
-.progress.is-warning::-moz-progress-bar {
-  background-color: #b55c06;
-}
-.progress.is-warning::-ms-fill {
-  background-color: #b55c06;
-}
-.progress.is-danger::-webkit-progress-value {
-  background-color: #cd0200;
-}
-.progress.is-danger::-moz-progress-bar {
-  background-color: #cd0200;
-}
-.progress.is-danger::-ms-fill {
-  background-color: #cd0200;
-}
-.progress.is-small {
-  height: 0.85rem;
-}
-.progress.is-medium {
-  height: 1.25rem;
-}
-.progress.is-large {
-  height: 1.5rem;
-}
+  width: 100%; }
+  .progress::-webkit-progress-bar {
+    background-color: #cccccc; }
+  .progress::-webkit-progress-value {
+    background-color: #333; }
+  .progress::-moz-progress-bar {
+    background-color: #333; }
+  .progress::-ms-fill {
+    background-color: #333;
+    border: none; }
+  .progress.is-white::-webkit-progress-value {
+    background-color: white; }
+  .progress.is-white::-moz-progress-bar {
+    background-color: white; }
+  .progress.is-white::-ms-fill {
+    background-color: white; }
+  .progress.is-black::-webkit-progress-value {
+    background-color: #0a0a0a; }
+  .progress.is-black::-moz-progress-bar {
+    background-color: #0a0a0a; }
+  .progress.is-black::-ms-fill {
+    background-color: #0a0a0a; }
+  .progress.is-light::-webkit-progress-value {
+    background-color: whitesmoke; }
+  .progress.is-light::-moz-progress-bar {
+    background-color: whitesmoke; }
+  .progress.is-light::-ms-fill {
+    background-color: whitesmoke; }
+  .progress.is-dark::-webkit-progress-value {
+    background-color: #2d2d2d; }
+  .progress.is-dark::-moz-progress-bar {
+    background-color: #2d2d2d; }
+  .progress.is-dark::-ms-fill {
+    background-color: #2d2d2d; }
+  .progress.is-primary::-webkit-progress-value {
+    background-color: #b31b1b; }
+  .progress.is-primary::-moz-progress-bar {
+    background-color: #b31b1b; }
+  .progress.is-primary::-ms-fill {
+    background-color: #b31b1b; }
+  .progress.is-link::-webkit-progress-value {
+    background-color: #1565c0; }
+  .progress.is-link::-moz-progress-bar {
+    background-color: #1565c0; }
+  .progress.is-link::-ms-fill {
+    background-color: #1565c0; }
+  .progress.is-info::-webkit-progress-value {
+    background-color: #209cee; }
+  .progress.is-info::-moz-progress-bar {
+    background-color: #209cee; }
+  .progress.is-info::-ms-fill {
+    background-color: #209cee; }
+  .progress.is-success::-webkit-progress-value {
+    background-color: #008412; }
+  .progress.is-success::-moz-progress-bar {
+    background-color: #008412; }
+  .progress.is-success::-ms-fill {
+    background-color: #008412; }
+  .progress.is-warning::-webkit-progress-value {
+    background-color: #b55c06; }
+  .progress.is-warning::-moz-progress-bar {
+    background-color: #b55c06; }
+  .progress.is-warning::-ms-fill {
+    background-color: #b55c06; }
+  .progress.is-danger::-webkit-progress-value {
+    background-color: #cd0200; }
+  .progress.is-danger::-moz-progress-bar {
+    background-color: #cd0200; }
+  .progress.is-danger::-ms-fill {
+    background-color: #cd0200; }
+  .progress.is-small {
+    height: 0.85rem; }
+  .progress.is-medium {
+    height: 1.25rem; }
+  .progress.is-large {
+    height: 1.5rem; }
 
 .table {
-  background-color: hsl(0deg, 0%, 100%);
-  color: #2d2d2d;
-}
-.table td,
-.table th {
-  border: 1px solid hsl(0deg, 0%, 80%);
-  border-width: 0 0 1px;
-  padding: 0.5em 0.75em;
-  vertical-align: top;
-}
-.table td.is-white,
-.table th.is-white {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 4%);
-}
-.table td.is-black,
-.table th.is-black {
-  background-color: hsl(0deg, 0%, 4%);
-  border-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 100%);
-}
-.table td.is-light,
-.table th.is-light {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.table td.is-dark,
-.table th.is-dark {
-  background-color: #2d2d2d;
-  border-color: #2d2d2d;
-  color: hsl(0deg, 0%, 96%);
-}
-.table td.is-primary,
-.table th.is-primary {
-  background-color: #b31b1b;
-  border-color: #b31b1b;
-  color: #fff;
-}
-.table td.is-link,
-.table th.is-link {
-  background-color: #086db1;
-  border-color: #086db1;
-  color: #fff;
-}
-.table td.is-info,
-.table th.is-info {
-  background-color: hsl(204deg, 86%, 53%);
-  border-color: hsl(204deg, 86%, 53%);
-  color: #fff;
-}
-.table td.is-success,
-.table th.is-success {
-  background-color: #008412;
-  border-color: #008412;
-  color: #fff;
-}
-.table td.is-warning,
-.table th.is-warning {
-  background-color: #b55c06;
-  border-color: #b55c06;
-  color: #fff;
-}
-.table td.is-danger,
-.table th.is-danger {
-  background-color: #cd0200;
-  border-color: #cd0200;
-  color: #fff;
-}
-.table td.is-narrow,
-.table th.is-narrow {
-  white-space: nowrap;
-  width: 1%;
-}
-.table td.is-selected,
-.table th.is-selected {
-  background-color: #b31b1b;
-  color: #fff;
-}
-.table td.is-selected a,
-.table td.is-selected strong,
-.table th.is-selected a,
-.table th.is-selected strong {
-  color: currentColor;
-}
-.table th {
-  color: #2d2d2d;
-  text-align: left;
-}
-.table tr.is-selected {
-  background-color: #b31b1b;
-  color: #fff;
-}
-.table tr.is-selected a,
-.table tr.is-selected strong {
-  color: currentColor;
-}
-.table tr.is-selected td,
-.table tr.is-selected th {
-  border-color: #fff;
-  color: currentColor;
-}
-.table thead td,
-.table thead th {
-  border-width: 0 0 2px;
-  color: #2d2d2d;
-}
-.table tfoot td,
-.table tfoot th {
-  border-width: 2px 0 0;
-  color: #2d2d2d;
-}
-.table tbody tr:last-child td,
-.table tbody tr:last-child th {
-  border-bottom-width: 0;
-}
-.table.is-bordered td,
-.table.is-bordered th {
-  border-width: 1px;
-}
-.table.is-bordered tr:last-child td,
-.table.is-bordered tr:last-child th {
-  border-bottom-width: 1px;
-}
-.table.is-fullwidth {
-  width: 100%;
-}
-.table.is-hoverable tbody tr:not(.is-selected):hover {
-  background-color: hsl(0deg, 0%, 98%);
-}
-.table.is-hoverable.is-striped tbody tr:not(.is-selected):hover {
-  background-color: hsl(0deg, 0%, 98%);
-}
-.table.is-hoverable.is-striped tbody tr:not(.is-selected):hover:nth-child(even) {
-  background-color: hsl(0deg, 0%, 96%);
-}
-.table.is-narrow td,
-.table.is-narrow th {
-  padding: 0.25em 0.5em;
-}
-.table.is-striped tbody tr:not(.is-selected):nth-child(even) {
-  background-color: hsl(0deg, 0%, 98%);
-}
+  background-color: white;
+  color: #2d2d2d; }
+  .table td,
+  .table th {
+    border: 1px solid #cccccc;
+    border-width: 0 0 1px;
+    padding: 0.5em 0.75em;
+    vertical-align: top; }
+    .table td.is-white,
+    .table th.is-white {
+      background-color: white;
+      border-color: white;
+      color: #0a0a0a; }
+    .table td.is-black,
+    .table th.is-black {
+      background-color: #0a0a0a;
+      border-color: #0a0a0a;
+      color: white; }
+    .table td.is-light,
+    .table th.is-light {
+      background-color: whitesmoke;
+      border-color: whitesmoke;
+      color: #2d2d2d; }
+    .table td.is-dark,
+    .table th.is-dark {
+      background-color: #2d2d2d;
+      border-color: #2d2d2d;
+      color: whitesmoke; }
+    .table td.is-primary,
+    .table th.is-primary {
+      background-color: #b31b1b;
+      border-color: #b31b1b;
+      color: #fff; }
+    .table td.is-link,
+    .table th.is-link {
+      background-color: #1565c0;
+      border-color: #1565c0;
+      color: #fff; }
+    .table td.is-info,
+    .table th.is-info {
+      background-color: #209cee;
+      border-color: #209cee;
+      color: #fff; }
+    .table td.is-success,
+    .table th.is-success {
+      background-color: #008412;
+      border-color: #008412;
+      color: #fff; }
+    .table td.is-warning,
+    .table th.is-warning {
+      background-color: #b55c06;
+      border-color: #b55c06;
+      color: #fff; }
+    .table td.is-danger,
+    .table th.is-danger {
+      background-color: #cd0200;
+      border-color: #cd0200;
+      color: #fff; }
+    .table td.is-narrow,
+    .table th.is-narrow {
+      white-space: nowrap;
+      width: 1%; }
+    .table td.is-selected,
+    .table th.is-selected {
+      background-color: #b31b1b;
+      color: #fff; }
+      .table td.is-selected a,
+      .table td.is-selected strong,
+      .table th.is-selected a,
+      .table th.is-selected strong {
+        color: currentColor; }
+  .table th {
+    color: #2d2d2d;
+    text-align: left; }
+  .table tr.is-selected {
+    background-color: #b31b1b;
+    color: #fff; }
+    .table tr.is-selected a,
+    .table tr.is-selected strong {
+      color: currentColor; }
+    .table tr.is-selected td,
+    .table tr.is-selected th {
+      border-color: #fff;
+      color: currentColor; }
+  .table thead td,
+  .table thead th {
+    border-width: 0 0 2px;
+    color: #2d2d2d; }
+  .table tfoot td,
+  .table tfoot th {
+    border-width: 2px 0 0;
+    color: #2d2d2d; }
+  .table tbody tr:last-child td,
+  .table tbody tr:last-child th {
+    border-bottom-width: 0; }
+  .table.is-bordered td,
+  .table.is-bordered th {
+    border-width: 1px; }
+  .table.is-bordered tr:last-child td,
+  .table.is-bordered tr:last-child th {
+    border-bottom-width: 1px; }
+  .table.is-fullwidth {
+    width: 100%; }
+  .table.is-hoverable tbody tr:not(.is-selected):hover {
+    background-color: #fafafa; }
+  .table.is-hoverable.is-striped tbody tr:not(.is-selected):hover {
+    background-color: #fafafa; }
+    .table.is-hoverable.is-striped tbody tr:not(.is-selected):hover:nth-child(even) {
+      background-color: whitesmoke; }
+  .table.is-narrow td,
+  .table.is-narrow th {
+    padding: 0.25em 0.5em; }
+  .table.is-striped tbody tr:not(.is-selected):nth-child(even) {
+    background-color: #fafafa; }
 
 .table-container {
   -webkit-overflow-scrolling: touch;
   overflow: auto;
   overflow-y: hidden;
-  max-width: 100%;
-}
+  max-width: 100%; }
 
 .tags {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-start;
-}
-.tags .tag {
-  margin-bottom: 0.5rem;
-}
-.tags .tag:not(:last-child) {
-  margin-right: 0.5rem;
-}
-.tags:last-child {
-  margin-bottom: -0.5rem;
-}
-.tags:not(:last-child) {
-  margin-bottom: 1rem;
-}
-.tags.has-addons .tag {
-  margin-right: 0;
-}
-.tags.has-addons .tag:not(:first-child) {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-}
-.tags.has-addons .tag:not(:last-child) {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-}
-.tags.is-centered {
-  justify-content: center;
-}
-.tags.is-centered .tag {
-  margin-right: 0.25rem;
-  margin-left: 0.25rem;
-}
-.tags.is-right {
-  justify-content: flex-end;
-}
-.tags.is-right .tag:not(:first-child) {
-  margin-left: 0.5rem;
-}
-.tags.is-right .tag:not(:last-child) {
-  margin-right: 0;
-}
+  justify-content: flex-start; }
+  .tags .tag {
+    margin-bottom: 0.5rem; }
+    .tags .tag:not(:last-child) {
+      margin-right: 0.5rem; }
+  .tags:last-child {
+    margin-bottom: -0.5rem; }
+  .tags:not(:last-child) {
+    margin-bottom: 1rem; }
+  .tags.has-addons .tag {
+    margin-right: 0; }
+    .tags.has-addons .tag:not(:first-child) {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0; }
+    .tags.has-addons .tag:not(:last-child) {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0; }
+  .tags.is-centered {
+    justify-content: center; }
+    .tags.is-centered .tag {
+      margin-right: 0.25rem;
+      margin-left: 0.25rem; }
+  .tags.is-right {
+    justify-content: flex-end; }
+    .tags.is-right .tag:not(:first-child) {
+      margin-left: 0.5rem; }
+    .tags.is-right .tag:not(:last-child) {
+      margin-right: 0; }
 
 .tag:not(body) {
   align-items: center;
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   border-radius: 4px;
   color: #333;
   display: inline-flex;
@@ -4204,226 +3290,172 @@ a.box:active {
   line-height: 1.5;
   padding-left: 0.75em;
   padding-right: 0.75em;
-  white-space: nowrap;
-}
-.tag:not(body) .delete {
-  margin-left: 0.25rem;
-  margin-right: -0.375rem;
-}
-.tag:not(body).is-white {
-  background-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 4%);
-}
-.tag:not(body).is-black {
-  background-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 100%);
-}
-.tag:not(body).is-light {
-  background-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.tag:not(body).is-dark {
-  background-color: #2d2d2d;
-  color: hsl(0deg, 0%, 96%);
-}
-.tag:not(body).is-primary {
-  background-color: #b31b1b;
-  color: #fff;
-}
-.tag:not(body).is-link {
-  background-color: #086db1;
-  color: #fff;
-}
-.tag:not(body).is-info {
-  background-color: hsl(204deg, 86%, 53%);
-  color: #fff;
-}
-.tag:not(body).is-success {
-  background-color: #008412;
-  color: #fff;
-}
-.tag:not(body).is-warning {
-  background-color: #b55c06;
-  color: #fff;
-}
-.tag:not(body).is-danger {
-  background-color: #cd0200;
-  color: #fff;
-}
-.tag:not(body).is-medium {
-  font-size: 1rem;
-}
-.tag:not(body).is-large {
-  font-size: 1.25rem;
-}
-.tag:not(body) .icon:first-child:not(:last-child) {
-  margin-left: -0.375em;
-  margin-right: 0.1875em;
-}
-.tag:not(body) .icon:last-child:not(:first-child) {
-  margin-left: 0.1875em;
-  margin-right: -0.375em;
-}
-.tag:not(body) .icon:first-child:last-child {
-  margin-left: -0.375em;
-  margin-right: -0.375em;
-}
-.tag:not(body).is-delete {
-  margin-left: 1px;
-  padding: 0;
-  position: relative;
-  width: 2em;
-}
-.tag:not(body).is-delete::before, .tag:not(body).is-delete::after {
-  background-color: currentColor;
-  content: "";
-  display: block;
-  left: 50%;
-  position: absolute;
-  top: 50%;
-  transform: translateX(-50%) translateY(-50%) rotate(45deg);
-  transform-origin: center center;
-}
-.tag:not(body).is-delete::before {
-  height: 1px;
-  width: 50%;
-}
-.tag:not(body).is-delete::after {
-  height: 50%;
-  width: 1px;
-}
-.tag:not(body).is-delete:hover, .tag:not(body).is-delete:focus {
-  background-color: #e8e8e8;
-}
-.tag:not(body).is-delete:active {
-  background-color: #dbdbdb;
-}
-.tag:not(body).is-rounded {
-  border-radius: 290486px;
-}
+  white-space: nowrap; }
+  .tag:not(body) .delete {
+    margin-left: 0.25rem;
+    margin-right: -0.375rem; }
+  .tag:not(body).is-white {
+    background-color: white;
+    color: #0a0a0a; }
+  .tag:not(body).is-black {
+    background-color: #0a0a0a;
+    color: white; }
+  .tag:not(body).is-light {
+    background-color: whitesmoke;
+    color: #2d2d2d; }
+  .tag:not(body).is-dark {
+    background-color: #2d2d2d;
+    color: whitesmoke; }
+  .tag:not(body).is-primary {
+    background-color: #b31b1b;
+    color: #fff; }
+  .tag:not(body).is-link {
+    background-color: #1565c0;
+    color: #fff; }
+  .tag:not(body).is-info {
+    background-color: #209cee;
+    color: #fff; }
+  .tag:not(body).is-success {
+    background-color: #008412;
+    color: #fff; }
+  .tag:not(body).is-warning {
+    background-color: #b55c06;
+    color: #fff; }
+  .tag:not(body).is-danger {
+    background-color: #cd0200;
+    color: #fff; }
+  .tag:not(body).is-medium {
+    font-size: 1rem; }
+  .tag:not(body).is-large {
+    font-size: 1.25rem; }
+  .tag:not(body) .icon:first-child:not(:last-child) {
+    margin-left: -0.375em;
+    margin-right: 0.1875em; }
+  .tag:not(body) .icon:last-child:not(:first-child) {
+    margin-left: 0.1875em;
+    margin-right: -0.375em; }
+  .tag:not(body) .icon:first-child:last-child {
+    margin-left: -0.375em;
+    margin-right: -0.375em; }
+  .tag:not(body).is-delete {
+    margin-left: 1px;
+    padding: 0;
+    position: relative;
+    width: 2em; }
+    .tag:not(body).is-delete::before, .tag:not(body).is-delete::after {
+      background-color: currentColor;
+      content: "";
+      display: block;
+      left: 50%;
+      position: absolute;
+      top: 50%;
+      transform: translateX(-50%) translateY(-50%) rotate(45deg);
+      transform-origin: center center; }
+    .tag:not(body).is-delete::before {
+      height: 1px;
+      width: 50%; }
+    .tag:not(body).is-delete::after {
+      height: 50%;
+      width: 1px; }
+    .tag:not(body).is-delete:hover, .tag:not(body).is-delete:focus {
+      background-color: #e8e8e8; }
+    .tag:not(body).is-delete:active {
+      background-color: #dbdbdb; }
+  .tag:not(body).is-rounded {
+    border-radius: 290486px; }
 
 a.tag:hover {
-  text-decoration: underline;
-}
+  text-decoration: underline; }
 
 .title,
 .subtitle {
-  word-break: break-word;
-}
-.title em,
-.title span,
-.subtitle em,
-.subtitle span {
-  font-weight: inherit;
-}
-.title sub,
-.subtitle sub {
-  font-size: 0.75em;
-}
-.title sup,
-.subtitle sup {
-  font-size: 0.75em;
-}
-.title .tag,
-.subtitle .tag {
-  vertical-align: middle;
-}
+  word-break: break-word; }
+  .title em,
+  .title span,
+  .subtitle em,
+  .subtitle span {
+    font-weight: inherit; }
+  .title sub,
+  .subtitle sub {
+    font-size: 0.75em; }
+  .title sup,
+  .subtitle sup {
+    font-size: 0.75em; }
+  .title .tag,
+  .subtitle .tag {
+    vertical-align: middle; }
 
 .title {
   color: #2d2d2d;
   font-size: 2rem;
   font-weight: 600;
-  line-height: 1.125;
-}
-.title strong {
-  color: inherit;
-  font-weight: inherit;
-}
-.title + .highlight {
-  margin-top: -0.75rem;
-}
-.title:not(.is-spaced) + .subtitle {
-  margin-top: -1.25rem;
-}
-.title.is-1 {
-  font-size: 3rem;
-}
-.title.is-2 {
-  font-size: 2.5rem;
-}
-.title.is-3 {
-  font-size: 2rem;
-}
-.title.is-4 {
-  font-size: 1.5rem;
-}
-.title.is-5 {
-  font-size: 1.25rem;
-}
-.title.is-6 {
-  font-size: 1rem;
-}
-.title.is-7 {
-  font-size: 0.85rem;
-}
+  line-height: 1.125; }
+  .title strong {
+    color: inherit;
+    font-weight: inherit; }
+  .title + .highlight {
+    margin-top: -0.75rem; }
+  .title:not(.is-spaced) + .subtitle {
+    margin-top: -1.25rem; }
+  .title.is-1 {
+    font-size: 3rem; }
+  .title.is-2 {
+    font-size: 2.5rem; }
+  .title.is-3 {
+    font-size: 2rem; }
+  .title.is-4 {
+    font-size: 1.5rem; }
+  .title.is-5 {
+    font-size: 1.25rem; }
+  .title.is-6 {
+    font-size: 1rem; }
+  .title.is-7 {
+    font-size: 0.85rem; }
 
 .subtitle {
   color: #757575;
   font-size: 1.25rem;
   font-weight: 400;
-  line-height: 1.25;
-}
-.subtitle strong {
-  color: #2d2d2d;
-  font-weight: 600;
-}
-.subtitle:not(.is-spaced) + .title {
-  margin-top: -1.25rem;
-}
-.subtitle.is-1 {
-  font-size: 3rem;
-}
-.subtitle.is-2 {
-  font-size: 2.5rem;
-}
-.subtitle.is-3 {
-  font-size: 2rem;
-}
-.subtitle.is-4 {
-  font-size: 1.5rem;
-}
-.subtitle.is-5 {
-  font-size: 1.25rem;
-}
-.subtitle.is-6 {
-  font-size: 1rem;
-}
-.subtitle.is-7 {
-  font-size: 0.85rem;
-}
+  line-height: 1.25; }
+  .subtitle strong {
+    color: #2d2d2d;
+    font-weight: 600; }
+  .subtitle:not(.is-spaced) + .title {
+    margin-top: -1.25rem; }
+  .subtitle.is-1 {
+    font-size: 3rem; }
+  .subtitle.is-2 {
+    font-size: 2.5rem; }
+  .subtitle.is-3 {
+    font-size: 2rem; }
+  .subtitle.is-4 {
+    font-size: 1.5rem; }
+  .subtitle.is-5 {
+    font-size: 1.25rem; }
+  .subtitle.is-6 {
+    font-size: 1rem; }
+  .subtitle.is-7 {
+    font-size: 0.85rem; }
 
 .heading {
   display: block;
   font-size: 11px;
   letter-spacing: 1px;
   margin-bottom: 5px;
-  text-transform: uppercase;
-}
+  text-transform: uppercase; }
 
 .highlight {
   font-weight: 400;
   max-width: 100%;
   overflow: hidden;
-  padding: 0;
-}
-.highlight pre {
-  overflow: auto;
-  max-width: 100%;
-}
+  padding: 0; }
+  .highlight pre {
+    overflow: auto;
+    max-width: 100%; }
 
 .number {
   align-items: center;
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   border-radius: 290486px;
   display: inline-flex;
   font-size: 1.25rem;
@@ -4433,96 +3465,74 @@ a.tag:hover {
   min-width: 2.5em;
   padding: 0.25rem 0.5rem;
   text-align: center;
-  vertical-align: top;
-}
+  vertical-align: top; }
 
 .breadcrumb {
   font-size: 1rem;
-  white-space: nowrap;
-}
-.breadcrumb a {
-  align-items: center;
-  color: #086db1;
-  display: flex;
-  justify-content: center;
-  padding: 0 0.75em;
-}
-.breadcrumb a:hover {
-  color: #2d2d2d;
-}
-.breadcrumb li {
-  align-items: center;
-  display: flex;
-}
-.breadcrumb li:first-child a {
-  padding-left: 0;
-}
-.breadcrumb li.is-active a {
-  color: #2d2d2d;
-  cursor: default;
-  pointer-events: none;
-}
-.breadcrumb li + li::before {
-  color: hsl(0deg, 0%, 60%);
-  content: "/";
-}
-.breadcrumb ul,
-.breadcrumb ol {
-  align-items: flex-start;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-}
-.breadcrumb .icon:first-child {
-  margin-right: 0.5em;
-}
-.breadcrumb .icon:last-child {
-  margin-left: 0.5em;
-}
-.breadcrumb.is-centered ol,
-.breadcrumb.is-centered ul {
-  justify-content: center;
-}
-.breadcrumb.is-right ol,
-.breadcrumb.is-right ul {
-  justify-content: flex-end;
-}
-.breadcrumb.is-small {
-  font-size: 0.85rem;
-}
-.breadcrumb.is-medium {
-  font-size: 1.25rem;
-}
-.breadcrumb.is-large {
-  font-size: 1.5rem;
-}
-.breadcrumb.has-arrow-separator li + li::before {
-  content: "→";
-}
-.breadcrumb.has-bullet-separator li + li::before {
-  content: "•";
-}
-.breadcrumb.has-dot-separator li + li::before {
-  content: "·";
-}
-.breadcrumb.has-succeeds-separator li + li::before {
-  content: "≻";
-}
+  white-space: nowrap; }
+  .breadcrumb a {
+    align-items: center;
+    color: #1565c0;
+    display: flex;
+    justify-content: center;
+    padding: 0 0.75em; }
+    .breadcrumb a:hover {
+      color: #2d2d2d; }
+  .breadcrumb li {
+    align-items: center;
+    display: flex; }
+    .breadcrumb li:first-child a {
+      padding-left: 0; }
+    .breadcrumb li.is-active a {
+      color: #2d2d2d;
+      cursor: default;
+      pointer-events: none; }
+    .breadcrumb li + li::before {
+      color: #999999;
+      content: "\0002f"; }
+  .breadcrumb ul,
+  .breadcrumb ol {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start; }
+  .breadcrumb .icon:first-child {
+    margin-right: 0.5em; }
+  .breadcrumb .icon:last-child {
+    margin-left: 0.5em; }
+  .breadcrumb.is-centered ol,
+  .breadcrumb.is-centered ul {
+    justify-content: center; }
+  .breadcrumb.is-right ol,
+  .breadcrumb.is-right ul {
+    justify-content: flex-end; }
+  .breadcrumb.is-small {
+    font-size: 0.85rem; }
+  .breadcrumb.is-medium {
+    font-size: 1.25rem; }
+  .breadcrumb.is-large {
+    font-size: 1.5rem; }
+  .breadcrumb.has-arrow-separator li + li::before {
+    content: "\02192"; }
+  .breadcrumb.has-bullet-separator li + li::before {
+    content: "\02022"; }
+  .breadcrumb.has-dot-separator li + li::before {
+    content: "\000b7"; }
+  .breadcrumb.has-succeeds-separator li + li::before {
+    content: "\0227B"; }
 
 .card {
-  background-color: hsl(0deg, 0%, 100%);
+  background-color: white;
   box-shadow: 0 2px 3px rgba(10, 10, 10, 0.1), 0 0 0 1px rgba(10, 10, 10, 0.1);
   color: #333;
   max-width: 100%;
-  position: relative;
-}
+  position: relative; }
 
 .card-header {
   background-color: transparent;
   align-items: stretch;
   box-shadow: 0 1px 2px rgba(10, 10, 10, 0.1);
-  display: flex;
-}
+  display: flex; }
 
 .card-header-title {
   align-items: center;
@@ -4530,36 +3540,30 @@ a.tag:hover {
   display: flex;
   flex-grow: 1;
   font-weight: 700;
-  padding: 0.75rem;
-}
-.card-header-title.is-centered {
-  justify-content: center;
-}
+  padding: 0.75rem; }
+  .card-header-title.is-centered {
+    justify-content: center; }
 
 .card-header-icon {
   align-items: center;
   cursor: pointer;
   display: flex;
   justify-content: center;
-  padding: 0.75rem;
-}
+  padding: 0.75rem; }
 
 .card-image {
   display: block;
-  position: relative;
-}
+  position: relative; }
 
 .card-content {
   background-color: transparent;
-  padding: 1.5rem;
-}
+  padding: 1.5rem; }
 
 .card-footer {
   background-color: transparent;
-  border-top: 1px solid hsl(0deg, 0%, 80%);
+  border-top: 1px solid #cccccc;
   align-items: stretch;
-  display: flex;
-}
+  display: flex; }
 
 .card-footer-item {
   align-items: center;
@@ -4568,34 +3572,27 @@ a.tag:hover {
   flex-grow: 1;
   flex-shrink: 0;
   justify-content: center;
-  padding: 0.75rem;
-}
-.card-footer-item:not(:last-child) {
-  border-right: 1px solid hsl(0deg, 0%, 80%);
-}
+  padding: 0.75rem; }
+  .card-footer-item:not(:last-child) {
+    border-right: 1px solid #cccccc; }
 
 .card .media:not(:last-child) {
-  margin-bottom: 0.75rem;
-}
+  margin-bottom: 0.75rem; }
 
 .dropdown {
   display: inline-flex;
   position: relative;
-  vertical-align: top;
-}
-.dropdown.is-active .dropdown-menu, .dropdown.is-hoverable:hover .dropdown-menu {
-  display: block;
-}
-.dropdown.is-right .dropdown-menu {
-  left: auto;
-  right: 0;
-}
-.dropdown.is-up .dropdown-menu {
-  bottom: 100%;
-  padding-bottom: 4px;
-  padding-top: initial;
-  top: auto;
-}
+  vertical-align: top; }
+  .dropdown.is-active .dropdown-menu, .dropdown.is-hoverable:hover .dropdown-menu {
+    display: block; }
+  .dropdown.is-right .dropdown-menu {
+    left: auto;
+    right: 0; }
+  .dropdown.is-up .dropdown-menu {
+    bottom: 100%;
+    padding-bottom: 4px;
+    padding-top: initial;
+    top: auto; }
 
 .dropdown-menu {
   display: none;
@@ -4604,16 +3601,14 @@ a.tag:hover {
   padding-top: 4px;
   position: absolute;
   top: 100%;
-  z-index: 20;
-}
+  z-index: 20; }
 
 .dropdown-content {
-  background-color: hsl(0deg, 0%, 100%);
+  background-color: white;
   border-radius: 4px;
   box-shadow: 0 2px 3px rgba(10, 10, 10, 0.1), 0 0 0 1px rgba(10, 10, 10, 0.1);
   padding-bottom: 0.5rem;
-  padding-top: 0.5rem;
-}
+  padding-top: 0.5rem; }
 
 .dropdown-item {
   color: #333;
@@ -4621,406 +3616,300 @@ a.tag:hover {
   font-size: 0.875rem;
   line-height: 1.5;
   padding: 0.375rem 1rem;
-  position: relative;
-}
+  position: relative; }
 
 a.dropdown-item,
 button.dropdown-item {
   padding-right: 3rem;
   text-align: left;
   white-space: nowrap;
-  width: 100%;
-}
-a.dropdown-item:hover,
-button.dropdown-item:hover {
-  background-color: hsl(0deg, 0%, 96%);
-  color: hsl(0deg, 0%, 4%);
-}
-a.dropdown-item.is-active,
-button.dropdown-item.is-active {
-  background-color: #086db1;
-  color: #fff;
-}
+  width: 100%; }
+  a.dropdown-item:hover,
+  button.dropdown-item:hover {
+    background-color: whitesmoke;
+    color: #0a0a0a; }
+  a.dropdown-item.is-active,
+  button.dropdown-item.is-active {
+    background-color: #1565c0;
+    color: #fff; }
 
 .dropdown-divider {
-  background-color: hsl(0deg, 0%, 80%);
+  background-color: #cccccc;
   border: none;
   display: block;
   height: 1px;
-  margin: 0.5rem 0;
-}
+  margin: 0.5rem 0; }
 
 .level {
   align-items: center;
-  justify-content: space-between;
-}
-.level code {
-  border-radius: 4px;
-}
-.level img {
-  display: inline-block;
-  vertical-align: top;
-}
-.level.is-mobile {
-  display: flex;
-}
-.level.is-mobile .level-left,
-.level.is-mobile .level-right {
-  display: flex;
-}
-.level.is-mobile .level-left + .level-right {
-  margin-top: 0;
-}
-.level.is-mobile .level-item:not(:last-child) {
-  margin-bottom: 0;
-  margin-right: 0.75rem;
-}
-.level.is-mobile .level-item:not(.is-narrow) {
-  flex-grow: 1;
-}
-@media screen and (min-width: 769px), print {
-  .level {
-    display: flex;
-  }
-  .level > .level-item:not(.is-narrow) {
-    flex-grow: 1;
-  }
-}
-
+  justify-content: space-between; }
+  .level code {
+    border-radius: 4px; }
+  .level img {
+    display: inline-block;
+    vertical-align: top; }
+  .level.is-mobile {
+    display: flex; }
+    .level.is-mobile .level-left,
+    .level.is-mobile .level-right {
+      display: flex; }
+    .level.is-mobile .level-left + .level-right {
+      margin-top: 0; }
+    .level.is-mobile .level-item:not(:last-child) {
+      margin-bottom: 0;
+      margin-right: 0.75rem; }
+    .level.is-mobile .level-item:not(.is-narrow) {
+      flex-grow: 1; }
+  @media screen and (min-width: 769px), print {
+    .level {
+      display: flex; }
+      .level > .level-item:not(.is-narrow) {
+        flex-grow: 1; } }
 .level-item {
   align-items: center;
   display: flex;
   flex-basis: auto;
   flex-grow: 0;
   flex-shrink: 0;
-  justify-content: center;
-}
-.level-item .title,
-.level-item .subtitle {
-  margin-bottom: 0;
-}
-@media screen and (max-width: 768px) {
-  .level-item:not(:last-child) {
-    margin-bottom: 0.75rem;
-  }
-}
-
+  justify-content: center; }
+  .level-item .title,
+  .level-item .subtitle {
+    margin-bottom: 0; }
+  @media screen and (max-width: 768px) {
+    .level-item:not(:last-child) {
+      margin-bottom: 0.75rem; } }
 .level-left,
 .level-right {
   flex-basis: auto;
   flex-grow: 0;
-  flex-shrink: 0;
-}
-.level-left .level-item.is-flexible,
-.level-right .level-item.is-flexible {
-  flex-grow: 1;
-}
-@media screen and (min-width: 769px), print {
-  .level-left .level-item:not(:last-child),
-  .level-right .level-item:not(:last-child) {
-    margin-right: 0.75rem;
-  }
-}
-
+  flex-shrink: 0; }
+  .level-left .level-item.is-flexible,
+  .level-right .level-item.is-flexible {
+    flex-grow: 1; }
+  @media screen and (min-width: 769px), print {
+    .level-left .level-item:not(:last-child),
+    .level-right .level-item:not(:last-child) {
+      margin-right: 0.75rem; } }
 .level-left {
   align-items: center;
-  justify-content: flex-start;
-}
-@media screen and (max-width: 768px) {
-  .level-left + .level-right {
-    margin-top: 1.5rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .level-left {
-    display: flex;
-  }
-}
-
+  justify-content: flex-start; }
+  @media screen and (max-width: 768px) {
+    .level-left + .level-right {
+      margin-top: 1.5rem; } }
+  @media screen and (min-width: 769px), print {
+    .level-left {
+      display: flex; } }
 .level-right {
   align-items: center;
-  justify-content: flex-end;
-}
-@media screen and (min-width: 769px), print {
-  .level-right {
-    display: flex;
-  }
-}
-
+  justify-content: flex-end; }
+  @media screen and (min-width: 769px), print {
+    .level-right {
+      display: flex; } }
 .list {
-  background-color: hsl(0deg, 0%, 100%);
+  background-color: white;
   border-radius: 4px;
-  box-shadow: 0 2px 3px rgba(10, 10, 10, 0.1), 0 0 0 1px rgba(10, 10, 10, 0.1);
-}
+  box-shadow: 0 2px 3px rgba(10, 10, 10, 0.1), 0 0 0 1px rgba(10, 10, 10, 0.1); }
 
 .list-item {
   display: block;
-  padding: 0.5em 1em;
-}
-.list-item:not(a) {
-  color: #333;
-}
-.list-item:first-child {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-}
-.list-item:last-child {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-}
-.list-item:not(:last-child) {
-  border-bottom: 1px solid hsl(0deg, 0%, 80%);
-}
-.list-item.is-active {
-  background-color: #086db1;
-  color: #fff;
-}
+  padding: 0.5em 1em; }
+  .list-item:not(a) {
+    color: #333; }
+  .list-item:first-child {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px; }
+  .list-item:last-child {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px; }
+  .list-item:not(:last-child) {
+    border-bottom: 1px solid #cccccc; }
+  .list-item.is-active {
+    background-color: #1565c0;
+    color: #fff; }
 
 a.list-item {
-  background-color: hsl(0deg, 0%, 96%);
-  cursor: pointer;
-}
+  background-color: whitesmoke;
+  cursor: pointer; }
 
 .media {
   align-items: flex-start;
   display: flex;
-  text-align: left;
-}
-.media .content:not(:last-child) {
-  margin-bottom: 0.75rem;
-}
-.media .media {
-  border-top: 1px solid rgba(204, 204, 204, 0.5);
-  display: flex;
-  padding-top: 0.75rem;
-}
-.media .media .content:not(:last-child),
-.media .media .control:not(:last-child) {
-  margin-bottom: 0.5rem;
-}
-.media .media .media {
-  padding-top: 0.5rem;
-}
-.media .media .media + .media {
-  margin-top: 0.5rem;
-}
-.media + .media {
-  border-top: 1px solid rgba(204, 204, 204, 0.5);
-  margin-top: 1rem;
-  padding-top: 1rem;
-}
-.media.is-large + .media {
-  margin-top: 1.5rem;
-  padding-top: 1.5rem;
-}
+  text-align: left; }
+  .media .content:not(:last-child) {
+    margin-bottom: 0.75rem; }
+  .media .media {
+    border-top: 1px solid rgba(204, 204, 204, 0.5);
+    display: flex;
+    padding-top: 0.75rem; }
+    .media .media .content:not(:last-child),
+    .media .media .control:not(:last-child) {
+      margin-bottom: 0.5rem; }
+    .media .media .media {
+      padding-top: 0.5rem; }
+      .media .media .media + .media {
+        margin-top: 0.5rem; }
+  .media + .media {
+    border-top: 1px solid rgba(204, 204, 204, 0.5);
+    margin-top: 1rem;
+    padding-top: 1rem; }
+  .media.is-large + .media {
+    margin-top: 1.5rem;
+    padding-top: 1.5rem; }
 
 .media-left,
 .media-right {
   flex-basis: auto;
   flex-grow: 0;
-  flex-shrink: 0;
-}
+  flex-shrink: 0; }
 
 .media-left {
-  margin-right: 1rem;
-}
+  margin-right: 1rem; }
 
 .media-right {
-  margin-left: 1rem;
-}
+  margin-left: 1rem; }
 
 .media-content {
   flex-basis: auto;
   flex-grow: 1;
   flex-shrink: 1;
-  text-align: left;
-}
+  text-align: left; }
 
 @media screen and (max-width: 768px) {
   .media-content {
-    overflow-x: auto;
-  }
-}
+    overflow-x: auto; } }
+
 .menu {
-  font-size: 1rem;
-}
-.menu.is-small {
-  font-size: 0.85rem;
-}
-.menu.is-medium {
-  font-size: 1.25rem;
-}
-.menu.is-large {
-  font-size: 1.5rem;
-}
+  font-size: 1rem; }
+  .menu.is-small {
+    font-size: 0.85rem; }
+  .menu.is-medium {
+    font-size: 1.25rem; }
+  .menu.is-large {
+    font-size: 1.5rem; }
 
 .menu-list {
-  line-height: 1.25;
-}
-.menu-list a {
-  border-radius: 2px;
-  color: #333;
-  display: block;
-  padding: 0.5em 0.75em;
-}
-.menu-list a:hover {
-  background-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.menu-list a.is-active {
-  background-color: #086db1;
-  color: #fff;
-}
-.menu-list li ul {
-  border-left: 1px solid hsl(0deg, 0%, 80%);
-  margin: 0.75em;
-  padding-left: 0.75em;
-}
+  line-height: 1.25; }
+  .menu-list a {
+    border-radius: 2px;
+    color: #333;
+    display: block;
+    padding: 0.5em 0.75em; }
+    .menu-list a:hover {
+      background-color: whitesmoke;
+      color: #2d2d2d; }
+    .menu-list a.is-active {
+      background-color: #1565c0;
+      color: #fff; }
+  .menu-list li ul {
+    border-left: 1px solid #cccccc;
+    margin: 0.75em;
+    padding-left: 0.75em; }
 
 .menu-label {
   color: #757575;
   font-size: 0.75em;
   letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-.menu-label:not(:first-child) {
-  margin-top: 1em;
-}
-.menu-label:not(:last-child) {
-  margin-bottom: 1em;
-}
+  text-transform: uppercase; }
+  .menu-label:not(:first-child) {
+    margin-top: 1em; }
+  .menu-label:not(:last-child) {
+    margin-bottom: 1em; }
 
 .message {
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   border-radius: 4px;
-  font-size: 1rem;
-}
-.message strong {
-  color: currentColor;
-}
-.message a:not(.button):not(.tag) {
-  color: currentColor;
-  text-decoration: underline;
-}
-.message.is-small {
-  font-size: 0.85rem;
-}
-.message.is-medium {
-  font-size: 1.25rem;
-}
-.message.is-large {
-  font-size: 1.5rem;
-}
-.message.is-white {
-  background-color: white;
-}
-.message.is-white .message-header {
-  background-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 4%);
-}
-.message.is-white .message-body {
-  border-color: hsl(0deg, 0%, 100%);
-  color: #4d4d4d;
-}
-.message.is-black {
-  background-color: #fafafa;
-}
-.message.is-black .message-header {
-  background-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 100%);
-}
-.message.is-black .message-body {
-  border-color: hsl(0deg, 0%, 4%);
-  color: #0a0a0a;
-}
-.message.is-light {
-  background-color: #fafafa;
-}
-.message.is-light .message-header {
-  background-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.message.is-light .message-body {
-  border-color: hsl(0deg, 0%, 96%);
-  color: #4f4f4f;
-}
-.message.is-dark {
-  background-color: #fafafa;
-}
-.message.is-dark .message-header {
-  background-color: #2d2d2d;
-  color: hsl(0deg, 0%, 96%);
-}
-.message.is-dark .message-body {
-  border-color: #2d2d2d;
-  color: #242424;
-}
-.message.is-primary {
-  background-color: #fef6f6;
-}
-.message.is-primary .message-header {
-  background-color: #b31b1b;
-  color: #fff;
-}
-.message.is-primary .message-body {
-  border-color: #b31b1b;
-  color: #881818;
-}
-.message.is-link {
-  background-color: #f5fbff;
-}
-.message.is-link .message-header {
-  background-color: #086db1;
-  color: #fff;
-}
-.message.is-link .message-body {
-  border-color: #086db1;
-  color: #08456e;
-}
-.message.is-info {
-  background-color: #f6fbfe;
-}
-.message.is-info .message-header {
-  background-color: hsl(204deg, 86%, 53%);
-  color: #fff;
-}
-.message.is-info .message-body {
-  border-color: hsl(204deg, 86%, 53%);
-  color: #12537e;
-}
-.message.is-success {
-  background-color: #f5fff6;
-}
-.message.is-success .message-header {
-  background-color: #008412;
-  color: #fff;
-}
-.message.is-success .message-body {
-  border-color: #008412;
-  color: #023709;
-}
-.message.is-warning {
-  background-color: #fffaf5;
-}
-.message.is-warning .message-header {
-  background-color: #b55c06;
-  color: #fff;
-}
-.message.is-warning .message-body {
-  border-color: #b55c06;
-  color: #643507;
-}
-.message.is-danger {
-  background-color: #fff5f5;
-}
-.message.is-danger .message-header {
-  background-color: #cd0200;
-  color: #fff;
-}
-.message.is-danger .message-body {
-  border-color: #cd0200;
-  color: #970503;
-}
+  font-size: 1rem; }
+  .message strong {
+    color: currentColor; }
+  .message a:not(.button):not(.tag) {
+    color: currentColor;
+    text-decoration: underline; }
+  .message.is-small {
+    font-size: 0.85rem; }
+  .message.is-medium {
+    font-size: 1.25rem; }
+  .message.is-large {
+    font-size: 1.5rem; }
+  .message.is-white {
+    background-color: white; }
+    .message.is-white .message-header {
+      background-color: white;
+      color: #0a0a0a; }
+    .message.is-white .message-body {
+      border-color: white;
+      color: #4d4d4d; }
+  .message.is-black {
+    background-color: #fafafa; }
+    .message.is-black .message-header {
+      background-color: #0a0a0a;
+      color: white; }
+    .message.is-black .message-body {
+      border-color: #0a0a0a;
+      color: #090909; }
+  .message.is-light {
+    background-color: #fafafa; }
+    .message.is-light .message-header {
+      background-color: whitesmoke;
+      color: #2d2d2d; }
+    .message.is-light .message-body {
+      border-color: whitesmoke;
+      color: #505050; }
+  .message.is-dark {
+    background-color: #fafafa; }
+    .message.is-dark .message-header {
+      background-color: #2d2d2d;
+      color: whitesmoke; }
+    .message.is-dark .message-body {
+      border-color: #2d2d2d;
+      color: #242424; }
+  .message.is-primary {
+    background-color: #fef6f6; }
+    .message.is-primary .message-header {
+      background-color: #b31b1b;
+      color: #fff; }
+    .message.is-primary .message-body {
+      border-color: #b31b1b;
+      color: #881818; }
+  .message.is-link {
+    background-color: #f6fafe; }
+    .message.is-link .message-header {
+      background-color: #1565c0;
+      color: #fff; }
+    .message.is-link .message-body {
+      border-color: #1565c0;
+      color: #134783; }
+  .message.is-info {
+    background-color: #f6fbfe; }
+    .message.is-info .message-header {
+      background-color: #209cee;
+      color: #fff; }
+    .message.is-info .message-body {
+      border-color: #209cee;
+      color: #12537e; }
+  .message.is-success {
+    background-color: #f5fff6; }
+    .message.is-success .message-header {
+      background-color: #008412;
+      color: #fff; }
+    .message.is-success .message-body {
+      border-color: #008412;
+      color: #023709; }
+  .message.is-warning {
+    background-color: #fffaf5; }
+    .message.is-warning .message-header {
+      background-color: #b55c06;
+      color: #fff; }
+    .message.is-warning .message-body {
+      border-color: #b55c06;
+      color: #643507; }
+  .message.is-danger {
+    background-color: #fff5f5; }
+    .message.is-danger .message-header {
+      background-color: #cd0200;
+      color: #fff; }
+    .message.is-danger .message-body {
+      border-color: #cd0200;
+      color: #970503; }
 
 .message-header {
   align-items: center;
@@ -5032,34 +3921,28 @@ a.list-item {
   justify-content: space-between;
   line-height: 1.25;
   padding: 0.75em 1em;
-  position: relative;
-}
-.message-header .delete {
-  flex-grow: 0;
-  flex-shrink: 0;
-  margin-left: 0.75em;
-}
-.message-header + .message-body {
-  border-width: 1px;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
+  position: relative; }
+  .message-header .delete {
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin-left: 0.75em; }
+  .message-header + .message-body {
+    border-width: 1px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0; }
 
 .message-body {
-  border-color: hsl(0deg, 0%, 80%);
+  border-color: #cccccc;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   color: #333;
-  padding: 1.25em 1.5em;
-}
-.message-body code,
-.message-body pre {
-  background-color: hsl(0deg, 0%, 100%);
-}
-.message-body pre code {
-  background-color: transparent;
-}
+  padding: 1.25em 1.5em; }
+  .message-body code,
+  .message-body pre {
+    background-color: white; }
+  .message-body pre code {
+    background-color: transparent; }
 
 .modal {
   align-items: center;
@@ -5068,15 +3951,12 @@ a.list-item {
   justify-content: center;
   overflow: hidden;
   position: fixed;
-  z-index: 40;
-}
-.modal.is-active {
-  display: flex;
-}
+  z-index: 40; }
+  .modal.is-active {
+    display: flex; }
 
 .modal-background {
-  background-color: rgba(10, 10, 10, 0.86);
-}
+  background-color: rgba(10, 10, 10, 0.86); }
 
 .modal-content,
 .modal-card {
@@ -5084,645 +3964,512 @@ a.list-item {
   max-height: calc(100vh - 160px);
   overflow: auto;
   position: relative;
-  width: 100%;
-}
-@media screen and (min-width: 769px), print {
-  .modal-content,
-  .modal-card {
-    margin: 0 auto;
-    max-height: calc(100vh - 40px);
-    width: 640px;
-  }
-}
-
+  width: 100%; }
+  @media screen and (min-width: 769px), print {
+    .modal-content,
+    .modal-card {
+      margin: 0 auto;
+      max-height: calc(100vh - 40px);
+      width: 640px; } }
 .modal-close {
   background: none;
   height: 40px;
   position: fixed;
   right: 20px;
   top: 20px;
-  width: 40px;
-}
+  width: 40px; }
 
 .modal-card {
   display: flex;
   flex-direction: column;
   max-height: calc(100vh - 40px);
   overflow: hidden;
-  -ms-overflow-y: visible;
-}
+  -ms-overflow-y: visible; }
 
 .modal-card-head,
 .modal-card-foot {
   align-items: center;
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   display: flex;
   flex-shrink: 0;
   justify-content: flex-start;
   padding: 20px;
-  position: relative;
-}
+  position: relative; }
 
 .modal-card-head {
-  border-bottom: 1px solid hsl(0deg, 0%, 80%);
+  border-bottom: 1px solid #cccccc;
   border-top-left-radius: 6px;
-  border-top-right-radius: 6px;
-}
+  border-top-right-radius: 6px; }
 
 .modal-card-title {
   color: #2d2d2d;
   flex-grow: 1;
   flex-shrink: 0;
   font-size: 1.5rem;
-  line-height: 1;
-}
+  line-height: 1; }
 
 .modal-card-foot {
   border-bottom-left-radius: 6px;
   border-bottom-right-radius: 6px;
-  border-top: 1px solid hsl(0deg, 0%, 80%);
-}
-.modal-card-foot .button:not(:last-child) {
-  margin-right: 10px;
-}
+  border-top: 1px solid #cccccc; }
+  .modal-card-foot .button:not(:last-child) {
+    margin-right: 10px; }
 
 .modal-card-body {
   -webkit-overflow-scrolling: touch;
-  background-color: hsl(0deg, 0%, 100%);
+  background-color: white;
   flex-grow: 1;
   flex-shrink: 1;
   overflow: auto;
-  padding: 20px;
-}
+  padding: 20px; }
 
 .navbar {
-  background-color: hsl(0deg, 0%, 100%);
+  background-color: white;
   min-height: 3.25rem;
   position: relative;
-  z-index: 30;
-}
-.navbar.is-white {
-  background-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 4%);
-}
-.navbar.is-white .navbar-brand > .navbar-item,
-.navbar.is-white .navbar-brand .navbar-link {
-  color: hsl(0deg, 0%, 4%);
-}
-.navbar.is-white .navbar-brand > a.navbar-item:hover, .navbar.is-white .navbar-brand > a.navbar-item.is-active,
-.navbar.is-white .navbar-brand .navbar-link:hover,
-.navbar.is-white .navbar-brand .navbar-link.is-active {
-  background-color: #f2f2f2;
-  color: hsl(0deg, 0%, 4%);
-}
-.navbar.is-white .navbar-brand .navbar-link::after {
-  border-color: hsl(0deg, 0%, 4%);
-}
-.navbar.is-white .navbar-burger {
-  color: hsl(0deg, 0%, 4%);
-}
-@media screen and (min-width: 1088px) {
-  .navbar.is-white .navbar-start > .navbar-item,
-  .navbar.is-white .navbar-start .navbar-link,
-  .navbar.is-white .navbar-end > .navbar-item,
-  .navbar.is-white .navbar-end .navbar-link {
-    color: hsl(0deg, 0%, 4%);
-  }
-  .navbar.is-white .navbar-start > a.navbar-item:hover, .navbar.is-white .navbar-start > a.navbar-item.is-active,
-  .navbar.is-white .navbar-start .navbar-link:hover,
-  .navbar.is-white .navbar-start .navbar-link.is-active,
-  .navbar.is-white .navbar-end > a.navbar-item:hover,
-  .navbar.is-white .navbar-end > a.navbar-item.is-active,
-  .navbar.is-white .navbar-end .navbar-link:hover,
-  .navbar.is-white .navbar-end .navbar-link.is-active {
-    background-color: #f2f2f2;
-    color: hsl(0deg, 0%, 4%);
-  }
-  .navbar.is-white .navbar-start .navbar-link::after,
-  .navbar.is-white .navbar-end .navbar-link::after {
-    border-color: hsl(0deg, 0%, 4%);
-  }
-  .navbar.is-white .navbar-item.has-dropdown:hover .navbar-link,
-  .navbar.is-white .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #f2f2f2;
-    color: hsl(0deg, 0%, 4%);
-  }
-  .navbar.is-white .navbar-dropdown a.navbar-item.is-active {
-    background-color: hsl(0deg, 0%, 100%);
-    color: hsl(0deg, 0%, 4%);
-  }
-}
-.navbar.is-black {
-  background-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 100%);
-}
-.navbar.is-black .navbar-brand > .navbar-item,
-.navbar.is-black .navbar-brand .navbar-link {
-  color: hsl(0deg, 0%, 100%);
-}
-.navbar.is-black .navbar-brand > a.navbar-item:hover, .navbar.is-black .navbar-brand > a.navbar-item.is-active,
-.navbar.is-black .navbar-brand .navbar-link:hover,
-.navbar.is-black .navbar-brand .navbar-link.is-active {
-  background-color: black;
-  color: hsl(0deg, 0%, 100%);
-}
-.navbar.is-black .navbar-brand .navbar-link::after {
-  border-color: hsl(0deg, 0%, 100%);
-}
-.navbar.is-black .navbar-burger {
-  color: hsl(0deg, 0%, 100%);
-}
-@media screen and (min-width: 1088px) {
-  .navbar.is-black .navbar-start > .navbar-item,
-  .navbar.is-black .navbar-start .navbar-link,
-  .navbar.is-black .navbar-end > .navbar-item,
-  .navbar.is-black .navbar-end .navbar-link {
-    color: hsl(0deg, 0%, 100%);
-  }
-  .navbar.is-black .navbar-start > a.navbar-item:hover, .navbar.is-black .navbar-start > a.navbar-item.is-active,
-  .navbar.is-black .navbar-start .navbar-link:hover,
-  .navbar.is-black .navbar-start .navbar-link.is-active,
-  .navbar.is-black .navbar-end > a.navbar-item:hover,
-  .navbar.is-black .navbar-end > a.navbar-item.is-active,
-  .navbar.is-black .navbar-end .navbar-link:hover,
-  .navbar.is-black .navbar-end .navbar-link.is-active {
-    background-color: black;
-    color: hsl(0deg, 0%, 100%);
-  }
-  .navbar.is-black .navbar-start .navbar-link::after,
-  .navbar.is-black .navbar-end .navbar-link::after {
-    border-color: hsl(0deg, 0%, 100%);
-  }
-  .navbar.is-black .navbar-item.has-dropdown:hover .navbar-link,
-  .navbar.is-black .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: black;
-    color: hsl(0deg, 0%, 100%);
-  }
-  .navbar.is-black .navbar-dropdown a.navbar-item.is-active {
-    background-color: hsl(0deg, 0%, 4%);
-    color: hsl(0deg, 0%, 100%);
-  }
-}
-.navbar.is-light {
-  background-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.navbar.is-light .navbar-brand > .navbar-item,
-.navbar.is-light .navbar-brand .navbar-link {
-  color: #2d2d2d;
-}
-.navbar.is-light .navbar-brand > a.navbar-item:hover, .navbar.is-light .navbar-brand > a.navbar-item.is-active,
-.navbar.is-light .navbar-brand .navbar-link:hover,
-.navbar.is-light .navbar-brand .navbar-link.is-active {
-  background-color: #e8e8e8;
-  color: #2d2d2d;
-}
-.navbar.is-light .navbar-brand .navbar-link::after {
-  border-color: #2d2d2d;
-}
-.navbar.is-light .navbar-burger {
-  color: #2d2d2d;
-}
-@media screen and (min-width: 1088px) {
-  .navbar.is-light .navbar-start > .navbar-item,
-  .navbar.is-light .navbar-start .navbar-link,
-  .navbar.is-light .navbar-end > .navbar-item,
-  .navbar.is-light .navbar-end .navbar-link {
-    color: #2d2d2d;
-  }
-  .navbar.is-light .navbar-start > a.navbar-item:hover, .navbar.is-light .navbar-start > a.navbar-item.is-active,
-  .navbar.is-light .navbar-start .navbar-link:hover,
-  .navbar.is-light .navbar-start .navbar-link.is-active,
-  .navbar.is-light .navbar-end > a.navbar-item:hover,
-  .navbar.is-light .navbar-end > a.navbar-item.is-active,
-  .navbar.is-light .navbar-end .navbar-link:hover,
-  .navbar.is-light .navbar-end .navbar-link.is-active {
-    background-color: #e8e8e8;
-    color: #2d2d2d;
-  }
-  .navbar.is-light .navbar-start .navbar-link::after,
-  .navbar.is-light .navbar-end .navbar-link::after {
-    border-color: #2d2d2d;
-  }
-  .navbar.is-light .navbar-item.has-dropdown:hover .navbar-link,
-  .navbar.is-light .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #e8e8e8;
-    color: #2d2d2d;
-  }
-  .navbar.is-light .navbar-dropdown a.navbar-item.is-active {
-    background-color: hsl(0deg, 0%, 96%);
-    color: #2d2d2d;
-  }
-}
-.navbar.is-dark {
-  background-color: #2d2d2d;
-  color: hsl(0deg, 0%, 96%);
-}
-.navbar.is-dark .navbar-brand > .navbar-item,
-.navbar.is-dark .navbar-brand .navbar-link {
-  color: hsl(0deg, 0%, 96%);
-}
-.navbar.is-dark .navbar-brand > a.navbar-item:hover, .navbar.is-dark .navbar-brand > a.navbar-item.is-active,
-.navbar.is-dark .navbar-brand .navbar-link:hover,
-.navbar.is-dark .navbar-brand .navbar-link.is-active {
-  background-color: #202020;
-  color: hsl(0deg, 0%, 96%);
-}
-.navbar.is-dark .navbar-brand .navbar-link::after {
-  border-color: hsl(0deg, 0%, 96%);
-}
-.navbar.is-dark .navbar-burger {
-  color: hsl(0deg, 0%, 96%);
-}
-@media screen and (min-width: 1088px) {
-  .navbar.is-dark .navbar-start > .navbar-item,
-  .navbar.is-dark .navbar-start .navbar-link,
-  .navbar.is-dark .navbar-end > .navbar-item,
-  .navbar.is-dark .navbar-end .navbar-link {
-    color: hsl(0deg, 0%, 96%);
-  }
-  .navbar.is-dark .navbar-start > a.navbar-item:hover, .navbar.is-dark .navbar-start > a.navbar-item.is-active,
-  .navbar.is-dark .navbar-start .navbar-link:hover,
-  .navbar.is-dark .navbar-start .navbar-link.is-active,
-  .navbar.is-dark .navbar-end > a.navbar-item:hover,
-  .navbar.is-dark .navbar-end > a.navbar-item.is-active,
-  .navbar.is-dark .navbar-end .navbar-link:hover,
-  .navbar.is-dark .navbar-end .navbar-link.is-active {
-    background-color: #202020;
-    color: hsl(0deg, 0%, 96%);
-  }
-  .navbar.is-dark .navbar-start .navbar-link::after,
-  .navbar.is-dark .navbar-end .navbar-link::after {
-    border-color: hsl(0deg, 0%, 96%);
-  }
-  .navbar.is-dark .navbar-item.has-dropdown:hover .navbar-link,
-  .navbar.is-dark .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #202020;
-    color: hsl(0deg, 0%, 96%);
-  }
-  .navbar.is-dark .navbar-dropdown a.navbar-item.is-active {
+  z-index: 30; }
+  .navbar.is-white {
+    background-color: white;
+    color: #0a0a0a; }
+    .navbar.is-white .navbar-brand > .navbar-item,
+    .navbar.is-white .navbar-brand .navbar-link {
+      color: #0a0a0a; }
+    .navbar.is-white .navbar-brand > a.navbar-item:hover, .navbar.is-white .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-white .navbar-brand .navbar-link:hover,
+    .navbar.is-white .navbar-brand .navbar-link.is-active {
+      background-color: #f2f2f2;
+      color: #0a0a0a; }
+    .navbar.is-white .navbar-brand .navbar-link::after {
+      border-color: #0a0a0a; }
+    .navbar.is-white .navbar-burger {
+      color: #0a0a0a; }
+    @media screen and (min-width: 1088px) {
+      .navbar.is-white .navbar-start > .navbar-item,
+      .navbar.is-white .navbar-start .navbar-link,
+      .navbar.is-white .navbar-end > .navbar-item,
+      .navbar.is-white .navbar-end .navbar-link {
+        color: #0a0a0a; }
+      .navbar.is-white .navbar-start > a.navbar-item:hover, .navbar.is-white .navbar-start > a.navbar-item.is-active,
+      .navbar.is-white .navbar-start .navbar-link:hover,
+      .navbar.is-white .navbar-start .navbar-link.is-active,
+      .navbar.is-white .navbar-end > a.navbar-item:hover,
+      .navbar.is-white .navbar-end > a.navbar-item.is-active,
+      .navbar.is-white .navbar-end .navbar-link:hover,
+      .navbar.is-white .navbar-end .navbar-link.is-active {
+        background-color: #f2f2f2;
+        color: #0a0a0a; }
+      .navbar.is-white .navbar-start .navbar-link::after,
+      .navbar.is-white .navbar-end .navbar-link::after {
+        border-color: #0a0a0a; }
+      .navbar.is-white .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-white .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #f2f2f2;
+        color: #0a0a0a; }
+      .navbar.is-white .navbar-dropdown a.navbar-item.is-active {
+        background-color: white;
+        color: #0a0a0a; } }
+  .navbar.is-black {
+    background-color: #0a0a0a;
+    color: white; }
+    .navbar.is-black .navbar-brand > .navbar-item,
+    .navbar.is-black .navbar-brand .navbar-link {
+      color: white; }
+    .navbar.is-black .navbar-brand > a.navbar-item:hover, .navbar.is-black .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-black .navbar-brand .navbar-link:hover,
+    .navbar.is-black .navbar-brand .navbar-link.is-active {
+      background-color: black;
+      color: white; }
+    .navbar.is-black .navbar-brand .navbar-link::after {
+      border-color: white; }
+    .navbar.is-black .navbar-burger {
+      color: white; }
+    @media screen and (min-width: 1088px) {
+      .navbar.is-black .navbar-start > .navbar-item,
+      .navbar.is-black .navbar-start .navbar-link,
+      .navbar.is-black .navbar-end > .navbar-item,
+      .navbar.is-black .navbar-end .navbar-link {
+        color: white; }
+      .navbar.is-black .navbar-start > a.navbar-item:hover, .navbar.is-black .navbar-start > a.navbar-item.is-active,
+      .navbar.is-black .navbar-start .navbar-link:hover,
+      .navbar.is-black .navbar-start .navbar-link.is-active,
+      .navbar.is-black .navbar-end > a.navbar-item:hover,
+      .navbar.is-black .navbar-end > a.navbar-item.is-active,
+      .navbar.is-black .navbar-end .navbar-link:hover,
+      .navbar.is-black .navbar-end .navbar-link.is-active {
+        background-color: black;
+        color: white; }
+      .navbar.is-black .navbar-start .navbar-link::after,
+      .navbar.is-black .navbar-end .navbar-link::after {
+        border-color: white; }
+      .navbar.is-black .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-black .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: black;
+        color: white; }
+      .navbar.is-black .navbar-dropdown a.navbar-item.is-active {
+        background-color: #0a0a0a;
+        color: white; } }
+  .navbar.is-light {
+    background-color: whitesmoke;
+    color: #2d2d2d; }
+    .navbar.is-light .navbar-brand > .navbar-item,
+    .navbar.is-light .navbar-brand .navbar-link {
+      color: #2d2d2d; }
+    .navbar.is-light .navbar-brand > a.navbar-item:hover, .navbar.is-light .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-light .navbar-brand .navbar-link:hover,
+    .navbar.is-light .navbar-brand .navbar-link.is-active {
+      background-color: #e8e8e8;
+      color: #2d2d2d; }
+    .navbar.is-light .navbar-brand .navbar-link::after {
+      border-color: #2d2d2d; }
+    .navbar.is-light .navbar-burger {
+      color: #2d2d2d; }
+    @media screen and (min-width: 1088px) {
+      .navbar.is-light .navbar-start > .navbar-item,
+      .navbar.is-light .navbar-start .navbar-link,
+      .navbar.is-light .navbar-end > .navbar-item,
+      .navbar.is-light .navbar-end .navbar-link {
+        color: #2d2d2d; }
+      .navbar.is-light .navbar-start > a.navbar-item:hover, .navbar.is-light .navbar-start > a.navbar-item.is-active,
+      .navbar.is-light .navbar-start .navbar-link:hover,
+      .navbar.is-light .navbar-start .navbar-link.is-active,
+      .navbar.is-light .navbar-end > a.navbar-item:hover,
+      .navbar.is-light .navbar-end > a.navbar-item.is-active,
+      .navbar.is-light .navbar-end .navbar-link:hover,
+      .navbar.is-light .navbar-end .navbar-link.is-active {
+        background-color: #e8e8e8;
+        color: #2d2d2d; }
+      .navbar.is-light .navbar-start .navbar-link::after,
+      .navbar.is-light .navbar-end .navbar-link::after {
+        border-color: #2d2d2d; }
+      .navbar.is-light .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-light .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #e8e8e8;
+        color: #2d2d2d; }
+      .navbar.is-light .navbar-dropdown a.navbar-item.is-active {
+        background-color: whitesmoke;
+        color: #2d2d2d; } }
+  .navbar.is-dark {
     background-color: #2d2d2d;
-    color: hsl(0deg, 0%, 96%);
-  }
-}
-.navbar.is-primary {
-  background-color: #b31b1b;
-  color: #fff;
-}
-.navbar.is-primary .navbar-brand > .navbar-item,
-.navbar.is-primary .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-primary .navbar-brand > a.navbar-item:hover, .navbar.is-primary .navbar-brand > a.navbar-item.is-active,
-.navbar.is-primary .navbar-brand .navbar-link:hover,
-.navbar.is-primary .navbar-brand .navbar-link.is-active {
-  background-color: #9d1818;
-  color: #fff;
-}
-.navbar.is-primary .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-primary .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1088px) {
-  .navbar.is-primary .navbar-start > .navbar-item,
-  .navbar.is-primary .navbar-start .navbar-link,
-  .navbar.is-primary .navbar-end > .navbar-item,
-  .navbar.is-primary .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-primary .navbar-start > a.navbar-item:hover, .navbar.is-primary .navbar-start > a.navbar-item.is-active,
-  .navbar.is-primary .navbar-start .navbar-link:hover,
-  .navbar.is-primary .navbar-start .navbar-link.is-active,
-  .navbar.is-primary .navbar-end > a.navbar-item:hover,
-  .navbar.is-primary .navbar-end > a.navbar-item.is-active,
-  .navbar.is-primary .navbar-end .navbar-link:hover,
-  .navbar.is-primary .navbar-end .navbar-link.is-active {
-    background-color: #9d1818;
-    color: #fff;
-  }
-  .navbar.is-primary .navbar-start .navbar-link::after,
-  .navbar.is-primary .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-primary .navbar-item.has-dropdown:hover .navbar-link,
-  .navbar.is-primary .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #9d1818;
-    color: #fff;
-  }
-  .navbar.is-primary .navbar-dropdown a.navbar-item.is-active {
+    color: whitesmoke; }
+    .navbar.is-dark .navbar-brand > .navbar-item,
+    .navbar.is-dark .navbar-brand .navbar-link {
+      color: whitesmoke; }
+    .navbar.is-dark .navbar-brand > a.navbar-item:hover, .navbar.is-dark .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-dark .navbar-brand .navbar-link:hover,
+    .navbar.is-dark .navbar-brand .navbar-link.is-active {
+      background-color: #202020;
+      color: whitesmoke; }
+    .navbar.is-dark .navbar-brand .navbar-link::after {
+      border-color: whitesmoke; }
+    .navbar.is-dark .navbar-burger {
+      color: whitesmoke; }
+    @media screen and (min-width: 1088px) {
+      .navbar.is-dark .navbar-start > .navbar-item,
+      .navbar.is-dark .navbar-start .navbar-link,
+      .navbar.is-dark .navbar-end > .navbar-item,
+      .navbar.is-dark .navbar-end .navbar-link {
+        color: whitesmoke; }
+      .navbar.is-dark .navbar-start > a.navbar-item:hover, .navbar.is-dark .navbar-start > a.navbar-item.is-active,
+      .navbar.is-dark .navbar-start .navbar-link:hover,
+      .navbar.is-dark .navbar-start .navbar-link.is-active,
+      .navbar.is-dark .navbar-end > a.navbar-item:hover,
+      .navbar.is-dark .navbar-end > a.navbar-item.is-active,
+      .navbar.is-dark .navbar-end .navbar-link:hover,
+      .navbar.is-dark .navbar-end .navbar-link.is-active {
+        background-color: #202020;
+        color: whitesmoke; }
+      .navbar.is-dark .navbar-start .navbar-link::after,
+      .navbar.is-dark .navbar-end .navbar-link::after {
+        border-color: whitesmoke; }
+      .navbar.is-dark .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-dark .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #202020;
+        color: whitesmoke; }
+      .navbar.is-dark .navbar-dropdown a.navbar-item.is-active {
+        background-color: #2d2d2d;
+        color: whitesmoke; } }
+  .navbar.is-primary {
     background-color: #b31b1b;
-    color: #fff;
-  }
-}
-.navbar.is-link {
-  background-color: #086db1;
-  color: #fff;
-}
-.navbar.is-link .navbar-brand > .navbar-item,
-.navbar.is-link .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-link .navbar-brand > a.navbar-item:hover, .navbar.is-link .navbar-brand > a.navbar-item.is-active,
-.navbar.is-link .navbar-brand .navbar-link:hover,
-.navbar.is-link .navbar-brand .navbar-link.is-active {
-  background-color: #075e99;
-  color: #fff;
-}
-.navbar.is-link .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-link .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1088px) {
-  .navbar.is-link .navbar-start > .navbar-item,
-  .navbar.is-link .navbar-start .navbar-link,
-  .navbar.is-link .navbar-end > .navbar-item,
-  .navbar.is-link .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-link .navbar-start > a.navbar-item:hover, .navbar.is-link .navbar-start > a.navbar-item.is-active,
-  .navbar.is-link .navbar-start .navbar-link:hover,
-  .navbar.is-link .navbar-start .navbar-link.is-active,
-  .navbar.is-link .navbar-end > a.navbar-item:hover,
-  .navbar.is-link .navbar-end > a.navbar-item.is-active,
-  .navbar.is-link .navbar-end .navbar-link:hover,
-  .navbar.is-link .navbar-end .navbar-link.is-active {
-    background-color: #075e99;
-    color: #fff;
-  }
-  .navbar.is-link .navbar-start .navbar-link::after,
-  .navbar.is-link .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-link .navbar-item.has-dropdown:hover .navbar-link,
-  .navbar.is-link .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #075e99;
-    color: #fff;
-  }
-  .navbar.is-link .navbar-dropdown a.navbar-item.is-active {
-    background-color: #086db1;
-    color: #fff;
-  }
-}
-.navbar.is-info {
-  background-color: hsl(204deg, 86%, 53%);
-  color: #fff;
-}
-.navbar.is-info .navbar-brand > .navbar-item,
-.navbar.is-info .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-info .navbar-brand > a.navbar-item:hover, .navbar.is-info .navbar-brand > a.navbar-item.is-active,
-.navbar.is-info .navbar-brand .navbar-link:hover,
-.navbar.is-info .navbar-brand .navbar-link.is-active {
-  background-color: #118fe4;
-  color: #fff;
-}
-.navbar.is-info .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-info .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1088px) {
-  .navbar.is-info .navbar-start > .navbar-item,
-  .navbar.is-info .navbar-start .navbar-link,
-  .navbar.is-info .navbar-end > .navbar-item,
-  .navbar.is-info .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-info .navbar-start > a.navbar-item:hover, .navbar.is-info .navbar-start > a.navbar-item.is-active,
-  .navbar.is-info .navbar-start .navbar-link:hover,
-  .navbar.is-info .navbar-start .navbar-link.is-active,
-  .navbar.is-info .navbar-end > a.navbar-item:hover,
-  .navbar.is-info .navbar-end > a.navbar-item.is-active,
-  .navbar.is-info .navbar-end .navbar-link:hover,
-  .navbar.is-info .navbar-end .navbar-link.is-active {
-    background-color: #118fe4;
-    color: #fff;
-  }
-  .navbar.is-info .navbar-start .navbar-link::after,
-  .navbar.is-info .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-info .navbar-item.has-dropdown:hover .navbar-link,
-  .navbar.is-info .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #118fe4;
-    color: #fff;
-  }
-  .navbar.is-info .navbar-dropdown a.navbar-item.is-active {
-    background-color: hsl(204deg, 86%, 53%);
-    color: #fff;
-  }
-}
-.navbar.is-success {
-  background-color: #008412;
-  color: #fff;
-}
-.navbar.is-success .navbar-brand > .navbar-item,
-.navbar.is-success .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-success .navbar-brand > a.navbar-item:hover, .navbar.is-success .navbar-brand > a.navbar-item.is-active,
-.navbar.is-success .navbar-brand .navbar-link:hover,
-.navbar.is-success .navbar-brand .navbar-link.is-active {
-  background-color: #006b0f;
-  color: #fff;
-}
-.navbar.is-success .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-success .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1088px) {
-  .navbar.is-success .navbar-start > .navbar-item,
-  .navbar.is-success .navbar-start .navbar-link,
-  .navbar.is-success .navbar-end > .navbar-item,
-  .navbar.is-success .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-success .navbar-start > a.navbar-item:hover, .navbar.is-success .navbar-start > a.navbar-item.is-active,
-  .navbar.is-success .navbar-start .navbar-link:hover,
-  .navbar.is-success .navbar-start .navbar-link.is-active,
-  .navbar.is-success .navbar-end > a.navbar-item:hover,
-  .navbar.is-success .navbar-end > a.navbar-item.is-active,
-  .navbar.is-success .navbar-end .navbar-link:hover,
-  .navbar.is-success .navbar-end .navbar-link.is-active {
-    background-color: #006b0f;
-    color: #fff;
-  }
-  .navbar.is-success .navbar-start .navbar-link::after,
-  .navbar.is-success .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-success .navbar-item.has-dropdown:hover .navbar-link,
-  .navbar.is-success .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #006b0f;
-    color: #fff;
-  }
-  .navbar.is-success .navbar-dropdown a.navbar-item.is-active {
+    color: #fff; }
+    .navbar.is-primary .navbar-brand > .navbar-item,
+    .navbar.is-primary .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-primary .navbar-brand > a.navbar-item:hover, .navbar.is-primary .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-primary .navbar-brand .navbar-link:hover,
+    .navbar.is-primary .navbar-brand .navbar-link.is-active {
+      background-color: #9d1818;
+      color: #fff; }
+    .navbar.is-primary .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-primary .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1088px) {
+      .navbar.is-primary .navbar-start > .navbar-item,
+      .navbar.is-primary .navbar-start .navbar-link,
+      .navbar.is-primary .navbar-end > .navbar-item,
+      .navbar.is-primary .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-primary .navbar-start > a.navbar-item:hover, .navbar.is-primary .navbar-start > a.navbar-item.is-active,
+      .navbar.is-primary .navbar-start .navbar-link:hover,
+      .navbar.is-primary .navbar-start .navbar-link.is-active,
+      .navbar.is-primary .navbar-end > a.navbar-item:hover,
+      .navbar.is-primary .navbar-end > a.navbar-item.is-active,
+      .navbar.is-primary .navbar-end .navbar-link:hover,
+      .navbar.is-primary .navbar-end .navbar-link.is-active {
+        background-color: #9d1818;
+        color: #fff; }
+      .navbar.is-primary .navbar-start .navbar-link::after,
+      .navbar.is-primary .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-primary .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-primary .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #9d1818;
+        color: #fff; }
+      .navbar.is-primary .navbar-dropdown a.navbar-item.is-active {
+        background-color: #b31b1b;
+        color: #fff; } }
+  .navbar.is-link {
+    background-color: #1565c0;
+    color: #fff; }
+    .navbar.is-link .navbar-brand > .navbar-item,
+    .navbar.is-link .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-link .navbar-brand > a.navbar-item:hover, .navbar.is-link .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-link .navbar-brand .navbar-link:hover,
+    .navbar.is-link .navbar-brand .navbar-link.is-active {
+      background-color: #1259a9;
+      color: #fff; }
+    .navbar.is-link .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-link .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1088px) {
+      .navbar.is-link .navbar-start > .navbar-item,
+      .navbar.is-link .navbar-start .navbar-link,
+      .navbar.is-link .navbar-end > .navbar-item,
+      .navbar.is-link .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-link .navbar-start > a.navbar-item:hover, .navbar.is-link .navbar-start > a.navbar-item.is-active,
+      .navbar.is-link .navbar-start .navbar-link:hover,
+      .navbar.is-link .navbar-start .navbar-link.is-active,
+      .navbar.is-link .navbar-end > a.navbar-item:hover,
+      .navbar.is-link .navbar-end > a.navbar-item.is-active,
+      .navbar.is-link .navbar-end .navbar-link:hover,
+      .navbar.is-link .navbar-end .navbar-link.is-active {
+        background-color: #1259a9;
+        color: #fff; }
+      .navbar.is-link .navbar-start .navbar-link::after,
+      .navbar.is-link .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-link .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-link .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #1259a9;
+        color: #fff; }
+      .navbar.is-link .navbar-dropdown a.navbar-item.is-active {
+        background-color: #1565c0;
+        color: #fff; } }
+  .navbar.is-info {
+    background-color: #209cee;
+    color: #fff; }
+    .navbar.is-info .navbar-brand > .navbar-item,
+    .navbar.is-info .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-info .navbar-brand > a.navbar-item:hover, .navbar.is-info .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-info .navbar-brand .navbar-link:hover,
+    .navbar.is-info .navbar-brand .navbar-link.is-active {
+      background-color: #118fe4;
+      color: #fff; }
+    .navbar.is-info .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-info .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1088px) {
+      .navbar.is-info .navbar-start > .navbar-item,
+      .navbar.is-info .navbar-start .navbar-link,
+      .navbar.is-info .navbar-end > .navbar-item,
+      .navbar.is-info .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-info .navbar-start > a.navbar-item:hover, .navbar.is-info .navbar-start > a.navbar-item.is-active,
+      .navbar.is-info .navbar-start .navbar-link:hover,
+      .navbar.is-info .navbar-start .navbar-link.is-active,
+      .navbar.is-info .navbar-end > a.navbar-item:hover,
+      .navbar.is-info .navbar-end > a.navbar-item.is-active,
+      .navbar.is-info .navbar-end .navbar-link:hover,
+      .navbar.is-info .navbar-end .navbar-link.is-active {
+        background-color: #118fe4;
+        color: #fff; }
+      .navbar.is-info .navbar-start .navbar-link::after,
+      .navbar.is-info .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-info .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-info .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #118fe4;
+        color: #fff; }
+      .navbar.is-info .navbar-dropdown a.navbar-item.is-active {
+        background-color: #209cee;
+        color: #fff; } }
+  .navbar.is-success {
     background-color: #008412;
-    color: #fff;
-  }
-}
-.navbar.is-warning {
-  background-color: #b55c06;
-  color: #fff;
-}
-.navbar.is-warning .navbar-brand > .navbar-item,
-.navbar.is-warning .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-warning .navbar-brand > a.navbar-item:hover, .navbar.is-warning .navbar-brand > a.navbar-item.is-active,
-.navbar.is-warning .navbar-brand .navbar-link:hover,
-.navbar.is-warning .navbar-brand .navbar-link.is-active {
-  background-color: #9c4f05;
-  color: #fff;
-}
-.navbar.is-warning .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-warning .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1088px) {
-  .navbar.is-warning .navbar-start > .navbar-item,
-  .navbar.is-warning .navbar-start .navbar-link,
-  .navbar.is-warning .navbar-end > .navbar-item,
-  .navbar.is-warning .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-warning .navbar-start > a.navbar-item:hover, .navbar.is-warning .navbar-start > a.navbar-item.is-active,
-  .navbar.is-warning .navbar-start .navbar-link:hover,
-  .navbar.is-warning .navbar-start .navbar-link.is-active,
-  .navbar.is-warning .navbar-end > a.navbar-item:hover,
-  .navbar.is-warning .navbar-end > a.navbar-item.is-active,
-  .navbar.is-warning .navbar-end .navbar-link:hover,
-  .navbar.is-warning .navbar-end .navbar-link.is-active {
-    background-color: #9c4f05;
-    color: #fff;
-  }
-  .navbar.is-warning .navbar-start .navbar-link::after,
-  .navbar.is-warning .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-warning .navbar-item.has-dropdown:hover .navbar-link,
-  .navbar.is-warning .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #9c4f05;
-    color: #fff;
-  }
-  .navbar.is-warning .navbar-dropdown a.navbar-item.is-active {
+    color: #fff; }
+    .navbar.is-success .navbar-brand > .navbar-item,
+    .navbar.is-success .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-success .navbar-brand > a.navbar-item:hover, .navbar.is-success .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-success .navbar-brand .navbar-link:hover,
+    .navbar.is-success .navbar-brand .navbar-link.is-active {
+      background-color: #006b0f;
+      color: #fff; }
+    .navbar.is-success .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-success .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1088px) {
+      .navbar.is-success .navbar-start > .navbar-item,
+      .navbar.is-success .navbar-start .navbar-link,
+      .navbar.is-success .navbar-end > .navbar-item,
+      .navbar.is-success .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-success .navbar-start > a.navbar-item:hover, .navbar.is-success .navbar-start > a.navbar-item.is-active,
+      .navbar.is-success .navbar-start .navbar-link:hover,
+      .navbar.is-success .navbar-start .navbar-link.is-active,
+      .navbar.is-success .navbar-end > a.navbar-item:hover,
+      .navbar.is-success .navbar-end > a.navbar-item.is-active,
+      .navbar.is-success .navbar-end .navbar-link:hover,
+      .navbar.is-success .navbar-end .navbar-link.is-active {
+        background-color: #006b0f;
+        color: #fff; }
+      .navbar.is-success .navbar-start .navbar-link::after,
+      .navbar.is-success .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-success .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-success .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #006b0f;
+        color: #fff; }
+      .navbar.is-success .navbar-dropdown a.navbar-item.is-active {
+        background-color: #008412;
+        color: #fff; } }
+  .navbar.is-warning {
     background-color: #b55c06;
-    color: #fff;
-  }
-}
-.navbar.is-danger {
-  background-color: #cd0200;
-  color: #fff;
-}
-.navbar.is-danger .navbar-brand > .navbar-item,
-.navbar.is-danger .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-danger .navbar-brand > a.navbar-item:hover, .navbar.is-danger .navbar-brand > a.navbar-item.is-active,
-.navbar.is-danger .navbar-brand .navbar-link:hover,
-.navbar.is-danger .navbar-brand .navbar-link.is-active {
-  background-color: #b40200;
-  color: #fff;
-}
-.navbar.is-danger .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-danger .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1088px) {
-  .navbar.is-danger .navbar-start > .navbar-item,
-  .navbar.is-danger .navbar-start .navbar-link,
-  .navbar.is-danger .navbar-end > .navbar-item,
-  .navbar.is-danger .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-danger .navbar-start > a.navbar-item:hover, .navbar.is-danger .navbar-start > a.navbar-item.is-active,
-  .navbar.is-danger .navbar-start .navbar-link:hover,
-  .navbar.is-danger .navbar-start .navbar-link.is-active,
-  .navbar.is-danger .navbar-end > a.navbar-item:hover,
-  .navbar.is-danger .navbar-end > a.navbar-item.is-active,
-  .navbar.is-danger .navbar-end .navbar-link:hover,
-  .navbar.is-danger .navbar-end .navbar-link.is-active {
-    background-color: #b40200;
-    color: #fff;
-  }
-  .navbar.is-danger .navbar-start .navbar-link::after,
-  .navbar.is-danger .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-danger .navbar-item.has-dropdown:hover .navbar-link,
-  .navbar.is-danger .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #b40200;
-    color: #fff;
-  }
-  .navbar.is-danger .navbar-dropdown a.navbar-item.is-active {
+    color: #fff; }
+    .navbar.is-warning .navbar-brand > .navbar-item,
+    .navbar.is-warning .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-warning .navbar-brand > a.navbar-item:hover, .navbar.is-warning .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-warning .navbar-brand .navbar-link:hover,
+    .navbar.is-warning .navbar-brand .navbar-link.is-active {
+      background-color: #9c4f05;
+      color: #fff; }
+    .navbar.is-warning .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-warning .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1088px) {
+      .navbar.is-warning .navbar-start > .navbar-item,
+      .navbar.is-warning .navbar-start .navbar-link,
+      .navbar.is-warning .navbar-end > .navbar-item,
+      .navbar.is-warning .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-warning .navbar-start > a.navbar-item:hover, .navbar.is-warning .navbar-start > a.navbar-item.is-active,
+      .navbar.is-warning .navbar-start .navbar-link:hover,
+      .navbar.is-warning .navbar-start .navbar-link.is-active,
+      .navbar.is-warning .navbar-end > a.navbar-item:hover,
+      .navbar.is-warning .navbar-end > a.navbar-item.is-active,
+      .navbar.is-warning .navbar-end .navbar-link:hover,
+      .navbar.is-warning .navbar-end .navbar-link.is-active {
+        background-color: #9c4f05;
+        color: #fff; }
+      .navbar.is-warning .navbar-start .navbar-link::after,
+      .navbar.is-warning .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-warning .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-warning .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #9c4f05;
+        color: #fff; }
+      .navbar.is-warning .navbar-dropdown a.navbar-item.is-active {
+        background-color: #b55c06;
+        color: #fff; } }
+  .navbar.is-danger {
     background-color: #cd0200;
-    color: #fff;
-  }
-}
-.navbar > .container {
-  align-items: stretch;
-  display: flex;
-  min-height: 3.25rem;
-  width: 100%;
-}
-.navbar.has-shadow {
-  box-shadow: 0 2px 0 0 hsl(0deg, 0%, 96%);
-}
-.navbar.is-fixed-bottom, .navbar.is-fixed-top {
-  left: 0;
-  position: fixed;
-  right: 0;
-  z-index: 30;
-}
-.navbar.is-fixed-bottom {
-  bottom: 0;
-}
-.navbar.is-fixed-bottom.has-shadow {
-  box-shadow: 0 -2px 0 0 hsl(0deg, 0%, 96%);
-}
-.navbar.is-fixed-top {
-  top: 0;
-}
+    color: #fff; }
+    .navbar.is-danger .navbar-brand > .navbar-item,
+    .navbar.is-danger .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-danger .navbar-brand > a.navbar-item:hover, .navbar.is-danger .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-danger .navbar-brand .navbar-link:hover,
+    .navbar.is-danger .navbar-brand .navbar-link.is-active {
+      background-color: #b40200;
+      color: #fff; }
+    .navbar.is-danger .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-danger .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1088px) {
+      .navbar.is-danger .navbar-start > .navbar-item,
+      .navbar.is-danger .navbar-start .navbar-link,
+      .navbar.is-danger .navbar-end > .navbar-item,
+      .navbar.is-danger .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-danger .navbar-start > a.navbar-item:hover, .navbar.is-danger .navbar-start > a.navbar-item.is-active,
+      .navbar.is-danger .navbar-start .navbar-link:hover,
+      .navbar.is-danger .navbar-start .navbar-link.is-active,
+      .navbar.is-danger .navbar-end > a.navbar-item:hover,
+      .navbar.is-danger .navbar-end > a.navbar-item.is-active,
+      .navbar.is-danger .navbar-end .navbar-link:hover,
+      .navbar.is-danger .navbar-end .navbar-link.is-active {
+        background-color: #b40200;
+        color: #fff; }
+      .navbar.is-danger .navbar-start .navbar-link::after,
+      .navbar.is-danger .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-danger .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-danger .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #b40200;
+        color: #fff; }
+      .navbar.is-danger .navbar-dropdown a.navbar-item.is-active {
+        background-color: #cd0200;
+        color: #fff; } }
+  .navbar > .container {
+    align-items: stretch;
+    display: flex;
+    min-height: 3.25rem;
+    width: 100%; }
+  .navbar.has-shadow {
+    box-shadow: 0 2px 0 0 whitesmoke; }
+  .navbar.is-fixed-bottom, .navbar.is-fixed-top {
+    left: 0;
+    position: fixed;
+    right: 0;
+    z-index: 30; }
+  .navbar.is-fixed-bottom {
+    bottom: 0; }
+    .navbar.is-fixed-bottom.has-shadow {
+      box-shadow: 0 -2px 0 0 whitesmoke; }
+  .navbar.is-fixed-top {
+    top: 0; }
 
 html.has-navbar-fixed-top,
 body.has-navbar-fixed-top {
-  padding-top: 3.25rem;
-}
+  padding-top: 3.25rem; }
+
 html.has-navbar-fixed-bottom,
 body.has-navbar-fixed-bottom {
-  padding-bottom: 3.25rem;
-}
+  padding-bottom: 3.25rem; }
 
 .navbar-brand,
 .navbar-tabs {
   align-items: stretch;
   display: flex;
   flex-shrink: 0;
-  min-height: 3.25rem;
-}
+  min-height: 3.25rem; }
 
 .navbar-brand a.navbar-item:hover {
-  background-color: transparent;
-}
+  background-color: transparent; }
 
 .navbar-tabs {
   -webkit-overflow-scrolling: touch;
   max-width: 100vw;
   overflow-x: auto;
-  overflow-y: hidden;
-}
+  overflow-y: hidden; }
 
 .navbar-burger {
   color: #333;
@@ -5731,45 +4478,35 @@ body.has-navbar-fixed-bottom {
   height: 3.25rem;
   position: relative;
   width: 3.25rem;
-  margin-left: auto;
-}
-.navbar-burger span {
-  background-color: currentColor;
-  display: block;
-  height: 1px;
-  left: calc(50% - 8px);
-  position: absolute;
-  transform-origin: center;
-  transition-duration: 86ms;
-  transition-property: background-color, opacity, transform;
-  transition-timing-function: ease-out;
-  width: 16px;
-}
-.navbar-burger span:nth-child(1) {
-  top: calc(50% - 6px);
-}
-.navbar-burger span:nth-child(2) {
-  top: calc(50% - 1px);
-}
-.navbar-burger span:nth-child(3) {
-  top: calc(50% + 4px);
-}
-.navbar-burger:hover {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-.navbar-burger.is-active span:nth-child(1) {
-  transform: translateY(5px) rotate(45deg);
-}
-.navbar-burger.is-active span:nth-child(2) {
-  opacity: 0;
-}
-.navbar-burger.is-active span:nth-child(3) {
-  transform: translateY(-5px) rotate(-45deg);
-}
+  margin-left: auto; }
+  .navbar-burger span {
+    background-color: currentColor;
+    display: block;
+    height: 1px;
+    left: calc(50% - 8px);
+    position: absolute;
+    transform-origin: center;
+    transition-duration: 86ms;
+    transition-property: background-color, opacity, transform;
+    transition-timing-function: ease-out;
+    width: 16px; }
+    .navbar-burger span:nth-child(1) {
+      top: calc(50% - 6px); }
+    .navbar-burger span:nth-child(2) {
+      top: calc(50% - 1px); }
+    .navbar-burger span:nth-child(3) {
+      top: calc(50% + 4px); }
+  .navbar-burger:hover {
+    background-color: rgba(0, 0, 0, 0.05); }
+  .navbar-burger.is-active span:nth-child(1) {
+    transform: translateY(5px) rotate(45deg); }
+  .navbar-burger.is-active span:nth-child(2) {
+    opacity: 0; }
+  .navbar-burger.is-active span:nth-child(3) {
+    transform: translateY(-5px) rotate(-45deg); }
 
 .navbar-menu {
-  display: none;
-}
+  display: none; }
 
 .navbar-item,
 .navbar-link {
@@ -5777,227 +4514,178 @@ body.has-navbar-fixed-bottom {
   display: block;
   line-height: 1.5;
   padding: 0.5rem 0.75rem;
-  position: relative;
-}
-.navbar-item .icon:only-child,
-.navbar-link .icon:only-child {
-  margin-left: -0.25rem;
-  margin-right: -0.25rem;
-}
+  position: relative; }
+  .navbar-item .icon:only-child,
+  .navbar-link .icon:only-child {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem; }
 
 a.navbar-item,
 .navbar-link {
-  cursor: pointer;
-}
-a.navbar-item:hover, a.navbar-item.is-active,
-.navbar-link:hover,
-.navbar-link.is-active {
-  background-color: transparent;
-  color: #086db1;
-}
+  cursor: pointer; }
+  a.navbar-item:hover, a.navbar-item.is-active,
+  .navbar-link:hover,
+  .navbar-link.is-active {
+    background-color: transparent;
+    color: #1565c0; }
 
 .navbar-item {
   display: block;
   flex-grow: 0;
-  flex-shrink: 0;
-}
-.navbar-item img {
-  max-height: 1.75rem;
-}
-.navbar-item.has-dropdown {
-  padding: 0;
-}
-.navbar-item.is-expanded {
-  flex-grow: 1;
-  flex-shrink: 1;
-}
-.navbar-item.is-tab {
-  border-bottom: 1px solid transparent;
-  min-height: 3.25rem;
-  padding-bottom: calc(0.5rem - 1px);
-}
-.navbar-item.is-tab:hover {
-  background-color: transparent;
-  border-bottom-color: #086db1;
-}
-.navbar-item.is-tab.is-active {
-  background-color: transparent;
-  border-bottom-color: #086db1;
-  border-bottom-style: solid;
-  border-bottom-width: 3px;
-  color: #086db1;
-  padding-bottom: calc(0.5rem - 3px);
-}
+  flex-shrink: 0; }
+  .navbar-item img {
+    max-height: 1.75rem; }
+  .navbar-item.has-dropdown {
+    padding: 0; }
+  .navbar-item.is-expanded {
+    flex-grow: 1;
+    flex-shrink: 1; }
+  .navbar-item.is-tab {
+    border-bottom: 1px solid transparent;
+    min-height: 3.25rem;
+    padding-bottom: calc(0.5rem - 1px); }
+    .navbar-item.is-tab:hover {
+      background-color: transparent;
+      border-bottom-color: #1565c0; }
+    .navbar-item.is-tab.is-active {
+      background-color: transparent;
+      border-bottom-color: #1565c0;
+      border-bottom-style: solid;
+      border-bottom-width: 3px;
+      color: #1565c0;
+      padding-bottom: calc(0.5rem - 3px); }
 
 .navbar-content {
   flex-grow: 1;
-  flex-shrink: 1;
-}
+  flex-shrink: 1; }
 
 .navbar-link:not(.is-arrowless) {
-  padding-right: 2.5em;
-}
-.navbar-link:not(.is-arrowless)::after {
-  border-color: #086db1;
-  margin-top: -0.375em;
-  right: 1.125em;
-}
+  padding-right: 2.5em; }
+  .navbar-link:not(.is-arrowless)::after {
+    border-color: #1565c0;
+    margin-top: -0.375em;
+    right: 1.125em; }
 
 .navbar-dropdown {
   font-size: 0.875rem;
   padding-bottom: 0.5rem;
-  padding-top: 0.5rem;
-}
-.navbar-dropdown .navbar-item {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-}
+  padding-top: 0.5rem; }
+  .navbar-dropdown .navbar-item {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem; }
 
 .navbar-divider {
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   border: none;
   display: none;
   height: 2px;
-  margin: 0.5rem 0;
-}
+  margin: 0.5rem 0; }
 
 @media screen and (max-width: 1087px) {
   .navbar > .container {
-    display: block;
-  }
+    display: block; }
   .navbar-brand .navbar-item,
   .navbar-tabs .navbar-item {
     align-items: center;
-    display: flex;
-  }
+    display: flex; }
   .navbar-link::after {
-    display: none;
-  }
+    display: none; }
   .navbar-menu {
-    background-color: hsl(0deg, 0%, 100%);
+    background-color: white;
     box-shadow: 0 8px 16px rgba(10, 10, 10, 0.1);
-    padding: 0.5rem 0;
-  }
-  .navbar-menu.is-active {
-    display: block;
-  }
+    padding: 0.5rem 0; }
+    .navbar-menu.is-active {
+      display: block; }
   .navbar.is-fixed-bottom-touch, .navbar.is-fixed-top-touch {
     left: 0;
     position: fixed;
     right: 0;
-    z-index: 30;
-  }
+    z-index: 30; }
   .navbar.is-fixed-bottom-touch {
-    bottom: 0;
-  }
-  .navbar.is-fixed-bottom-touch.has-shadow {
-    box-shadow: 0 -2px 3px rgba(10, 10, 10, 0.1);
-  }
+    bottom: 0; }
+    .navbar.is-fixed-bottom-touch.has-shadow {
+      box-shadow: 0 -2px 3px rgba(10, 10, 10, 0.1); }
   .navbar.is-fixed-top-touch {
-    top: 0;
-  }
+    top: 0; }
   .navbar.is-fixed-top .navbar-menu, .navbar.is-fixed-top-touch .navbar-menu {
     -webkit-overflow-scrolling: touch;
     max-height: calc(100vh - 3.25rem);
-    overflow: auto;
-  }
+    overflow: auto; }
   html.has-navbar-fixed-top-touch,
   body.has-navbar-fixed-top-touch {
-    padding-top: 3.25rem;
-  }
+    padding-top: 3.25rem; }
   html.has-navbar-fixed-bottom-touch,
   body.has-navbar-fixed-bottom-touch {
-    padding-bottom: 3.25rem;
-  }
-}
+    padding-bottom: 3.25rem; } }
+
 @media screen and (min-width: 1088px) {
   .navbar,
   .navbar-menu,
   .navbar-start,
   .navbar-end {
     align-items: stretch;
-    display: flex;
-  }
+    display: flex; }
   .navbar {
-    min-height: 3.25rem;
-  }
-  .navbar.is-spaced {
-    padding: 1rem 2rem;
-  }
-  .navbar.is-spaced .navbar-start,
-  .navbar.is-spaced .navbar-end {
-    align-items: center;
-  }
-  .navbar.is-spaced a.navbar-item,
-  .navbar.is-spaced .navbar-link {
-    border-radius: 4px;
-  }
-  .navbar.is-transparent a.navbar-item:hover, .navbar.is-transparent a.navbar-item.is-active,
-  .navbar.is-transparent .navbar-link:hover,
-  .navbar.is-transparent .navbar-link.is-active {
-    background-color: transparent !important;
-  }
-  .navbar.is-transparent .navbar-item.has-dropdown.is-active .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:hover .navbar-link {
-    background-color: transparent !important;
-  }
-  .navbar.is-transparent .navbar-dropdown a.navbar-item:hover {
-    background-color: hsl(0deg, 0%, 96%);
-    color: hsl(0deg, 0%, 4%);
-  }
-  .navbar.is-transparent .navbar-dropdown a.navbar-item.is-active {
-    background-color: hsl(0deg, 0%, 96%);
-    color: #086db1;
-  }
+    min-height: 3.25rem; }
+    .navbar.is-spaced {
+      padding: 1rem 2rem; }
+      .navbar.is-spaced .navbar-start,
+      .navbar.is-spaced .navbar-end {
+        align-items: center; }
+      .navbar.is-spaced a.navbar-item,
+      .navbar.is-spaced .navbar-link {
+        border-radius: 4px; }
+    .navbar.is-transparent a.navbar-item:hover, .navbar.is-transparent a.navbar-item.is-active,
+    .navbar.is-transparent .navbar-link:hover,
+    .navbar.is-transparent .navbar-link.is-active {
+      background-color: transparent !important; }
+    .navbar.is-transparent .navbar-item.has-dropdown.is-active .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:hover .navbar-link {
+      background-color: transparent !important; }
+    .navbar.is-transparent .navbar-dropdown a.navbar-item:hover {
+      background-color: whitesmoke;
+      color: #0a0a0a; }
+    .navbar.is-transparent .navbar-dropdown a.navbar-item.is-active {
+      background-color: whitesmoke;
+      color: #1565c0; }
   .navbar-burger {
-    display: none;
-  }
+    display: none; }
   .navbar-item,
   .navbar-link {
     align-items: center;
-    display: flex;
-  }
+    display: flex; }
   .navbar-item {
-    display: flex;
-  }
-  .navbar-item.has-dropdown {
-    align-items: stretch;
-  }
-  .navbar-item.has-dropdown-up .navbar-link::after {
-    transform: rotate(135deg) translate(0.25em, -0.25em);
-  }
-  .navbar-item.has-dropdown-up .navbar-dropdown {
-    border-bottom: 2px solid hsl(0deg, 0%, 80%);
-    border-radius: 6px 6px 0 0;
-    border-top: none;
-    bottom: 100%;
-    box-shadow: 0 -8px 8px rgba(10, 10, 10, 0.1);
-    top: auto;
-  }
-  .navbar-item.is-active .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown {
-    display: block;
-  }
-  .navbar.is-spaced .navbar-item.is-active .navbar-dropdown, .navbar-item.is-active .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:hover .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown.is-boxed {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
-  }
+    display: flex; }
+    .navbar-item.has-dropdown {
+      align-items: stretch; }
+    .navbar-item.has-dropdown-up .navbar-link::after {
+      transform: rotate(135deg) translate(0.25em, -0.25em); }
+    .navbar-item.has-dropdown-up .navbar-dropdown {
+      border-bottom: 2px solid #cccccc;
+      border-radius: 6px 6px 0 0;
+      border-top: none;
+      bottom: 100%;
+      box-shadow: 0 -8px 8px rgba(10, 10, 10, 0.1);
+      top: auto; }
+    .navbar-item.is-active .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown {
+      display: block; }
+      .navbar.is-spaced .navbar-item.is-active .navbar-dropdown, .navbar-item.is-active .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:hover .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown.is-boxed {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translateY(0); }
   .navbar-menu {
     flex-grow: 1;
-    flex-shrink: 0;
-  }
+    flex-shrink: 0; }
   .navbar-start {
     justify-content: flex-start;
-    margin-right: auto;
-  }
+    margin-right: auto; }
   .navbar-end {
     justify-content: flex-end;
-    margin-left: auto;
-  }
+    margin-left: auto; }
   .navbar-dropdown {
-    background-color: hsl(0deg, 0%, 100%);
+    background-color: white;
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
-    border-top: 2px solid hsl(0deg, 0%, 80%);
+    border-top: 2px solid #cccccc;
     box-shadow: 0 8px 8px rgba(10, 10, 10, 0.1);
     display: none;
     font-size: 0.875rem;
@@ -6005,123 +4693,95 @@ a.navbar-item:hover, a.navbar-item.is-active,
     min-width: 100%;
     position: absolute;
     top: 100%;
-    z-index: 20;
-  }
-  .navbar-dropdown .navbar-item {
-    padding: 0.375rem 1rem;
-    white-space: nowrap;
-  }
-  .navbar-dropdown a.navbar-item {
-    padding-right: 3rem;
-  }
-  .navbar-dropdown a.navbar-item:hover {
-    background-color: hsl(0deg, 0%, 96%);
-    color: hsl(0deg, 0%, 4%);
-  }
-  .navbar-dropdown a.navbar-item.is-active {
-    background-color: hsl(0deg, 0%, 96%);
-    color: #086db1;
-  }
-  .navbar.is-spaced .navbar-dropdown, .navbar-dropdown.is-boxed {
-    border-radius: 6px;
-    border-top: none;
-    box-shadow: 0 8px 8px rgba(10, 10, 10, 0.1), 0 0 0 1px rgba(10, 10, 10, 0.1);
-    display: block;
-    opacity: 0;
-    pointer-events: none;
-    top: calc(100% + (-4px));
-    transform: translateY(-5px);
-    transition-duration: 86ms;
-    transition-property: opacity, transform;
-  }
-  .navbar-dropdown.is-right {
-    left: auto;
-    right: 0;
-  }
+    z-index: 20; }
+    .navbar-dropdown .navbar-item {
+      padding: 0.375rem 1rem;
+      white-space: nowrap; }
+    .navbar-dropdown a.navbar-item {
+      padding-right: 3rem; }
+      .navbar-dropdown a.navbar-item:hover {
+        background-color: whitesmoke;
+        color: #0a0a0a; }
+      .navbar-dropdown a.navbar-item.is-active {
+        background-color: whitesmoke;
+        color: #1565c0; }
+    .navbar.is-spaced .navbar-dropdown, .navbar-dropdown.is-boxed {
+      border-radius: 6px;
+      border-top: none;
+      box-shadow: 0 8px 8px rgba(10, 10, 10, 0.1), 0 0 0 1px rgba(10, 10, 10, 0.1);
+      display: block;
+      opacity: 0;
+      pointer-events: none;
+      top: calc(100% + (-4px));
+      transform: translateY(-5px);
+      transition-duration: 86ms;
+      transition-property: opacity, transform; }
+    .navbar-dropdown.is-right {
+      left: auto;
+      right: 0; }
   .navbar-divider {
-    display: block;
-  }
+    display: block; }
   .navbar > .container .navbar-brand,
   .container > .navbar .navbar-brand {
-    margin-left: -0.75rem;
-  }
+    margin-left: -.75rem; }
   .navbar > .container .navbar-menu,
   .container > .navbar .navbar-menu {
-    margin-right: -0.75rem;
-  }
+    margin-right: -.75rem; }
   .navbar.is-fixed-bottom-desktop, .navbar.is-fixed-top-desktop {
     left: 0;
     position: fixed;
     right: 0;
-    z-index: 30;
-  }
+    z-index: 30; }
   .navbar.is-fixed-bottom-desktop {
-    bottom: 0;
-  }
-  .navbar.is-fixed-bottom-desktop.has-shadow {
-    box-shadow: 0 -2px 3px rgba(10, 10, 10, 0.1);
-  }
+    bottom: 0; }
+    .navbar.is-fixed-bottom-desktop.has-shadow {
+      box-shadow: 0 -2px 3px rgba(10, 10, 10, 0.1); }
   .navbar.is-fixed-top-desktop {
-    top: 0;
-  }
+    top: 0; }
   html.has-navbar-fixed-top-desktop,
   body.has-navbar-fixed-top-desktop {
-    padding-top: 3.25rem;
-  }
+    padding-top: 3.25rem; }
   html.has-navbar-fixed-bottom-desktop,
   body.has-navbar-fixed-bottom-desktop {
-    padding-bottom: 3.25rem;
-  }
+    padding-bottom: 3.25rem; }
   html.has-spaced-navbar-fixed-top,
   body.has-spaced-navbar-fixed-top {
-    padding-top: 5.25rem;
-  }
+    padding-top: 5.25rem; }
   html.has-spaced-navbar-fixed-bottom,
   body.has-spaced-navbar-fixed-bottom {
-    padding-bottom: 5.25rem;
-  }
+    padding-bottom: 5.25rem; }
   a.navbar-item.is-active,
   .navbar-link.is-active {
-    color: #b31b1b;
-  }
+    color: #b31b1b; }
   a.navbar-item.is-active:not(:hover),
   .navbar-link.is-active:not(:hover) {
-    background-color: transparent;
-  }
+    background-color: transparent; }
   .navbar-item.has-dropdown:hover .navbar-link, .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: transparent;
-  }
-}
+    background-color: transparent; } }
+
 .pagination {
   font-size: 1rem;
-  margin: -0.25rem;
-}
-.pagination.is-small {
-  font-size: 0.85rem;
-}
-.pagination.is-medium {
-  font-size: 1.25rem;
-}
-.pagination.is-large {
-  font-size: 1.5rem;
-}
-.pagination.is-rounded .pagination-previous,
-.pagination.is-rounded .pagination-next {
-  padding-left: 1em;
-  padding-right: 1em;
-  border-radius: 290486px;
-}
-.pagination.is-rounded .pagination-link {
-  border-radius: 290486px;
-}
+  margin: -0.25rem; }
+  .pagination.is-small {
+    font-size: 0.85rem; }
+  .pagination.is-medium {
+    font-size: 1.25rem; }
+  .pagination.is-large {
+    font-size: 1.5rem; }
+  .pagination.is-rounded .pagination-previous,
+  .pagination.is-rounded .pagination-next {
+    padding-left: 1em;
+    padding-right: 1em;
+    border-radius: 290486px; }
+  .pagination.is-rounded .pagination-link {
+    border-radius: 290486px; }
 
 .pagination,
 .pagination-list {
   align-items: center;
   display: flex;
   justify-content: center;
-  text-align: center;
-}
+  text-align: center; }
 
 .pagination-previous,
 .pagination-next,
@@ -6132,202 +4792,161 @@ a.navbar-item:hover, a.navbar-item.is-active,
   padding-right: 0.5em;
   justify-content: center;
   margin: 0.25rem;
-  text-align: center;
-}
+  text-align: center; }
 
 .pagination-previous,
 .pagination-next,
 .pagination-link {
-  border-color: hsl(0deg, 0%, 80%);
+  border-color: #cccccc;
   color: #2d2d2d;
-  min-width: 2.25em;
-}
-.pagination-previous:hover,
-.pagination-next:hover,
-.pagination-link:hover {
-  border-color: hsl(0deg, 0%, 60%);
-  color: #2d2d2d;
-}
-.pagination-previous:focus,
-.pagination-next:focus,
-.pagination-link:focus {
-  border-color: #086db1;
-}
-.pagination-previous:active,
-.pagination-next:active,
-.pagination-link:active {
-  box-shadow: inset 0 1px 2px rgba(10, 10, 10, 0.2);
-}
-.pagination-previous[disabled],
-.pagination-next[disabled],
-.pagination-link[disabled] {
-  background-color: hsl(0deg, 0%, 80%);
-  border-color: hsl(0deg, 0%, 80%);
-  box-shadow: none;
-  color: #757575;
-  opacity: 0.5;
-}
+  min-width: 2.25em; }
+  .pagination-previous:hover,
+  .pagination-next:hover,
+  .pagination-link:hover {
+    border-color: #999999;
+    color: #2d2d2d; }
+  .pagination-previous:focus,
+  .pagination-next:focus,
+  .pagination-link:focus {
+    border-color: #1565c0; }
+  .pagination-previous:active,
+  .pagination-next:active,
+  .pagination-link:active {
+    box-shadow: inset 0 1px 2px rgba(10, 10, 10, 0.2); }
+  .pagination-previous[disabled],
+  .pagination-next[disabled],
+  .pagination-link[disabled] {
+    background-color: #cccccc;
+    border-color: #cccccc;
+    box-shadow: none;
+    color: #757575;
+    opacity: 0.5; }
 
 .pagination-previous,
 .pagination-next {
   padding-left: 0.75em;
   padding-right: 0.75em;
-  white-space: nowrap;
-}
+  white-space: nowrap; }
 
 .pagination-link.is-current {
-  background-color: #086db1;
-  border-color: #086db1;
-  color: #fff;
-}
+  background-color: #1565c0;
+  border-color: #1565c0;
+  color: #fff; }
 
 .pagination-ellipsis {
-  color: hsl(0deg, 0%, 60%);
-  pointer-events: none;
-}
+  color: #999999;
+  pointer-events: none; }
 
 .pagination-list {
-  flex-wrap: wrap;
-}
+  flex-wrap: wrap; }
 
 @media screen and (max-width: 768px) {
   .pagination {
-    flex-wrap: wrap;
-  }
+    flex-wrap: wrap; }
   .pagination-previous,
   .pagination-next {
     flex-grow: 1;
-    flex-shrink: 1;
-  }
+    flex-shrink: 1; }
   .pagination-list li {
     flex-grow: 1;
-    flex-shrink: 1;
-  }
-}
+    flex-shrink: 1; } }
+
 @media screen and (min-width: 769px), print {
   .pagination-list {
     flex-grow: 1;
     flex-shrink: 1;
     justify-content: flex-start;
-    order: 1;
-  }
+    order: 1; }
   .pagination-previous {
-    order: 2;
-  }
+    order: 2; }
   .pagination-next {
-    order: 3;
-  }
+    order: 3; }
   .pagination {
-    justify-content: space-between;
-  }
-  .pagination.is-centered .pagination-previous {
-    order: 1;
-  }
-  .pagination.is-centered .pagination-list {
-    justify-content: center;
-    order: 2;
-  }
-  .pagination.is-centered .pagination-next {
-    order: 3;
-  }
-  .pagination.is-right .pagination-previous {
-    order: 1;
-  }
-  .pagination.is-right .pagination-next {
-    order: 2;
-  }
-  .pagination.is-right .pagination-list {
-    justify-content: flex-end;
-    order: 3;
-  }
-}
+    justify-content: space-between; }
+    .pagination.is-centered .pagination-previous {
+      order: 1; }
+    .pagination.is-centered .pagination-list {
+      justify-content: center;
+      order: 2; }
+    .pagination.is-centered .pagination-next {
+      order: 3; }
+    .pagination.is-right .pagination-previous {
+      order: 1; }
+    .pagination.is-right .pagination-next {
+      order: 2; }
+    .pagination.is-right .pagination-list {
+      justify-content: flex-end;
+      order: 3; } }
+
 .panel {
-  font-size: 1rem;
-}
-.panel:not(:last-child) {
-  margin-bottom: 1.5rem;
-}
+  font-size: 1rem; }
+  .panel:not(:last-child) {
+    margin-bottom: 1.5rem; }
 
 .panel-heading,
 .panel-tabs,
 .panel-block {
-  border-bottom: 1px solid hsl(0deg, 0%, 80%);
-  border-left: 1px solid hsl(0deg, 0%, 80%);
-  border-right: 1px solid hsl(0deg, 0%, 80%);
-}
-.panel-heading:first-child,
-.panel-tabs:first-child,
-.panel-block:first-child {
-  border-top: 1px solid hsl(0deg, 0%, 80%);
-}
+  border-bottom: 1px solid #cccccc;
+  border-left: 1px solid #cccccc;
+  border-right: 1px solid #cccccc; }
+  .panel-heading:first-child,
+  .panel-tabs:first-child,
+  .panel-block:first-child {
+    border-top: 1px solid #cccccc; }
 
 .panel-heading {
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   border-radius: 4px 4px 0 0;
   color: #2d2d2d;
   font-size: 1.25em;
   font-weight: 300;
   line-height: 1.25;
-  padding: 0.5em 0.75em;
-}
+  padding: 0.5em 0.75em; }
 
 .panel-tabs {
   align-items: flex-end;
   display: flex;
   font-size: 0.875em;
-  justify-content: center;
-}
-.panel-tabs a {
-  border-bottom: 1px solid hsl(0deg, 0%, 80%);
-  margin-bottom: -1px;
-  padding: 0.5em;
-}
-.panel-tabs a.is-active {
-  border-bottom-color: #333;
-  color: #2d2d2d;
-}
+  justify-content: center; }
+  .panel-tabs a {
+    border-bottom: 1px solid #cccccc;
+    margin-bottom: -1px;
+    padding: 0.5em; }
+    .panel-tabs a.is-active {
+      border-bottom-color: #333;
+      color: #2d2d2d; }
 
 .panel-list a {
-  color: #333;
-}
-.panel-list a:hover {
-  color: #086db1;
-}
+  color: #333; }
+  .panel-list a:hover {
+    color: #1565c0; }
 
 .panel-block {
   align-items: center;
   color: #2d2d2d;
   display: flex;
   justify-content: flex-start;
-  padding: 0.5em 0.75em;
-}
-.panel-block input[type=checkbox] {
-  margin-right: 0.75em;
-}
-.panel-block > .control {
-  flex-grow: 1;
-  flex-shrink: 1;
-  width: 100%;
-}
-.panel-block.is-wrapped {
-  flex-wrap: wrap;
-}
-.panel-block.is-active {
-  border-left-color: #086db1;
-  color: #2d2d2d;
-}
-.panel-block.is-active .panel-icon {
-  color: #086db1;
-}
+  padding: 0.5em 0.75em; }
+  .panel-block input[type="checkbox"] {
+    margin-right: 0.75em; }
+  .panel-block > .control {
+    flex-grow: 1;
+    flex-shrink: 1;
+    width: 100%; }
+  .panel-block.is-wrapped {
+    flex-wrap: wrap; }
+  .panel-block.is-active {
+    border-left-color: #1565c0;
+    color: #2d2d2d; }
+    .panel-block.is-active .panel-icon {
+      color: #1565c0; }
 
 a.panel-block,
 label.panel-block {
-  cursor: pointer;
-}
-a.panel-block:hover,
-label.panel-block:hover {
-  background-color: hsl(0deg, 0%, 96%);
-}
+  cursor: pointer; }
+  a.panel-block:hover,
+  label.panel-block:hover {
+    background-color: whitesmoke; }
 
 .panel-icon {
   display: inline-block;
@@ -6338,12 +4957,10 @@ label.panel-block:hover {
   vertical-align: top;
   width: 1em;
   color: #757575;
-  margin-right: 0.75em;
-}
-.panel-icon .fa {
-  font-size: inherit;
-  line-height: inherit;
-}
+  margin-right: 0.75em; }
+  .panel-icon .fa {
+    font-size: inherit;
+    line-height: inherit; }
 
 .tabs {
   -webkit-overflow-scrolling: touch;
@@ -6353,3778 +4970,2752 @@ label.panel-block:hover {
   justify-content: space-between;
   overflow: hidden;
   overflow-x: auto;
-  white-space: nowrap;
-}
-.tabs a {
-  align-items: center;
-  border-bottom-color: hsl(0deg, 0%, 80%);
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  color: #333;
-  display: flex;
-  justify-content: center;
-  margin-bottom: -1px;
-  padding: 0.5em 1em;
-  vertical-align: top;
-}
-.tabs a:hover {
-  border-bottom-color: #2d2d2d;
-  color: #2d2d2d;
-}
-.tabs li {
-  display: block;
-}
-.tabs li.is-active a {
-  border-bottom-color: #086db1;
-  color: #086db1;
-}
-.tabs ul {
-  align-items: center;
-  border-bottom-color: hsl(0deg, 0%, 80%);
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  display: flex;
-  flex-grow: 1;
-  flex-shrink: 0;
-  justify-content: flex-start;
-}
-.tabs ul.is-left {
-  padding-right: 0.75em;
-}
-.tabs ul.is-center {
-  flex: none;
-  justify-content: center;
-  padding-left: 0.75em;
-  padding-right: 0.75em;
-}
-.tabs ul.is-right {
-  justify-content: flex-end;
-  padding-left: 0.75em;
-}
-.tabs .icon:first-child {
-  margin-right: 0.5em;
-}
-.tabs .icon:last-child {
-  margin-left: 0.5em;
-}
-.tabs.is-centered ul {
-  justify-content: center;
-}
-.tabs.is-right ul {
-  justify-content: flex-end;
-}
-.tabs.is-boxed a {
-  border: 1px solid transparent;
-  border-radius: 4px 4px 0 0;
-}
-.tabs.is-boxed a:hover {
-  background-color: hsl(0deg, 0%, 96%);
-  border-bottom-color: hsl(0deg, 0%, 80%);
-}
-.tabs.is-boxed li.is-active a {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: hsl(0deg, 0%, 80%);
-  border-bottom-color: transparent !important;
-}
-.tabs.is-fullwidth li {
-  flex-grow: 1;
-  flex-shrink: 0;
-}
-.tabs.is-toggle a {
-  border-color: hsl(0deg, 0%, 80%);
-  border-style: solid;
-  border-width: 1px;
-  margin-bottom: 0;
-  position: relative;
-}
-.tabs.is-toggle a:hover {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: hsl(0deg, 0%, 60%);
-  z-index: 2;
-}
-.tabs.is-toggle li + li {
-  margin-left: -1px;
-}
-.tabs.is-toggle li:first-child a {
-  border-radius: 4px 0 0 4px;
-}
-.tabs.is-toggle li:last-child a {
-  border-radius: 0 4px 4px 0;
-}
-.tabs.is-toggle li.is-active a {
-  background-color: #086db1;
-  border-color: #086db1;
-  color: #fff;
-  z-index: 1;
-}
-.tabs.is-toggle ul {
-  border-bottom: none;
-}
-.tabs.is-toggle.is-toggle-rounded li:first-child a {
-  border-bottom-left-radius: 290486px;
-  border-top-left-radius: 290486px;
-  padding-left: 1.25em;
-}
-.tabs.is-toggle.is-toggle-rounded li:last-child a {
-  border-bottom-right-radius: 290486px;
-  border-top-right-radius: 290486px;
-  padding-right: 1.25em;
-}
-.tabs.is-small {
-  font-size: 0.85rem;
-}
-.tabs.is-medium {
-  font-size: 1.25rem;
-}
-.tabs.is-large {
-  font-size: 1.5rem;
-}
+  white-space: nowrap; }
+  .tabs a {
+    align-items: center;
+    border-bottom-color: #cccccc;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    color: #333;
+    display: flex;
+    justify-content: center;
+    margin-bottom: -1px;
+    padding: 0.5em 1em;
+    vertical-align: top; }
+    .tabs a:hover {
+      border-bottom-color: #2d2d2d;
+      color: #2d2d2d; }
+  .tabs li {
+    display: block; }
+    .tabs li.is-active a {
+      border-bottom-color: #1565c0;
+      color: #1565c0; }
+  .tabs ul {
+    align-items: center;
+    border-bottom-color: #cccccc;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    display: flex;
+    flex-grow: 1;
+    flex-shrink: 0;
+    justify-content: flex-start; }
+    .tabs ul.is-left {
+      padding-right: 0.75em; }
+    .tabs ul.is-center {
+      flex: none;
+      justify-content: center;
+      padding-left: 0.75em;
+      padding-right: 0.75em; }
+    .tabs ul.is-right {
+      justify-content: flex-end;
+      padding-left: 0.75em; }
+  .tabs .icon:first-child {
+    margin-right: 0.5em; }
+  .tabs .icon:last-child {
+    margin-left: 0.5em; }
+  .tabs.is-centered ul {
+    justify-content: center; }
+  .tabs.is-right ul {
+    justify-content: flex-end; }
+  .tabs.is-boxed a {
+    border: 1px solid transparent;
+    border-radius: 4px 4px 0 0; }
+    .tabs.is-boxed a:hover {
+      background-color: whitesmoke;
+      border-bottom-color: #cccccc; }
+  .tabs.is-boxed li.is-active a {
+    background-color: white;
+    border-color: #cccccc;
+    border-bottom-color: transparent !important; }
+  .tabs.is-fullwidth li {
+    flex-grow: 1;
+    flex-shrink: 0; }
+  .tabs.is-toggle a {
+    border-color: #cccccc;
+    border-style: solid;
+    border-width: 1px;
+    margin-bottom: 0;
+    position: relative; }
+    .tabs.is-toggle a:hover {
+      background-color: whitesmoke;
+      border-color: #999999;
+      z-index: 2; }
+  .tabs.is-toggle li + li {
+    margin-left: -1px; }
+  .tabs.is-toggle li:first-child a {
+    border-radius: 4px 0 0 4px; }
+  .tabs.is-toggle li:last-child a {
+    border-radius: 0 4px 4px 0; }
+  .tabs.is-toggle li.is-active a {
+    background-color: #1565c0;
+    border-color: #1565c0;
+    color: #fff;
+    z-index: 1; }
+  .tabs.is-toggle ul {
+    border-bottom: none; }
+  .tabs.is-toggle.is-toggle-rounded li:first-child a {
+    border-bottom-left-radius: 290486px;
+    border-top-left-radius: 290486px;
+    padding-left: 1.25em; }
+  .tabs.is-toggle.is-toggle-rounded li:last-child a {
+    border-bottom-right-radius: 290486px;
+    border-top-right-radius: 290486px;
+    padding-right: 1.25em; }
+  .tabs.is-small {
+    font-size: 0.85rem; }
+  .tabs.is-medium {
+    font-size: 1.25rem; }
+  .tabs.is-large {
+    font-size: 1.5rem; }
 
 .column {
   display: block;
   flex-basis: 0;
   flex-grow: 1;
   flex-shrink: 1;
-  padding: 0.75rem;
-}
-.columns.is-mobile > .column.is-narrow {
-  flex: none;
-}
-.columns.is-mobile > .column.is-full {
-  flex: none;
-  width: 100%;
-}
-.columns.is-mobile > .column.is-three-quarters {
-  flex: none;
-  width: 75%;
-}
-.columns.is-mobile > .column.is-two-thirds {
-  flex: none;
-  width: 66.6666%;
-}
-.columns.is-mobile > .column.is-half {
-  flex: none;
-  width: 50%;
-}
-.columns.is-mobile > .column.is-one-third {
-  flex: none;
-  width: 33.3333%;
-}
-.columns.is-mobile > .column.is-one-quarter {
-  flex: none;
-  width: 25%;
-}
-.columns.is-mobile > .column.is-one-fifth {
-  flex: none;
-  width: 20%;
-}
-.columns.is-mobile > .column.is-two-fifths {
-  flex: none;
-  width: 40%;
-}
-.columns.is-mobile > .column.is-three-fifths {
-  flex: none;
-  width: 60%;
-}
-.columns.is-mobile > .column.is-four-fifths {
-  flex: none;
-  width: 80%;
-}
-.columns.is-mobile > .column.is-offset-three-quarters {
-  margin-left: 75%;
-}
-.columns.is-mobile > .column.is-offset-two-thirds {
-  margin-left: 66.6666%;
-}
-.columns.is-mobile > .column.is-offset-half {
-  margin-left: 50%;
-}
-.columns.is-mobile > .column.is-offset-one-third {
-  margin-left: 33.3333%;
-}
-.columns.is-mobile > .column.is-offset-one-quarter {
-  margin-left: 25%;
-}
-.columns.is-mobile > .column.is-offset-one-fifth {
-  margin-left: 20%;
-}
-.columns.is-mobile > .column.is-offset-two-fifths {
-  margin-left: 40%;
-}
-.columns.is-mobile > .column.is-offset-three-fifths {
-  margin-left: 60%;
-}
-.columns.is-mobile > .column.is-offset-four-fifths {
-  margin-left: 80%;
-}
-.columns.is-mobile > .column.is-1 {
-  flex: none;
-  width: 8.3333333333%;
-}
-.columns.is-mobile > .column.is-offset-1 {
-  margin-left: 8.3333333333%;
-}
-.columns.is-mobile > .column.is-2 {
-  flex: none;
-  width: 16.6666666667%;
-}
-.columns.is-mobile > .column.is-offset-2 {
-  margin-left: 16.6666666667%;
-}
-.columns.is-mobile > .column.is-3 {
-  flex: none;
-  width: 25%;
-}
-.columns.is-mobile > .column.is-offset-3 {
-  margin-left: 25%;
-}
-.columns.is-mobile > .column.is-4 {
-  flex: none;
-  width: 33.3333333333%;
-}
-.columns.is-mobile > .column.is-offset-4 {
-  margin-left: 33.3333333333%;
-}
-.columns.is-mobile > .column.is-5 {
-  flex: none;
-  width: 41.6666666667%;
-}
-.columns.is-mobile > .column.is-offset-5 {
-  margin-left: 41.6666666667%;
-}
-.columns.is-mobile > .column.is-6 {
-  flex: none;
-  width: 50%;
-}
-.columns.is-mobile > .column.is-offset-6 {
-  margin-left: 50%;
-}
-.columns.is-mobile > .column.is-7 {
-  flex: none;
-  width: 58.3333333333%;
-}
-.columns.is-mobile > .column.is-offset-7 {
-  margin-left: 58.3333333333%;
-}
-.columns.is-mobile > .column.is-8 {
-  flex: none;
-  width: 66.6666666667%;
-}
-.columns.is-mobile > .column.is-offset-8 {
-  margin-left: 66.6666666667%;
-}
-.columns.is-mobile > .column.is-9 {
-  flex: none;
-  width: 75%;
-}
-.columns.is-mobile > .column.is-offset-9 {
-  margin-left: 75%;
-}
-.columns.is-mobile > .column.is-10 {
-  flex: none;
-  width: 83.3333333333%;
-}
-.columns.is-mobile > .column.is-offset-10 {
-  margin-left: 83.3333333333%;
-}
-.columns.is-mobile > .column.is-11 {
-  flex: none;
-  width: 91.6666666667%;
-}
-.columns.is-mobile > .column.is-offset-11 {
-  margin-left: 91.6666666667%;
-}
-.columns.is-mobile > .column.is-12 {
-  flex: none;
-  width: 100%;
-}
-.columns.is-mobile > .column.is-offset-12 {
-  margin-left: 100%;
-}
-@media screen and (max-width: 768px) {
-  .column.is-narrow-mobile {
-    flex: none;
-  }
-  .column.is-full-mobile {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-three-quarters-mobile {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-two-thirds-mobile {
-    flex: none;
-    width: 66.6666%;
-  }
-  .column.is-half-mobile {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-one-third-mobile {
-    flex: none;
-    width: 33.3333%;
-  }
-  .column.is-one-quarter-mobile {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-one-fifth-mobile {
-    flex: none;
-    width: 20%;
-  }
-  .column.is-two-fifths-mobile {
-    flex: none;
-    width: 40%;
-  }
-  .column.is-three-fifths-mobile {
-    flex: none;
-    width: 60%;
-  }
-  .column.is-four-fifths-mobile {
-    flex: none;
-    width: 80%;
-  }
-  .column.is-offset-three-quarters-mobile {
-    margin-left: 75%;
-  }
-  .column.is-offset-two-thirds-mobile {
-    margin-left: 66.6666%;
-  }
-  .column.is-offset-half-mobile {
-    margin-left: 50%;
-  }
-  .column.is-offset-one-third-mobile {
-    margin-left: 33.3333%;
-  }
-  .column.is-offset-one-quarter-mobile {
-    margin-left: 25%;
-  }
-  .column.is-offset-one-fifth-mobile {
-    margin-left: 20%;
-  }
-  .column.is-offset-two-fifths-mobile {
-    margin-left: 40%;
-  }
-  .column.is-offset-three-fifths-mobile {
-    margin-left: 60%;
-  }
-  .column.is-offset-four-fifths-mobile {
-    margin-left: 80%;
-  }
-  .column.is-1-mobile {
-    flex: none;
-    width: 8.3333333333%;
-  }
-  .column.is-offset-1-mobile {
-    margin-left: 8.3333333333%;
-  }
-  .column.is-2-mobile {
-    flex: none;
-    width: 16.6666666667%;
-  }
-  .column.is-offset-2-mobile {
-    margin-left: 16.6666666667%;
-  }
-  .column.is-3-mobile {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-offset-3-mobile {
-    margin-left: 25%;
-  }
-  .column.is-4-mobile {
-    flex: none;
-    width: 33.3333333333%;
-  }
-  .column.is-offset-4-mobile {
-    margin-left: 33.3333333333%;
-  }
-  .column.is-5-mobile {
-    flex: none;
-    width: 41.6666666667%;
-  }
-  .column.is-offset-5-mobile {
-    margin-left: 41.6666666667%;
-  }
-  .column.is-6-mobile {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-offset-6-mobile {
-    margin-left: 50%;
-  }
-  .column.is-7-mobile {
-    flex: none;
-    width: 58.3333333333%;
-  }
-  .column.is-offset-7-mobile {
-    margin-left: 58.3333333333%;
-  }
-  .column.is-8-mobile {
-    flex: none;
-    width: 66.6666666667%;
-  }
-  .column.is-offset-8-mobile {
-    margin-left: 66.6666666667%;
-  }
-  .column.is-9-mobile {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-offset-9-mobile {
-    margin-left: 75%;
-  }
-  .column.is-10-mobile {
-    flex: none;
-    width: 83.3333333333%;
-  }
-  .column.is-offset-10-mobile {
-    margin-left: 83.3333333333%;
-  }
-  .column.is-11-mobile {
-    flex: none;
-    width: 91.6666666667%;
-  }
-  .column.is-offset-11-mobile {
-    margin-left: 91.6666666667%;
-  }
-  .column.is-12-mobile {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-offset-12-mobile {
-    margin-left: 100%;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .column.is-narrow, .column.is-narrow-tablet {
-    flex: none;
-  }
-  .column.is-full, .column.is-full-tablet {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-three-quarters, .column.is-three-quarters-tablet {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-two-thirds, .column.is-two-thirds-tablet {
-    flex: none;
-    width: 66.6666%;
-  }
-  .column.is-half, .column.is-half-tablet {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-one-third, .column.is-one-third-tablet {
-    flex: none;
-    width: 33.3333%;
-  }
-  .column.is-one-quarter, .column.is-one-quarter-tablet {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-one-fifth, .column.is-one-fifth-tablet {
-    flex: none;
-    width: 20%;
-  }
-  .column.is-two-fifths, .column.is-two-fifths-tablet {
-    flex: none;
-    width: 40%;
-  }
-  .column.is-three-fifths, .column.is-three-fifths-tablet {
-    flex: none;
-    width: 60%;
-  }
-  .column.is-four-fifths, .column.is-four-fifths-tablet {
-    flex: none;
-    width: 80%;
-  }
-  .column.is-offset-three-quarters, .column.is-offset-three-quarters-tablet {
-    margin-left: 75%;
-  }
-  .column.is-offset-two-thirds, .column.is-offset-two-thirds-tablet {
-    margin-left: 66.6666%;
-  }
-  .column.is-offset-half, .column.is-offset-half-tablet {
-    margin-left: 50%;
-  }
-  .column.is-offset-one-third, .column.is-offset-one-third-tablet {
-    margin-left: 33.3333%;
-  }
-  .column.is-offset-one-quarter, .column.is-offset-one-quarter-tablet {
-    margin-left: 25%;
-  }
-  .column.is-offset-one-fifth, .column.is-offset-one-fifth-tablet {
-    margin-left: 20%;
-  }
-  .column.is-offset-two-fifths, .column.is-offset-two-fifths-tablet {
-    margin-left: 40%;
-  }
-  .column.is-offset-three-fifths, .column.is-offset-three-fifths-tablet {
-    margin-left: 60%;
-  }
-  .column.is-offset-four-fifths, .column.is-offset-four-fifths-tablet {
-    margin-left: 80%;
-  }
-  .column.is-1, .column.is-1-tablet {
-    flex: none;
-    width: 8.3333333333%;
-  }
-  .column.is-offset-1, .column.is-offset-1-tablet {
-    margin-left: 8.3333333333%;
-  }
-  .column.is-2, .column.is-2-tablet {
-    flex: none;
-    width: 16.6666666667%;
-  }
-  .column.is-offset-2, .column.is-offset-2-tablet {
-    margin-left: 16.6666666667%;
-  }
-  .column.is-3, .column.is-3-tablet {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-offset-3, .column.is-offset-3-tablet {
-    margin-left: 25%;
-  }
-  .column.is-4, .column.is-4-tablet {
-    flex: none;
-    width: 33.3333333333%;
-  }
-  .column.is-offset-4, .column.is-offset-4-tablet {
-    margin-left: 33.3333333333%;
-  }
-  .column.is-5, .column.is-5-tablet {
-    flex: none;
-    width: 41.6666666667%;
-  }
-  .column.is-offset-5, .column.is-offset-5-tablet {
-    margin-left: 41.6666666667%;
-  }
-  .column.is-6, .column.is-6-tablet {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-offset-6, .column.is-offset-6-tablet {
-    margin-left: 50%;
-  }
-  .column.is-7, .column.is-7-tablet {
-    flex: none;
-    width: 58.3333333333%;
-  }
-  .column.is-offset-7, .column.is-offset-7-tablet {
-    margin-left: 58.3333333333%;
-  }
-  .column.is-8, .column.is-8-tablet {
-    flex: none;
-    width: 66.6666666667%;
-  }
-  .column.is-offset-8, .column.is-offset-8-tablet {
-    margin-left: 66.6666666667%;
-  }
-  .column.is-9, .column.is-9-tablet {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-offset-9, .column.is-offset-9-tablet {
-    margin-left: 75%;
-  }
-  .column.is-10, .column.is-10-tablet {
-    flex: none;
-    width: 83.3333333333%;
-  }
-  .column.is-offset-10, .column.is-offset-10-tablet {
-    margin-left: 83.3333333333%;
-  }
-  .column.is-11, .column.is-11-tablet {
-    flex: none;
-    width: 91.6666666667%;
-  }
-  .column.is-offset-11, .column.is-offset-11-tablet {
-    margin-left: 91.6666666667%;
-  }
-  .column.is-12, .column.is-12-tablet {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-offset-12, .column.is-offset-12-tablet {
-    margin-left: 100%;
-  }
-}
-@media screen and (max-width: 1087px) {
-  .column.is-narrow-touch {
-    flex: none;
-  }
-  .column.is-full-touch {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-three-quarters-touch {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-two-thirds-touch {
-    flex: none;
-    width: 66.6666%;
-  }
-  .column.is-half-touch {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-one-third-touch {
-    flex: none;
-    width: 33.3333%;
-  }
-  .column.is-one-quarter-touch {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-one-fifth-touch {
-    flex: none;
-    width: 20%;
-  }
-  .column.is-two-fifths-touch {
-    flex: none;
-    width: 40%;
-  }
-  .column.is-three-fifths-touch {
-    flex: none;
-    width: 60%;
-  }
-  .column.is-four-fifths-touch {
-    flex: none;
-    width: 80%;
-  }
-  .column.is-offset-three-quarters-touch {
-    margin-left: 75%;
-  }
-  .column.is-offset-two-thirds-touch {
-    margin-left: 66.6666%;
-  }
-  .column.is-offset-half-touch {
-    margin-left: 50%;
-  }
-  .column.is-offset-one-third-touch {
-    margin-left: 33.3333%;
-  }
-  .column.is-offset-one-quarter-touch {
-    margin-left: 25%;
-  }
-  .column.is-offset-one-fifth-touch {
-    margin-left: 20%;
-  }
-  .column.is-offset-two-fifths-touch {
-    margin-left: 40%;
-  }
-  .column.is-offset-three-fifths-touch {
-    margin-left: 60%;
-  }
-  .column.is-offset-four-fifths-touch {
-    margin-left: 80%;
-  }
-  .column.is-1-touch {
-    flex: none;
-    width: 8.3333333333%;
-  }
-  .column.is-offset-1-touch {
-    margin-left: 8.3333333333%;
-  }
-  .column.is-2-touch {
-    flex: none;
-    width: 16.6666666667%;
-  }
-  .column.is-offset-2-touch {
-    margin-left: 16.6666666667%;
-  }
-  .column.is-3-touch {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-offset-3-touch {
-    margin-left: 25%;
-  }
-  .column.is-4-touch {
-    flex: none;
-    width: 33.3333333333%;
-  }
-  .column.is-offset-4-touch {
-    margin-left: 33.3333333333%;
-  }
-  .column.is-5-touch {
-    flex: none;
-    width: 41.6666666667%;
-  }
-  .column.is-offset-5-touch {
-    margin-left: 41.6666666667%;
-  }
-  .column.is-6-touch {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-offset-6-touch {
-    margin-left: 50%;
-  }
-  .column.is-7-touch {
-    flex: none;
-    width: 58.3333333333%;
-  }
-  .column.is-offset-7-touch {
-    margin-left: 58.3333333333%;
-  }
-  .column.is-8-touch {
-    flex: none;
-    width: 66.6666666667%;
-  }
-  .column.is-offset-8-touch {
-    margin-left: 66.6666666667%;
-  }
-  .column.is-9-touch {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-offset-9-touch {
-    margin-left: 75%;
-  }
-  .column.is-10-touch {
-    flex: none;
-    width: 83.3333333333%;
-  }
-  .column.is-offset-10-touch {
-    margin-left: 83.3333333333%;
-  }
-  .column.is-11-touch {
-    flex: none;
-    width: 91.6666666667%;
-  }
-  .column.is-offset-11-touch {
-    margin-left: 91.6666666667%;
-  }
-  .column.is-12-touch {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-offset-12-touch {
-    margin-left: 100%;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .column.is-narrow-desktop {
-    flex: none;
-  }
-  .column.is-full-desktop {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-three-quarters-desktop {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-two-thirds-desktop {
-    flex: none;
-    width: 66.6666%;
-  }
-  .column.is-half-desktop {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-one-third-desktop {
-    flex: none;
-    width: 33.3333%;
-  }
-  .column.is-one-quarter-desktop {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-one-fifth-desktop {
-    flex: none;
-    width: 20%;
-  }
-  .column.is-two-fifths-desktop {
-    flex: none;
-    width: 40%;
-  }
-  .column.is-three-fifths-desktop {
-    flex: none;
-    width: 60%;
-  }
-  .column.is-four-fifths-desktop {
-    flex: none;
-    width: 80%;
-  }
-  .column.is-offset-three-quarters-desktop {
-    margin-left: 75%;
-  }
-  .column.is-offset-two-thirds-desktop {
-    margin-left: 66.6666%;
-  }
-  .column.is-offset-half-desktop {
-    margin-left: 50%;
-  }
-  .column.is-offset-one-third-desktop {
-    margin-left: 33.3333%;
-  }
-  .column.is-offset-one-quarter-desktop {
-    margin-left: 25%;
-  }
-  .column.is-offset-one-fifth-desktop {
-    margin-left: 20%;
-  }
-  .column.is-offset-two-fifths-desktop {
-    margin-left: 40%;
-  }
-  .column.is-offset-three-fifths-desktop {
-    margin-left: 60%;
-  }
-  .column.is-offset-four-fifths-desktop {
-    margin-left: 80%;
-  }
-  .column.is-1-desktop {
-    flex: none;
-    width: 8.3333333333%;
-  }
-  .column.is-offset-1-desktop {
-    margin-left: 8.3333333333%;
-  }
-  .column.is-2-desktop {
-    flex: none;
-    width: 16.6666666667%;
-  }
-  .column.is-offset-2-desktop {
-    margin-left: 16.6666666667%;
-  }
-  .column.is-3-desktop {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-offset-3-desktop {
-    margin-left: 25%;
-  }
-  .column.is-4-desktop {
-    flex: none;
-    width: 33.3333333333%;
-  }
-  .column.is-offset-4-desktop {
-    margin-left: 33.3333333333%;
-  }
-  .column.is-5-desktop {
-    flex: none;
-    width: 41.6666666667%;
-  }
-  .column.is-offset-5-desktop {
-    margin-left: 41.6666666667%;
-  }
-  .column.is-6-desktop {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-offset-6-desktop {
-    margin-left: 50%;
-  }
-  .column.is-7-desktop {
-    flex: none;
-    width: 58.3333333333%;
-  }
-  .column.is-offset-7-desktop {
-    margin-left: 58.3333333333%;
-  }
-  .column.is-8-desktop {
-    flex: none;
-    width: 66.6666666667%;
-  }
-  .column.is-offset-8-desktop {
-    margin-left: 66.6666666667%;
-  }
-  .column.is-9-desktop {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-offset-9-desktop {
-    margin-left: 75%;
-  }
-  .column.is-10-desktop {
-    flex: none;
-    width: 83.3333333333%;
-  }
-  .column.is-offset-10-desktop {
-    margin-left: 83.3333333333%;
-  }
-  .column.is-11-desktop {
-    flex: none;
-    width: 91.6666666667%;
-  }
-  .column.is-offset-11-desktop {
-    margin-left: 91.6666666667%;
-  }
-  .column.is-12-desktop {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-offset-12-desktop {
-    margin-left: 100%;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .column.is-narrow-widescreen {
-    flex: none;
-  }
-  .column.is-full-widescreen {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-three-quarters-widescreen {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-two-thirds-widescreen {
-    flex: none;
-    width: 66.6666%;
-  }
-  .column.is-half-widescreen {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-one-third-widescreen {
-    flex: none;
-    width: 33.3333%;
-  }
-  .column.is-one-quarter-widescreen {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-one-fifth-widescreen {
-    flex: none;
-    width: 20%;
-  }
-  .column.is-two-fifths-widescreen {
-    flex: none;
-    width: 40%;
-  }
-  .column.is-three-fifths-widescreen {
-    flex: none;
-    width: 60%;
-  }
-  .column.is-four-fifths-widescreen {
-    flex: none;
-    width: 80%;
-  }
-  .column.is-offset-three-quarters-widescreen {
-    margin-left: 75%;
-  }
-  .column.is-offset-two-thirds-widescreen {
-    margin-left: 66.6666%;
-  }
-  .column.is-offset-half-widescreen {
-    margin-left: 50%;
-  }
-  .column.is-offset-one-third-widescreen {
-    margin-left: 33.3333%;
-  }
-  .column.is-offset-one-quarter-widescreen {
-    margin-left: 25%;
-  }
-  .column.is-offset-one-fifth-widescreen {
-    margin-left: 20%;
-  }
-  .column.is-offset-two-fifths-widescreen {
-    margin-left: 40%;
-  }
-  .column.is-offset-three-fifths-widescreen {
-    margin-left: 60%;
-  }
-  .column.is-offset-four-fifths-widescreen {
-    margin-left: 80%;
-  }
-  .column.is-1-widescreen {
-    flex: none;
-    width: 8.3333333333%;
-  }
-  .column.is-offset-1-widescreen {
-    margin-left: 8.3333333333%;
-  }
-  .column.is-2-widescreen {
-    flex: none;
-    width: 16.6666666667%;
-  }
-  .column.is-offset-2-widescreen {
-    margin-left: 16.6666666667%;
-  }
-  .column.is-3-widescreen {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-offset-3-widescreen {
-    margin-left: 25%;
-  }
-  .column.is-4-widescreen {
-    flex: none;
-    width: 33.3333333333%;
-  }
-  .column.is-offset-4-widescreen {
-    margin-left: 33.3333333333%;
-  }
-  .column.is-5-widescreen {
-    flex: none;
-    width: 41.6666666667%;
-  }
-  .column.is-offset-5-widescreen {
-    margin-left: 41.6666666667%;
-  }
-  .column.is-6-widescreen {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-offset-6-widescreen {
-    margin-left: 50%;
-  }
-  .column.is-7-widescreen {
-    flex: none;
-    width: 58.3333333333%;
-  }
-  .column.is-offset-7-widescreen {
-    margin-left: 58.3333333333%;
-  }
-  .column.is-8-widescreen {
-    flex: none;
-    width: 66.6666666667%;
-  }
-  .column.is-offset-8-widescreen {
-    margin-left: 66.6666666667%;
-  }
-  .column.is-9-widescreen {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-offset-9-widescreen {
-    margin-left: 75%;
-  }
-  .column.is-10-widescreen {
-    flex: none;
-    width: 83.3333333333%;
-  }
-  .column.is-offset-10-widescreen {
-    margin-left: 83.3333333333%;
-  }
-  .column.is-11-widescreen {
-    flex: none;
-    width: 91.6666666667%;
-  }
-  .column.is-offset-11-widescreen {
-    margin-left: 91.6666666667%;
-  }
-  .column.is-12-widescreen {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-offset-12-widescreen {
-    margin-left: 100%;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .column.is-narrow-fullhd {
-    flex: none;
-  }
-  .column.is-full-fullhd {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-three-quarters-fullhd {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-two-thirds-fullhd {
-    flex: none;
-    width: 66.6666%;
-  }
-  .column.is-half-fullhd {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-one-third-fullhd {
-    flex: none;
-    width: 33.3333%;
-  }
-  .column.is-one-quarter-fullhd {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-one-fifth-fullhd {
-    flex: none;
-    width: 20%;
-  }
-  .column.is-two-fifths-fullhd {
-    flex: none;
-    width: 40%;
-  }
-  .column.is-three-fifths-fullhd {
-    flex: none;
-    width: 60%;
-  }
-  .column.is-four-fifths-fullhd {
-    flex: none;
-    width: 80%;
-  }
-  .column.is-offset-three-quarters-fullhd {
-    margin-left: 75%;
-  }
-  .column.is-offset-two-thirds-fullhd {
-    margin-left: 66.6666%;
-  }
-  .column.is-offset-half-fullhd {
-    margin-left: 50%;
-  }
-  .column.is-offset-one-third-fullhd {
-    margin-left: 33.3333%;
-  }
-  .column.is-offset-one-quarter-fullhd {
-    margin-left: 25%;
-  }
-  .column.is-offset-one-fifth-fullhd {
-    margin-left: 20%;
-  }
-  .column.is-offset-two-fifths-fullhd {
-    margin-left: 40%;
-  }
-  .column.is-offset-three-fifths-fullhd {
-    margin-left: 60%;
-  }
-  .column.is-offset-four-fifths-fullhd {
-    margin-left: 80%;
-  }
-  .column.is-1-fullhd {
-    flex: none;
-    width: 8.3333333333%;
-  }
-  .column.is-offset-1-fullhd {
-    margin-left: 8.3333333333%;
-  }
-  .column.is-2-fullhd {
-    flex: none;
-    width: 16.6666666667%;
-  }
-  .column.is-offset-2-fullhd {
-    margin-left: 16.6666666667%;
-  }
-  .column.is-3-fullhd {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-offset-3-fullhd {
-    margin-left: 25%;
-  }
-  .column.is-4-fullhd {
-    flex: none;
-    width: 33.3333333333%;
-  }
-  .column.is-offset-4-fullhd {
-    margin-left: 33.3333333333%;
-  }
-  .column.is-5-fullhd {
-    flex: none;
-    width: 41.6666666667%;
-  }
-  .column.is-offset-5-fullhd {
-    margin-left: 41.6666666667%;
-  }
-  .column.is-6-fullhd {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-offset-6-fullhd {
-    margin-left: 50%;
-  }
-  .column.is-7-fullhd {
-    flex: none;
-    width: 58.3333333333%;
-  }
-  .column.is-offset-7-fullhd {
-    margin-left: 58.3333333333%;
-  }
-  .column.is-8-fullhd {
-    flex: none;
-    width: 66.6666666667%;
-  }
-  .column.is-offset-8-fullhd {
-    margin-left: 66.6666666667%;
-  }
-  .column.is-9-fullhd {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-offset-9-fullhd {
-    margin-left: 75%;
-  }
-  .column.is-10-fullhd {
-    flex: none;
-    width: 83.3333333333%;
-  }
-  .column.is-offset-10-fullhd {
-    margin-left: 83.3333333333%;
-  }
-  .column.is-11-fullhd {
-    flex: none;
-    width: 91.6666666667%;
-  }
-  .column.is-offset-11-fullhd {
-    margin-left: 91.6666666667%;
-  }
-  .column.is-12-fullhd {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-offset-12-fullhd {
-    margin-left: 100%;
-  }
-}
-
+  padding: 0.75rem; }
+  .columns.is-mobile > .column.is-narrow {
+    flex: none; }
+  .columns.is-mobile > .column.is-full {
+    flex: none;
+    width: 100%; }
+  .columns.is-mobile > .column.is-three-quarters {
+    flex: none;
+    width: 75%; }
+  .columns.is-mobile > .column.is-two-thirds {
+    flex: none;
+    width: 66.6666%; }
+  .columns.is-mobile > .column.is-half {
+    flex: none;
+    width: 50%; }
+  .columns.is-mobile > .column.is-one-third {
+    flex: none;
+    width: 33.3333%; }
+  .columns.is-mobile > .column.is-one-quarter {
+    flex: none;
+    width: 25%; }
+  .columns.is-mobile > .column.is-one-fifth {
+    flex: none;
+    width: 20%; }
+  .columns.is-mobile > .column.is-two-fifths {
+    flex: none;
+    width: 40%; }
+  .columns.is-mobile > .column.is-three-fifths {
+    flex: none;
+    width: 60%; }
+  .columns.is-mobile > .column.is-four-fifths {
+    flex: none;
+    width: 80%; }
+  .columns.is-mobile > .column.is-offset-three-quarters {
+    margin-left: 75%; }
+  .columns.is-mobile > .column.is-offset-two-thirds {
+    margin-left: 66.6666%; }
+  .columns.is-mobile > .column.is-offset-half {
+    margin-left: 50%; }
+  .columns.is-mobile > .column.is-offset-one-third {
+    margin-left: 33.3333%; }
+  .columns.is-mobile > .column.is-offset-one-quarter {
+    margin-left: 25%; }
+  .columns.is-mobile > .column.is-offset-one-fifth {
+    margin-left: 20%; }
+  .columns.is-mobile > .column.is-offset-two-fifths {
+    margin-left: 40%; }
+  .columns.is-mobile > .column.is-offset-three-fifths {
+    margin-left: 60%; }
+  .columns.is-mobile > .column.is-offset-four-fifths {
+    margin-left: 80%; }
+  .columns.is-mobile > .column.is-1 {
+    flex: none;
+    width: 8.33333%; }
+  .columns.is-mobile > .column.is-offset-1 {
+    margin-left: 8.33333%; }
+  .columns.is-mobile > .column.is-2 {
+    flex: none;
+    width: 16.66667%; }
+  .columns.is-mobile > .column.is-offset-2 {
+    margin-left: 16.66667%; }
+  .columns.is-mobile > .column.is-3 {
+    flex: none;
+    width: 25%; }
+  .columns.is-mobile > .column.is-offset-3 {
+    margin-left: 25%; }
+  .columns.is-mobile > .column.is-4 {
+    flex: none;
+    width: 33.33333%; }
+  .columns.is-mobile > .column.is-offset-4 {
+    margin-left: 33.33333%; }
+  .columns.is-mobile > .column.is-5 {
+    flex: none;
+    width: 41.66667%; }
+  .columns.is-mobile > .column.is-offset-5 {
+    margin-left: 41.66667%; }
+  .columns.is-mobile > .column.is-6 {
+    flex: none;
+    width: 50%; }
+  .columns.is-mobile > .column.is-offset-6 {
+    margin-left: 50%; }
+  .columns.is-mobile > .column.is-7 {
+    flex: none;
+    width: 58.33333%; }
+  .columns.is-mobile > .column.is-offset-7 {
+    margin-left: 58.33333%; }
+  .columns.is-mobile > .column.is-8 {
+    flex: none;
+    width: 66.66667%; }
+  .columns.is-mobile > .column.is-offset-8 {
+    margin-left: 66.66667%; }
+  .columns.is-mobile > .column.is-9 {
+    flex: none;
+    width: 75%; }
+  .columns.is-mobile > .column.is-offset-9 {
+    margin-left: 75%; }
+  .columns.is-mobile > .column.is-10 {
+    flex: none;
+    width: 83.33333%; }
+  .columns.is-mobile > .column.is-offset-10 {
+    margin-left: 83.33333%; }
+  .columns.is-mobile > .column.is-11 {
+    flex: none;
+    width: 91.66667%; }
+  .columns.is-mobile > .column.is-offset-11 {
+    margin-left: 91.66667%; }
+  .columns.is-mobile > .column.is-12 {
+    flex: none;
+    width: 100%; }
+  .columns.is-mobile > .column.is-offset-12 {
+    margin-left: 100%; }
+  @media screen and (max-width: 768px) {
+    .column.is-narrow-mobile {
+      flex: none; }
+    .column.is-full-mobile {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-mobile {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-mobile {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-mobile {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-mobile {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-mobile {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-mobile {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-mobile {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-mobile {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-mobile {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-mobile {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-mobile {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-mobile {
+      margin-left: 50%; }
+    .column.is-offset-one-third-mobile {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-mobile {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-mobile {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-mobile {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-mobile {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-mobile {
+      margin-left: 80%; }
+    .column.is-1-mobile {
+      flex: none;
+      width: 8.33333%; }
+    .column.is-offset-1-mobile {
+      margin-left: 8.33333%; }
+    .column.is-2-mobile {
+      flex: none;
+      width: 16.66667%; }
+    .column.is-offset-2-mobile {
+      margin-left: 16.66667%; }
+    .column.is-3-mobile {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-mobile {
+      margin-left: 25%; }
+    .column.is-4-mobile {
+      flex: none;
+      width: 33.33333%; }
+    .column.is-offset-4-mobile {
+      margin-left: 33.33333%; }
+    .column.is-5-mobile {
+      flex: none;
+      width: 41.66667%; }
+    .column.is-offset-5-mobile {
+      margin-left: 41.66667%; }
+    .column.is-6-mobile {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-mobile {
+      margin-left: 50%; }
+    .column.is-7-mobile {
+      flex: none;
+      width: 58.33333%; }
+    .column.is-offset-7-mobile {
+      margin-left: 58.33333%; }
+    .column.is-8-mobile {
+      flex: none;
+      width: 66.66667%; }
+    .column.is-offset-8-mobile {
+      margin-left: 66.66667%; }
+    .column.is-9-mobile {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-mobile {
+      margin-left: 75%; }
+    .column.is-10-mobile {
+      flex: none;
+      width: 83.33333%; }
+    .column.is-offset-10-mobile {
+      margin-left: 83.33333%; }
+    .column.is-11-mobile {
+      flex: none;
+      width: 91.66667%; }
+    .column.is-offset-11-mobile {
+      margin-left: 91.66667%; }
+    .column.is-12-mobile {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-mobile {
+      margin-left: 100%; } }
+  @media screen and (min-width: 769px), print {
+    .column.is-narrow, .column.is-narrow-tablet {
+      flex: none; }
+    .column.is-full, .column.is-full-tablet {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters, .column.is-three-quarters-tablet {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds, .column.is-two-thirds-tablet {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half, .column.is-half-tablet {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third, .column.is-one-third-tablet {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter, .column.is-one-quarter-tablet {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth, .column.is-one-fifth-tablet {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths, .column.is-two-fifths-tablet {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths, .column.is-three-fifths-tablet {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths, .column.is-four-fifths-tablet {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters, .column.is-offset-three-quarters-tablet {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds, .column.is-offset-two-thirds-tablet {
+      margin-left: 66.6666%; }
+    .column.is-offset-half, .column.is-offset-half-tablet {
+      margin-left: 50%; }
+    .column.is-offset-one-third, .column.is-offset-one-third-tablet {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter, .column.is-offset-one-quarter-tablet {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth, .column.is-offset-one-fifth-tablet {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths, .column.is-offset-two-fifths-tablet {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths, .column.is-offset-three-fifths-tablet {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths, .column.is-offset-four-fifths-tablet {
+      margin-left: 80%; }
+    .column.is-1, .column.is-1-tablet {
+      flex: none;
+      width: 8.33333%; }
+    .column.is-offset-1, .column.is-offset-1-tablet {
+      margin-left: 8.33333%; }
+    .column.is-2, .column.is-2-tablet {
+      flex: none;
+      width: 16.66667%; }
+    .column.is-offset-2, .column.is-offset-2-tablet {
+      margin-left: 16.66667%; }
+    .column.is-3, .column.is-3-tablet {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3, .column.is-offset-3-tablet {
+      margin-left: 25%; }
+    .column.is-4, .column.is-4-tablet {
+      flex: none;
+      width: 33.33333%; }
+    .column.is-offset-4, .column.is-offset-4-tablet {
+      margin-left: 33.33333%; }
+    .column.is-5, .column.is-5-tablet {
+      flex: none;
+      width: 41.66667%; }
+    .column.is-offset-5, .column.is-offset-5-tablet {
+      margin-left: 41.66667%; }
+    .column.is-6, .column.is-6-tablet {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6, .column.is-offset-6-tablet {
+      margin-left: 50%; }
+    .column.is-7, .column.is-7-tablet {
+      flex: none;
+      width: 58.33333%; }
+    .column.is-offset-7, .column.is-offset-7-tablet {
+      margin-left: 58.33333%; }
+    .column.is-8, .column.is-8-tablet {
+      flex: none;
+      width: 66.66667%; }
+    .column.is-offset-8, .column.is-offset-8-tablet {
+      margin-left: 66.66667%; }
+    .column.is-9, .column.is-9-tablet {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9, .column.is-offset-9-tablet {
+      margin-left: 75%; }
+    .column.is-10, .column.is-10-tablet {
+      flex: none;
+      width: 83.33333%; }
+    .column.is-offset-10, .column.is-offset-10-tablet {
+      margin-left: 83.33333%; }
+    .column.is-11, .column.is-11-tablet {
+      flex: none;
+      width: 91.66667%; }
+    .column.is-offset-11, .column.is-offset-11-tablet {
+      margin-left: 91.66667%; }
+    .column.is-12, .column.is-12-tablet {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12, .column.is-offset-12-tablet {
+      margin-left: 100%; } }
+  @media screen and (max-width: 1087px) {
+    .column.is-narrow-touch {
+      flex: none; }
+    .column.is-full-touch {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-touch {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-touch {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-touch {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-touch {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-touch {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-touch {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-touch {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-touch {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-touch {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-touch {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-touch {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-touch {
+      margin-left: 50%; }
+    .column.is-offset-one-third-touch {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-touch {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-touch {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-touch {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-touch {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-touch {
+      margin-left: 80%; }
+    .column.is-1-touch {
+      flex: none;
+      width: 8.33333%; }
+    .column.is-offset-1-touch {
+      margin-left: 8.33333%; }
+    .column.is-2-touch {
+      flex: none;
+      width: 16.66667%; }
+    .column.is-offset-2-touch {
+      margin-left: 16.66667%; }
+    .column.is-3-touch {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-touch {
+      margin-left: 25%; }
+    .column.is-4-touch {
+      flex: none;
+      width: 33.33333%; }
+    .column.is-offset-4-touch {
+      margin-left: 33.33333%; }
+    .column.is-5-touch {
+      flex: none;
+      width: 41.66667%; }
+    .column.is-offset-5-touch {
+      margin-left: 41.66667%; }
+    .column.is-6-touch {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-touch {
+      margin-left: 50%; }
+    .column.is-7-touch {
+      flex: none;
+      width: 58.33333%; }
+    .column.is-offset-7-touch {
+      margin-left: 58.33333%; }
+    .column.is-8-touch {
+      flex: none;
+      width: 66.66667%; }
+    .column.is-offset-8-touch {
+      margin-left: 66.66667%; }
+    .column.is-9-touch {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-touch {
+      margin-left: 75%; }
+    .column.is-10-touch {
+      flex: none;
+      width: 83.33333%; }
+    .column.is-offset-10-touch {
+      margin-left: 83.33333%; }
+    .column.is-11-touch {
+      flex: none;
+      width: 91.66667%; }
+    .column.is-offset-11-touch {
+      margin-left: 91.66667%; }
+    .column.is-12-touch {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-touch {
+      margin-left: 100%; } }
+  @media screen and (min-width: 1088px) {
+    .column.is-narrow-desktop {
+      flex: none; }
+    .column.is-full-desktop {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-desktop {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-desktop {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-desktop {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-desktop {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-desktop {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-desktop {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-desktop {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-desktop {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-desktop {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-desktop {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-desktop {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-desktop {
+      margin-left: 50%; }
+    .column.is-offset-one-third-desktop {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-desktop {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-desktop {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-desktop {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-desktop {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-desktop {
+      margin-left: 80%; }
+    .column.is-1-desktop {
+      flex: none;
+      width: 8.33333%; }
+    .column.is-offset-1-desktop {
+      margin-left: 8.33333%; }
+    .column.is-2-desktop {
+      flex: none;
+      width: 16.66667%; }
+    .column.is-offset-2-desktop {
+      margin-left: 16.66667%; }
+    .column.is-3-desktop {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-desktop {
+      margin-left: 25%; }
+    .column.is-4-desktop {
+      flex: none;
+      width: 33.33333%; }
+    .column.is-offset-4-desktop {
+      margin-left: 33.33333%; }
+    .column.is-5-desktop {
+      flex: none;
+      width: 41.66667%; }
+    .column.is-offset-5-desktop {
+      margin-left: 41.66667%; }
+    .column.is-6-desktop {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-desktop {
+      margin-left: 50%; }
+    .column.is-7-desktop {
+      flex: none;
+      width: 58.33333%; }
+    .column.is-offset-7-desktop {
+      margin-left: 58.33333%; }
+    .column.is-8-desktop {
+      flex: none;
+      width: 66.66667%; }
+    .column.is-offset-8-desktop {
+      margin-left: 66.66667%; }
+    .column.is-9-desktop {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-desktop {
+      margin-left: 75%; }
+    .column.is-10-desktop {
+      flex: none;
+      width: 83.33333%; }
+    .column.is-offset-10-desktop {
+      margin-left: 83.33333%; }
+    .column.is-11-desktop {
+      flex: none;
+      width: 91.66667%; }
+    .column.is-offset-11-desktop {
+      margin-left: 91.66667%; }
+    .column.is-12-desktop {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-desktop {
+      margin-left: 100%; } }
+  @media screen and (min-width: 1280px) {
+    .column.is-narrow-widescreen {
+      flex: none; }
+    .column.is-full-widescreen {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-widescreen {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-widescreen {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-widescreen {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-widescreen {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-widescreen {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-widescreen {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-widescreen {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-widescreen {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-widescreen {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-widescreen {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-widescreen {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-widescreen {
+      margin-left: 50%; }
+    .column.is-offset-one-third-widescreen {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-widescreen {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-widescreen {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-widescreen {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-widescreen {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-widescreen {
+      margin-left: 80%; }
+    .column.is-1-widescreen {
+      flex: none;
+      width: 8.33333%; }
+    .column.is-offset-1-widescreen {
+      margin-left: 8.33333%; }
+    .column.is-2-widescreen {
+      flex: none;
+      width: 16.66667%; }
+    .column.is-offset-2-widescreen {
+      margin-left: 16.66667%; }
+    .column.is-3-widescreen {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-widescreen {
+      margin-left: 25%; }
+    .column.is-4-widescreen {
+      flex: none;
+      width: 33.33333%; }
+    .column.is-offset-4-widescreen {
+      margin-left: 33.33333%; }
+    .column.is-5-widescreen {
+      flex: none;
+      width: 41.66667%; }
+    .column.is-offset-5-widescreen {
+      margin-left: 41.66667%; }
+    .column.is-6-widescreen {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-widescreen {
+      margin-left: 50%; }
+    .column.is-7-widescreen {
+      flex: none;
+      width: 58.33333%; }
+    .column.is-offset-7-widescreen {
+      margin-left: 58.33333%; }
+    .column.is-8-widescreen {
+      flex: none;
+      width: 66.66667%; }
+    .column.is-offset-8-widescreen {
+      margin-left: 66.66667%; }
+    .column.is-9-widescreen {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-widescreen {
+      margin-left: 75%; }
+    .column.is-10-widescreen {
+      flex: none;
+      width: 83.33333%; }
+    .column.is-offset-10-widescreen {
+      margin-left: 83.33333%; }
+    .column.is-11-widescreen {
+      flex: none;
+      width: 91.66667%; }
+    .column.is-offset-11-widescreen {
+      margin-left: 91.66667%; }
+    .column.is-12-widescreen {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-widescreen {
+      margin-left: 100%; } }
+  @media screen and (min-width: 1472px) {
+    .column.is-narrow-fullhd {
+      flex: none; }
+    .column.is-full-fullhd {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-fullhd {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-fullhd {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-fullhd {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-fullhd {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-fullhd {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-fullhd {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-fullhd {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-fullhd {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-fullhd {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-fullhd {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-fullhd {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-fullhd {
+      margin-left: 50%; }
+    .column.is-offset-one-third-fullhd {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-fullhd {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-fullhd {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-fullhd {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-fullhd {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-fullhd {
+      margin-left: 80%; }
+    .column.is-1-fullhd {
+      flex: none;
+      width: 8.33333%; }
+    .column.is-offset-1-fullhd {
+      margin-left: 8.33333%; }
+    .column.is-2-fullhd {
+      flex: none;
+      width: 16.66667%; }
+    .column.is-offset-2-fullhd {
+      margin-left: 16.66667%; }
+    .column.is-3-fullhd {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-fullhd {
+      margin-left: 25%; }
+    .column.is-4-fullhd {
+      flex: none;
+      width: 33.33333%; }
+    .column.is-offset-4-fullhd {
+      margin-left: 33.33333%; }
+    .column.is-5-fullhd {
+      flex: none;
+      width: 41.66667%; }
+    .column.is-offset-5-fullhd {
+      margin-left: 41.66667%; }
+    .column.is-6-fullhd {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-fullhd {
+      margin-left: 50%; }
+    .column.is-7-fullhd {
+      flex: none;
+      width: 58.33333%; }
+    .column.is-offset-7-fullhd {
+      margin-left: 58.33333%; }
+    .column.is-8-fullhd {
+      flex: none;
+      width: 66.66667%; }
+    .column.is-offset-8-fullhd {
+      margin-left: 66.66667%; }
+    .column.is-9-fullhd {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-fullhd {
+      margin-left: 75%; }
+    .column.is-10-fullhd {
+      flex: none;
+      width: 83.33333%; }
+    .column.is-offset-10-fullhd {
+      margin-left: 83.33333%; }
+    .column.is-11-fullhd {
+      flex: none;
+      width: 91.66667%; }
+    .column.is-offset-11-fullhd {
+      margin-left: 91.66667%; }
+    .column.is-12-fullhd {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-fullhd {
+      margin-left: 100%; } }
 .columns {
   margin-left: -0.75rem;
   margin-right: -0.75rem;
-  margin-top: -0.75rem;
-}
-.columns:last-child {
-  margin-bottom: -0.75rem;
-}
-.columns:not(:last-child) {
-  margin-bottom: calc(1.5rem - 0.75rem);
-}
-.columns.is-centered {
-  justify-content: center;
-}
-.columns.is-gapless {
-  margin-left: 0;
-  margin-right: 0;
-  margin-top: 0;
-}
-.columns.is-gapless > .column {
-  margin: 0;
-  padding: 0 !important;
-}
-.columns.is-gapless:not(:last-child) {
-  margin-bottom: 1.5rem;
-}
-.columns.is-gapless:last-child {
-  margin-bottom: 0;
-}
-.columns.is-mobile {
-  display: flex;
-}
-.columns.is-multiline {
-  flex-wrap: wrap;
-}
-.columns.is-vcentered {
-  align-items: center;
-}
-@media screen and (min-width: 769px), print {
-  .columns:not(.is-desktop) {
-    display: flex;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .columns.is-desktop {
-    display: flex;
-  }
-}
-
+  margin-top: -0.75rem; }
+  .columns:last-child {
+    margin-bottom: -0.75rem; }
+  .columns:not(:last-child) {
+    margin-bottom: calc(1.5rem - 0.75rem); }
+  .columns.is-centered {
+    justify-content: center; }
+  .columns.is-gapless {
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: 0; }
+    .columns.is-gapless > .column {
+      margin: 0;
+      padding: 0 !important; }
+    .columns.is-gapless:not(:last-child) {
+      margin-bottom: 1.5rem; }
+    .columns.is-gapless:last-child {
+      margin-bottom: 0; }
+  .columns.is-mobile {
+    display: flex; }
+  .columns.is-multiline {
+    flex-wrap: wrap; }
+  .columns.is-vcentered {
+    align-items: center; }
+  @media screen and (min-width: 769px), print {
+    .columns:not(.is-desktop) {
+      display: flex; } }
+  @media screen and (min-width: 1088px) {
+    .columns.is-desktop {
+      display: flex; } }
 .columns.is-variable {
   --columnGap: 0.75rem;
   margin-left: calc(-1 * var(--columnGap));
-  margin-right: calc(-1 * var(--columnGap));
-}
-.columns.is-variable .column {
-  padding-left: var(--columnGap);
-  padding-right: var(--columnGap);
-}
-.columns.is-variable.is-0 {
-  --columnGap: 0rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-0-mobile {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-0-tablet {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1087px) {
-  .columns.is-variable.is-0-tablet-only {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (max-width: 1087px) {
-  .columns.is-variable.is-0-touch {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .columns.is-variable.is-0-desktop {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (min-width: 1088px) and (max-width: 1279px) {
-  .columns.is-variable.is-0-desktop-only {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .columns.is-variable.is-0-widescreen {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (min-width: 1280px) and (max-width: 1471px) {
-  .columns.is-variable.is-0-widescreen-only {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .columns.is-variable.is-0-fullhd {
-    --columnGap: 0rem;
-  }
-}
-.columns.is-variable.is-1 {
-  --columnGap: 0.25rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-1-mobile {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-1-tablet {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1087px) {
-  .columns.is-variable.is-1-tablet-only {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (max-width: 1087px) {
-  .columns.is-variable.is-1-touch {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .columns.is-variable.is-1-desktop {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (min-width: 1088px) and (max-width: 1279px) {
-  .columns.is-variable.is-1-desktop-only {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .columns.is-variable.is-1-widescreen {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (min-width: 1280px) and (max-width: 1471px) {
-  .columns.is-variable.is-1-widescreen-only {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .columns.is-variable.is-1-fullhd {
-    --columnGap: 0.25rem;
-  }
-}
-.columns.is-variable.is-2 {
-  --columnGap: 0.5rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-2-mobile {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-2-tablet {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1087px) {
-  .columns.is-variable.is-2-tablet-only {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (max-width: 1087px) {
-  .columns.is-variable.is-2-touch {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .columns.is-variable.is-2-desktop {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (min-width: 1088px) and (max-width: 1279px) {
-  .columns.is-variable.is-2-desktop-only {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .columns.is-variable.is-2-widescreen {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (min-width: 1280px) and (max-width: 1471px) {
-  .columns.is-variable.is-2-widescreen-only {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .columns.is-variable.is-2-fullhd {
-    --columnGap: 0.5rem;
-  }
-}
-.columns.is-variable.is-3 {
-  --columnGap: 0.75rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-3-mobile {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-3-tablet {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1087px) {
-  .columns.is-variable.is-3-tablet-only {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (max-width: 1087px) {
-  .columns.is-variable.is-3-touch {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .columns.is-variable.is-3-desktop {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (min-width: 1088px) and (max-width: 1279px) {
-  .columns.is-variable.is-3-desktop-only {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .columns.is-variable.is-3-widescreen {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (min-width: 1280px) and (max-width: 1471px) {
-  .columns.is-variable.is-3-widescreen-only {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .columns.is-variable.is-3-fullhd {
-    --columnGap: 0.75rem;
-  }
-}
-.columns.is-variable.is-4 {
-  --columnGap: 1rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-4-mobile {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-4-tablet {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1087px) {
-  .columns.is-variable.is-4-tablet-only {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (max-width: 1087px) {
-  .columns.is-variable.is-4-touch {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .columns.is-variable.is-4-desktop {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (min-width: 1088px) and (max-width: 1279px) {
-  .columns.is-variable.is-4-desktop-only {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .columns.is-variable.is-4-widescreen {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (min-width: 1280px) and (max-width: 1471px) {
-  .columns.is-variable.is-4-widescreen-only {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .columns.is-variable.is-4-fullhd {
-    --columnGap: 1rem;
-  }
-}
-.columns.is-variable.is-5 {
-  --columnGap: 1.25rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-5-mobile {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-5-tablet {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1087px) {
-  .columns.is-variable.is-5-tablet-only {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (max-width: 1087px) {
-  .columns.is-variable.is-5-touch {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .columns.is-variable.is-5-desktop {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (min-width: 1088px) and (max-width: 1279px) {
-  .columns.is-variable.is-5-desktop-only {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .columns.is-variable.is-5-widescreen {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (min-width: 1280px) and (max-width: 1471px) {
-  .columns.is-variable.is-5-widescreen-only {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .columns.is-variable.is-5-fullhd {
-    --columnGap: 1.25rem;
-  }
-}
-.columns.is-variable.is-6 {
-  --columnGap: 1.5rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-6-mobile {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-6-tablet {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1087px) {
-  .columns.is-variable.is-6-tablet-only {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (max-width: 1087px) {
-  .columns.is-variable.is-6-touch {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .columns.is-variable.is-6-desktop {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (min-width: 1088px) and (max-width: 1279px) {
-  .columns.is-variable.is-6-desktop-only {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .columns.is-variable.is-6-widescreen {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (min-width: 1280px) and (max-width: 1471px) {
-  .columns.is-variable.is-6-widescreen-only {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .columns.is-variable.is-6-fullhd {
-    --columnGap: 1.5rem;
-  }
-}
-.columns.is-variable.is-7 {
-  --columnGap: 1.75rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-7-mobile {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-7-tablet {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1087px) {
-  .columns.is-variable.is-7-tablet-only {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (max-width: 1087px) {
-  .columns.is-variable.is-7-touch {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .columns.is-variable.is-7-desktop {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (min-width: 1088px) and (max-width: 1279px) {
-  .columns.is-variable.is-7-desktop-only {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .columns.is-variable.is-7-widescreen {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (min-width: 1280px) and (max-width: 1471px) {
-  .columns.is-variable.is-7-widescreen-only {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .columns.is-variable.is-7-fullhd {
-    --columnGap: 1.75rem;
-  }
-}
-.columns.is-variable.is-8 {
-  --columnGap: 2rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-8-mobile {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-8-tablet {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1087px) {
-  .columns.is-variable.is-8-tablet-only {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (max-width: 1087px) {
-  .columns.is-variable.is-8-touch {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (min-width: 1088px) {
-  .columns.is-variable.is-8-desktop {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (min-width: 1088px) and (max-width: 1279px) {
-  .columns.is-variable.is-8-desktop-only {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (min-width: 1280px) {
-  .columns.is-variable.is-8-widescreen {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (min-width: 1280px) and (max-width: 1471px) {
-  .columns.is-variable.is-8-widescreen-only {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (min-width: 1472px) {
-  .columns.is-variable.is-8-fullhd {
-    --columnGap: 2rem;
-  }
-}
-
+  margin-right: calc(-1 * var(--columnGap)); }
+  .columns.is-variable .column {
+    padding-left: var(--columnGap);
+    padding-right: var(--columnGap); }
+  .columns.is-variable.is-0 {
+    --columnGap: 0rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-0-mobile {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-0-tablet {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1087px) {
+    .columns.is-variable.is-0-tablet-only {
+      --columnGap: 0rem; } }
+  @media screen and (max-width: 1087px) {
+    .columns.is-variable.is-0-touch {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1088px) {
+    .columns.is-variable.is-0-desktop {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1088px) and (max-width: 1279px) {
+    .columns.is-variable.is-0-desktop-only {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1280px) {
+    .columns.is-variable.is-0-widescreen {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1280px) and (max-width: 1471px) {
+    .columns.is-variable.is-0-widescreen-only {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1472px) {
+    .columns.is-variable.is-0-fullhd {
+      --columnGap: 0rem; } }
+  .columns.is-variable.is-1 {
+    --columnGap: 0.25rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-1-mobile {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-1-tablet {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1087px) {
+    .columns.is-variable.is-1-tablet-only {
+      --columnGap: 0.25rem; } }
+  @media screen and (max-width: 1087px) {
+    .columns.is-variable.is-1-touch {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1088px) {
+    .columns.is-variable.is-1-desktop {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1088px) and (max-width: 1279px) {
+    .columns.is-variable.is-1-desktop-only {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1280px) {
+    .columns.is-variable.is-1-widescreen {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1280px) and (max-width: 1471px) {
+    .columns.is-variable.is-1-widescreen-only {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1472px) {
+    .columns.is-variable.is-1-fullhd {
+      --columnGap: 0.25rem; } }
+  .columns.is-variable.is-2 {
+    --columnGap: 0.5rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-2-mobile {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-2-tablet {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1087px) {
+    .columns.is-variable.is-2-tablet-only {
+      --columnGap: 0.5rem; } }
+  @media screen and (max-width: 1087px) {
+    .columns.is-variable.is-2-touch {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1088px) {
+    .columns.is-variable.is-2-desktop {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1088px) and (max-width: 1279px) {
+    .columns.is-variable.is-2-desktop-only {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1280px) {
+    .columns.is-variable.is-2-widescreen {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1280px) and (max-width: 1471px) {
+    .columns.is-variable.is-2-widescreen-only {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1472px) {
+    .columns.is-variable.is-2-fullhd {
+      --columnGap: 0.5rem; } }
+  .columns.is-variable.is-3 {
+    --columnGap: 0.75rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-3-mobile {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-3-tablet {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1087px) {
+    .columns.is-variable.is-3-tablet-only {
+      --columnGap: 0.75rem; } }
+  @media screen and (max-width: 1087px) {
+    .columns.is-variable.is-3-touch {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1088px) {
+    .columns.is-variable.is-3-desktop {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1088px) and (max-width: 1279px) {
+    .columns.is-variable.is-3-desktop-only {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1280px) {
+    .columns.is-variable.is-3-widescreen {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1280px) and (max-width: 1471px) {
+    .columns.is-variable.is-3-widescreen-only {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1472px) {
+    .columns.is-variable.is-3-fullhd {
+      --columnGap: 0.75rem; } }
+  .columns.is-variable.is-4 {
+    --columnGap: 1rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-4-mobile {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-4-tablet {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1087px) {
+    .columns.is-variable.is-4-tablet-only {
+      --columnGap: 1rem; } }
+  @media screen and (max-width: 1087px) {
+    .columns.is-variable.is-4-touch {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1088px) {
+    .columns.is-variable.is-4-desktop {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1088px) and (max-width: 1279px) {
+    .columns.is-variable.is-4-desktop-only {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1280px) {
+    .columns.is-variable.is-4-widescreen {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1280px) and (max-width: 1471px) {
+    .columns.is-variable.is-4-widescreen-only {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1472px) {
+    .columns.is-variable.is-4-fullhd {
+      --columnGap: 1rem; } }
+  .columns.is-variable.is-5 {
+    --columnGap: 1.25rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-5-mobile {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-5-tablet {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1087px) {
+    .columns.is-variable.is-5-tablet-only {
+      --columnGap: 1.25rem; } }
+  @media screen and (max-width: 1087px) {
+    .columns.is-variable.is-5-touch {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1088px) {
+    .columns.is-variable.is-5-desktop {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1088px) and (max-width: 1279px) {
+    .columns.is-variable.is-5-desktop-only {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1280px) {
+    .columns.is-variable.is-5-widescreen {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1280px) and (max-width: 1471px) {
+    .columns.is-variable.is-5-widescreen-only {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1472px) {
+    .columns.is-variable.is-5-fullhd {
+      --columnGap: 1.25rem; } }
+  .columns.is-variable.is-6 {
+    --columnGap: 1.5rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-6-mobile {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-6-tablet {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1087px) {
+    .columns.is-variable.is-6-tablet-only {
+      --columnGap: 1.5rem; } }
+  @media screen and (max-width: 1087px) {
+    .columns.is-variable.is-6-touch {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1088px) {
+    .columns.is-variable.is-6-desktop {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1088px) and (max-width: 1279px) {
+    .columns.is-variable.is-6-desktop-only {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1280px) {
+    .columns.is-variable.is-6-widescreen {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1280px) and (max-width: 1471px) {
+    .columns.is-variable.is-6-widescreen-only {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1472px) {
+    .columns.is-variable.is-6-fullhd {
+      --columnGap: 1.5rem; } }
+  .columns.is-variable.is-7 {
+    --columnGap: 1.75rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-7-mobile {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-7-tablet {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1087px) {
+    .columns.is-variable.is-7-tablet-only {
+      --columnGap: 1.75rem; } }
+  @media screen and (max-width: 1087px) {
+    .columns.is-variable.is-7-touch {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1088px) {
+    .columns.is-variable.is-7-desktop {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1088px) and (max-width: 1279px) {
+    .columns.is-variable.is-7-desktop-only {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1280px) {
+    .columns.is-variable.is-7-widescreen {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1280px) and (max-width: 1471px) {
+    .columns.is-variable.is-7-widescreen-only {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1472px) {
+    .columns.is-variable.is-7-fullhd {
+      --columnGap: 1.75rem; } }
+  .columns.is-variable.is-8 {
+    --columnGap: 2rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-8-mobile {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-8-tablet {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1087px) {
+    .columns.is-variable.is-8-tablet-only {
+      --columnGap: 2rem; } }
+  @media screen and (max-width: 1087px) {
+    .columns.is-variable.is-8-touch {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1088px) {
+    .columns.is-variable.is-8-desktop {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1088px) and (max-width: 1279px) {
+    .columns.is-variable.is-8-desktop-only {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1280px) {
+    .columns.is-variable.is-8-widescreen {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1280px) and (max-width: 1471px) {
+    .columns.is-variable.is-8-widescreen-only {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1472px) {
+    .columns.is-variable.is-8-fullhd {
+      --columnGap: 2rem; } }
 .tile {
   align-items: stretch;
   display: block;
   flex-basis: 0;
   flex-grow: 1;
   flex-shrink: 1;
-  min-height: min-content;
-}
-.tile.is-ancestor {
-  margin-left: -0.75rem;
-  margin-right: -0.75rem;
-  margin-top: -0.75rem;
-}
-.tile.is-ancestor:last-child {
-  margin-bottom: -0.75rem;
-}
-.tile.is-ancestor:not(:last-child) {
-  margin-bottom: 0.75rem;
-}
-.tile.is-child {
-  margin: 0 !important;
-}
-.tile.is-parent {
-  padding: 0.75rem;
-}
-.tile.is-vertical {
-  flex-direction: column;
-}
-.tile.is-vertical > .tile.is-child:not(:last-child) {
-  margin-bottom: 1.5rem !important;
-}
-@media screen and (min-width: 769px), print {
-  .tile:not(.is-child) {
-    display: flex;
-  }
-  .tile.is-1 {
-    flex: none;
-    width: 8.3333333333%;
-  }
-  .tile.is-2 {
-    flex: none;
-    width: 16.6666666667%;
-  }
-  .tile.is-3 {
-    flex: none;
-    width: 25%;
-  }
-  .tile.is-4 {
-    flex: none;
-    width: 33.3333333333%;
-  }
-  .tile.is-5 {
-    flex: none;
-    width: 41.6666666667%;
-  }
-  .tile.is-6 {
-    flex: none;
-    width: 50%;
-  }
-  .tile.is-7 {
-    flex: none;
-    width: 58.3333333333%;
-  }
-  .tile.is-8 {
-    flex: none;
-    width: 66.6666666667%;
-  }
-  .tile.is-9 {
-    flex: none;
-    width: 75%;
-  }
-  .tile.is-10 {
-    flex: none;
-    width: 83.3333333333%;
-  }
-  .tile.is-11 {
-    flex: none;
-    width: 91.6666666667%;
-  }
-  .tile.is-12 {
-    flex: none;
-    width: 100%;
-  }
-}
-
+  min-height: min-content; }
+  .tile.is-ancestor {
+    margin-left: -0.75rem;
+    margin-right: -0.75rem;
+    margin-top: -0.75rem; }
+    .tile.is-ancestor:last-child {
+      margin-bottom: -0.75rem; }
+    .tile.is-ancestor:not(:last-child) {
+      margin-bottom: 0.75rem; }
+  .tile.is-child {
+    margin: 0 !important; }
+  .tile.is-parent {
+    padding: 0.75rem; }
+  .tile.is-vertical {
+    flex-direction: column; }
+    .tile.is-vertical > .tile.is-child:not(:last-child) {
+      margin-bottom: 1.5rem !important; }
+  @media screen and (min-width: 769px), print {
+    .tile:not(.is-child) {
+      display: flex; }
+    .tile.is-1 {
+      flex: none;
+      width: 8.33333%; }
+    .tile.is-2 {
+      flex: none;
+      width: 16.66667%; }
+    .tile.is-3 {
+      flex: none;
+      width: 25%; }
+    .tile.is-4 {
+      flex: none;
+      width: 33.33333%; }
+    .tile.is-5 {
+      flex: none;
+      width: 41.66667%; }
+    .tile.is-6 {
+      flex: none;
+      width: 50%; }
+    .tile.is-7 {
+      flex: none;
+      width: 58.33333%; }
+    .tile.is-8 {
+      flex: none;
+      width: 66.66667%; }
+    .tile.is-9 {
+      flex: none;
+      width: 75%; }
+    .tile.is-10 {
+      flex: none;
+      width: 83.33333%; }
+    .tile.is-11 {
+      flex: none;
+      width: 91.66667%; }
+    .tile.is-12 {
+      flex: none;
+      width: 100%; } }
 .hero {
   align-items: stretch;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-}
-.hero .navbar {
-  background: none;
-}
-.hero .tabs ul {
-  border-bottom: none;
-}
-.hero.is-white {
-  background-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 4%);
-}
-.hero.is-white a:not(.button):not(.dropdown-item):not(.tag),
-.hero.is-white strong {
-  color: inherit;
-}
-.hero.is-white .title {
-  color: hsl(0deg, 0%, 4%);
-}
-.hero.is-white .subtitle {
-  color: rgba(10, 10, 10, 0.9);
-}
-.hero.is-white .subtitle a:not(.button),
-.hero.is-white .subtitle strong {
-  color: hsl(0deg, 0%, 4%);
-}
-@media screen and (max-width: 1087px) {
-  .hero.is-white .navbar-menu {
-    background-color: hsl(0deg, 0%, 100%);
-  }
-}
-.hero.is-white .navbar-item,
-.hero.is-white .navbar-link {
-  color: rgba(10, 10, 10, 0.7);
-}
-.hero.is-white a.navbar-item:hover, .hero.is-white a.navbar-item.is-active,
-.hero.is-white .navbar-link:hover,
-.hero.is-white .navbar-link.is-active {
-  background-color: #f2f2f2;
-  color: hsl(0deg, 0%, 4%);
-}
-.hero.is-white .tabs a {
-  color: hsl(0deg, 0%, 4%);
-  opacity: 0.9;
-}
-.hero.is-white .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-white .tabs li.is-active a {
-  opacity: 1;
-}
-.hero.is-white .tabs.is-boxed a, .hero.is-white .tabs.is-toggle a {
-  color: hsl(0deg, 0%, 4%);
-}
-.hero.is-white .tabs.is-boxed a:hover, .hero.is-white .tabs.is-toggle a:hover {
-  background-color: rgba(10, 10, 10, 0.1);
-}
-.hero.is-white .tabs.is-boxed li.is-active a, .hero.is-white .tabs.is-boxed li.is-active a:hover, .hero.is-white .tabs.is-toggle li.is-active a, .hero.is-white .tabs.is-toggle li.is-active a:hover {
-  background-color: hsl(0deg, 0%, 4%);
-  border-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 100%);
-}
-.hero.is-white.is-bold {
-  background-image: linear-gradient(141deg, #e8e3e4 0%, hsl(0deg, 0%, 100%) 71%, white 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-white.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #e8e3e4 0%, hsl(0deg, 0%, 100%) 71%, white 100%);
-  }
-}
-.hero.is-black {
-  background-color: hsl(0deg, 0%, 4%);
-  color: hsl(0deg, 0%, 100%);
-}
-.hero.is-black a:not(.button):not(.dropdown-item):not(.tag),
-.hero.is-black strong {
-  color: inherit;
-}
-.hero.is-black .title {
-  color: hsl(0deg, 0%, 100%);
-}
-.hero.is-black .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-black .subtitle a:not(.button),
-.hero.is-black .subtitle strong {
-  color: hsl(0deg, 0%, 100%);
-}
-@media screen and (max-width: 1087px) {
-  .hero.is-black .navbar-menu {
-    background-color: hsl(0deg, 0%, 4%);
-  }
-}
-.hero.is-black .navbar-item,
-.hero.is-black .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-black a.navbar-item:hover, .hero.is-black a.navbar-item.is-active,
-.hero.is-black .navbar-link:hover,
-.hero.is-black .navbar-link.is-active {
-  background-color: black;
-  color: hsl(0deg, 0%, 100%);
-}
-.hero.is-black .tabs a {
-  color: hsl(0deg, 0%, 100%);
-  opacity: 0.9;
-}
-.hero.is-black .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-black .tabs li.is-active a {
-  opacity: 1;
-}
-.hero.is-black .tabs.is-boxed a, .hero.is-black .tabs.is-toggle a {
-  color: hsl(0deg, 0%, 100%);
-}
-.hero.is-black .tabs.is-boxed a:hover, .hero.is-black .tabs.is-toggle a:hover {
-  background-color: rgba(10, 10, 10, 0.1);
-}
-.hero.is-black .tabs.is-boxed li.is-active a, .hero.is-black .tabs.is-boxed li.is-active a:hover, .hero.is-black .tabs.is-toggle li.is-active a, .hero.is-black .tabs.is-toggle li.is-active a:hover {
-  background-color: hsl(0deg, 0%, 100%);
-  border-color: hsl(0deg, 0%, 100%);
-  color: hsl(0deg, 0%, 4%);
-}
-.hero.is-black.is-bold {
-  background-image: linear-gradient(141deg, black 0%, hsl(0deg, 0%, 4%) 71%, #181616 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-black.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, black 0%, hsl(0deg, 0%, 4%) 71%, #181616 100%);
-  }
-}
-.hero.is-light {
-  background-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.hero.is-light a:not(.button):not(.dropdown-item):not(.tag),
-.hero.is-light strong {
-  color: inherit;
-}
-.hero.is-light .title {
-  color: #2d2d2d;
-}
-.hero.is-light .subtitle {
-  color: rgba(45, 45, 45, 0.9);
-}
-.hero.is-light .subtitle a:not(.button),
-.hero.is-light .subtitle strong {
-  color: #2d2d2d;
-}
-@media screen and (max-width: 1087px) {
-  .hero.is-light .navbar-menu {
-    background-color: hsl(0deg, 0%, 96%);
-  }
-}
-.hero.is-light .navbar-item,
-.hero.is-light .navbar-link {
-  color: rgba(45, 45, 45, 0.7);
-}
-.hero.is-light a.navbar-item:hover, .hero.is-light a.navbar-item.is-active,
-.hero.is-light .navbar-link:hover,
-.hero.is-light .navbar-link.is-active {
-  background-color: #e8e8e8;
-  color: #2d2d2d;
-}
-.hero.is-light .tabs a {
-  color: #2d2d2d;
-  opacity: 0.9;
-}
-.hero.is-light .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-light .tabs li.is-active a {
-  opacity: 1;
-}
-.hero.is-light .tabs.is-boxed a, .hero.is-light .tabs.is-toggle a {
-  color: #2d2d2d;
-}
-.hero.is-light .tabs.is-boxed a:hover, .hero.is-light .tabs.is-toggle a:hover {
-  background-color: rgba(10, 10, 10, 0.1);
-}
-.hero.is-light .tabs.is-boxed li.is-active a, .hero.is-light .tabs.is-boxed li.is-active a:hover, .hero.is-light .tabs.is-toggle li.is-active a, .hero.is-light .tabs.is-toggle li.is-active a:hover {
-  background-color: #2d2d2d;
-  border-color: #2d2d2d;
-  color: hsl(0deg, 0%, 96%);
-}
-.hero.is-light.is-bold {
-  background-image: linear-gradient(141deg, #dfd8d9 0%, hsl(0deg, 0%, 96%) 71%, white 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-light.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #dfd8d9 0%, hsl(0deg, 0%, 96%) 71%, white 100%);
-  }
-}
-.hero.is-dark {
-  background-color: #2d2d2d;
-  color: hsl(0deg, 0%, 96%);
-}
-.hero.is-dark a:not(.button):not(.dropdown-item):not(.tag),
-.hero.is-dark strong {
-  color: inherit;
-}
-.hero.is-dark .title {
-  color: hsl(0deg, 0%, 96%);
-}
-.hero.is-dark .subtitle {
-  color: rgba(245, 245, 245, 0.9);
-}
-.hero.is-dark .subtitle a:not(.button),
-.hero.is-dark .subtitle strong {
-  color: hsl(0deg, 0%, 96%);
-}
-@media screen and (max-width: 1087px) {
-  .hero.is-dark .navbar-menu {
+  justify-content: space-between; }
+  .hero .navbar {
+    background: none; }
+  .hero .tabs ul {
+    border-bottom: none; }
+  .hero.is-white {
+    background-color: white;
+    color: #0a0a0a; }
+    .hero.is-white a:not(.button):not(.dropdown-item):not(.tag),
+    .hero.is-white strong {
+      color: inherit; }
+    .hero.is-white .title {
+      color: #0a0a0a; }
+    .hero.is-white .subtitle {
+      color: rgba(10, 10, 10, 0.9); }
+      .hero.is-white .subtitle a:not(.button),
+      .hero.is-white .subtitle strong {
+        color: #0a0a0a; }
+    @media screen and (max-width: 1087px) {
+      .hero.is-white .navbar-menu {
+        background-color: white; } }
+    .hero.is-white .navbar-item,
+    .hero.is-white .navbar-link {
+      color: rgba(10, 10, 10, 0.7); }
+    .hero.is-white a.navbar-item:hover, .hero.is-white a.navbar-item.is-active,
+    .hero.is-white .navbar-link:hover,
+    .hero.is-white .navbar-link.is-active {
+      background-color: #f2f2f2;
+      color: #0a0a0a; }
+    .hero.is-white .tabs a {
+      color: #0a0a0a;
+      opacity: 0.9; }
+      .hero.is-white .tabs a:hover {
+        opacity: 1; }
+    .hero.is-white .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-white .tabs.is-boxed a, .hero.is-white .tabs.is-toggle a {
+      color: #0a0a0a; }
+      .hero.is-white .tabs.is-boxed a:hover, .hero.is-white .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-white .tabs.is-boxed li.is-active a, .hero.is-white .tabs.is-boxed li.is-active a:hover, .hero.is-white .tabs.is-toggle li.is-active a, .hero.is-white .tabs.is-toggle li.is-active a:hover {
+      background-color: #0a0a0a;
+      border-color: #0a0a0a;
+      color: white; }
+    .hero.is-white.is-bold {
+      background-image: linear-gradient(141deg, #e8e3e4 0%, white 71%, white 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-white.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #e8e3e4 0%, white 71%, white 100%); } }
+  .hero.is-black {
+    background-color: #0a0a0a;
+    color: white; }
+    .hero.is-black a:not(.button):not(.dropdown-item):not(.tag),
+    .hero.is-black strong {
+      color: inherit; }
+    .hero.is-black .title {
+      color: white; }
+    .hero.is-black .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-black .subtitle a:not(.button),
+      .hero.is-black .subtitle strong {
+        color: white; }
+    @media screen and (max-width: 1087px) {
+      .hero.is-black .navbar-menu {
+        background-color: #0a0a0a; } }
+    .hero.is-black .navbar-item,
+    .hero.is-black .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-black a.navbar-item:hover, .hero.is-black a.navbar-item.is-active,
+    .hero.is-black .navbar-link:hover,
+    .hero.is-black .navbar-link.is-active {
+      background-color: black;
+      color: white; }
+    .hero.is-black .tabs a {
+      color: white;
+      opacity: 0.9; }
+      .hero.is-black .tabs a:hover {
+        opacity: 1; }
+    .hero.is-black .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-black .tabs.is-boxed a, .hero.is-black .tabs.is-toggle a {
+      color: white; }
+      .hero.is-black .tabs.is-boxed a:hover, .hero.is-black .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-black .tabs.is-boxed li.is-active a, .hero.is-black .tabs.is-boxed li.is-active a:hover, .hero.is-black .tabs.is-toggle li.is-active a, .hero.is-black .tabs.is-toggle li.is-active a:hover {
+      background-color: white;
+      border-color: white;
+      color: #0a0a0a; }
+    .hero.is-black.is-bold {
+      background-image: linear-gradient(141deg, black 0%, #0a0a0a 71%, #181616 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-black.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, black 0%, #0a0a0a 71%, #181616 100%); } }
+  .hero.is-light {
+    background-color: whitesmoke;
+    color: #2d2d2d; }
+    .hero.is-light a:not(.button):not(.dropdown-item):not(.tag),
+    .hero.is-light strong {
+      color: inherit; }
+    .hero.is-light .title {
+      color: #2d2d2d; }
+    .hero.is-light .subtitle {
+      color: rgba(45, 45, 45, 0.9); }
+      .hero.is-light .subtitle a:not(.button),
+      .hero.is-light .subtitle strong {
+        color: #2d2d2d; }
+    @media screen and (max-width: 1087px) {
+      .hero.is-light .navbar-menu {
+        background-color: whitesmoke; } }
+    .hero.is-light .navbar-item,
+    .hero.is-light .navbar-link {
+      color: rgba(45, 45, 45, 0.7); }
+    .hero.is-light a.navbar-item:hover, .hero.is-light a.navbar-item.is-active,
+    .hero.is-light .navbar-link:hover,
+    .hero.is-light .navbar-link.is-active {
+      background-color: #e8e8e8;
+      color: #2d2d2d; }
+    .hero.is-light .tabs a {
+      color: #2d2d2d;
+      opacity: 0.9; }
+      .hero.is-light .tabs a:hover {
+        opacity: 1; }
+    .hero.is-light .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-light .tabs.is-boxed a, .hero.is-light .tabs.is-toggle a {
+      color: #2d2d2d; }
+      .hero.is-light .tabs.is-boxed a:hover, .hero.is-light .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-light .tabs.is-boxed li.is-active a, .hero.is-light .tabs.is-boxed li.is-active a:hover, .hero.is-light .tabs.is-toggle li.is-active a, .hero.is-light .tabs.is-toggle li.is-active a:hover {
+      background-color: #2d2d2d;
+      border-color: #2d2d2d;
+      color: whitesmoke; }
+    .hero.is-light.is-bold {
+      background-image: linear-gradient(141deg, #dfd8d9 0%, whitesmoke 71%, white 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-light.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #dfd8d9 0%, whitesmoke 71%, white 100%); } }
+  .hero.is-dark {
     background-color: #2d2d2d;
-  }
-}
-.hero.is-dark .navbar-item,
-.hero.is-dark .navbar-link {
-  color: rgba(245, 245, 245, 0.7);
-}
-.hero.is-dark a.navbar-item:hover, .hero.is-dark a.navbar-item.is-active,
-.hero.is-dark .navbar-link:hover,
-.hero.is-dark .navbar-link.is-active {
-  background-color: #202020;
-  color: hsl(0deg, 0%, 96%);
-}
-.hero.is-dark .tabs a {
-  color: hsl(0deg, 0%, 96%);
-  opacity: 0.9;
-}
-.hero.is-dark .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-dark .tabs li.is-active a {
-  opacity: 1;
-}
-.hero.is-dark .tabs.is-boxed a, .hero.is-dark .tabs.is-toggle a {
-  color: hsl(0deg, 0%, 96%);
-}
-.hero.is-dark .tabs.is-boxed a:hover, .hero.is-dark .tabs.is-toggle a:hover {
-  background-color: rgba(10, 10, 10, 0.1);
-}
-.hero.is-dark .tabs.is-boxed li.is-active a, .hero.is-dark .tabs.is-boxed li.is-active a:hover, .hero.is-dark .tabs.is-toggle li.is-active a, .hero.is-dark .tabs.is-toggle li.is-active a:hover {
-  background-color: hsl(0deg, 0%, 96%);
-  border-color: hsl(0deg, 0%, 96%);
-  color: #2d2d2d;
-}
-.hero.is-dark.is-bold {
-  background-image: linear-gradient(141deg, #151212 0%, #2d2d2d 71%, #3d3837 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-dark.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #151212 0%, #2d2d2d 71%, #3d3837 100%);
-  }
-}
-.hero.is-primary {
-  background-color: #b31b1b;
-  color: #fff;
-}
-.hero.is-primary a:not(.button):not(.dropdown-item):not(.tag),
-.hero.is-primary strong {
-  color: inherit;
-}
-.hero.is-primary .title {
-  color: #fff;
-}
-.hero.is-primary .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-primary .subtitle a:not(.button),
-.hero.is-primary .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1087px) {
-  .hero.is-primary .navbar-menu {
+    color: whitesmoke; }
+    .hero.is-dark a:not(.button):not(.dropdown-item):not(.tag),
+    .hero.is-dark strong {
+      color: inherit; }
+    .hero.is-dark .title {
+      color: whitesmoke; }
+    .hero.is-dark .subtitle {
+      color: rgba(245, 245, 245, 0.9); }
+      .hero.is-dark .subtitle a:not(.button),
+      .hero.is-dark .subtitle strong {
+        color: whitesmoke; }
+    @media screen and (max-width: 1087px) {
+      .hero.is-dark .navbar-menu {
+        background-color: #2d2d2d; } }
+    .hero.is-dark .navbar-item,
+    .hero.is-dark .navbar-link {
+      color: rgba(245, 245, 245, 0.7); }
+    .hero.is-dark a.navbar-item:hover, .hero.is-dark a.navbar-item.is-active,
+    .hero.is-dark .navbar-link:hover,
+    .hero.is-dark .navbar-link.is-active {
+      background-color: #202020;
+      color: whitesmoke; }
+    .hero.is-dark .tabs a {
+      color: whitesmoke;
+      opacity: 0.9; }
+      .hero.is-dark .tabs a:hover {
+        opacity: 1; }
+    .hero.is-dark .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-dark .tabs.is-boxed a, .hero.is-dark .tabs.is-toggle a {
+      color: whitesmoke; }
+      .hero.is-dark .tabs.is-boxed a:hover, .hero.is-dark .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-dark .tabs.is-boxed li.is-active a, .hero.is-dark .tabs.is-boxed li.is-active a:hover, .hero.is-dark .tabs.is-toggle li.is-active a, .hero.is-dark .tabs.is-toggle li.is-active a:hover {
+      background-color: whitesmoke;
+      border-color: whitesmoke;
+      color: #2d2d2d; }
+    .hero.is-dark.is-bold {
+      background-image: linear-gradient(141deg, #151212 0%, #2d2d2d 71%, #3d3837 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-dark.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #151212 0%, #2d2d2d 71%, #3d3837 100%); } }
+  .hero.is-primary {
     background-color: #b31b1b;
-  }
-}
-.hero.is-primary .navbar-item,
-.hero.is-primary .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-primary a.navbar-item:hover, .hero.is-primary a.navbar-item.is-active,
-.hero.is-primary .navbar-link:hover,
-.hero.is-primary .navbar-link.is-active {
-  background-color: #9d1818;
-  color: #fff;
-}
-.hero.is-primary .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-primary .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-primary .tabs li.is-active a {
-  opacity: 1;
-}
-.hero.is-primary .tabs.is-boxed a, .hero.is-primary .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-primary .tabs.is-boxed a:hover, .hero.is-primary .tabs.is-toggle a:hover {
-  background-color: rgba(10, 10, 10, 0.1);
-}
-.hero.is-primary .tabs.is-boxed li.is-active a, .hero.is-primary .tabs.is-boxed li.is-active a:hover, .hero.is-primary .tabs.is-toggle li.is-active a, .hero.is-primary .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: #b31b1b;
-}
-.hero.is-primary.is-bold {
-  background-image: linear-gradient(141deg, #8e0d22 0%, #b31b1b 71%, #cf3719 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-primary.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #8e0d22 0%, #b31b1b 71%, #cf3719 100%);
-  }
-}
-.hero.is-link {
-  background-color: #086db1;
-  color: #fff;
-}
-.hero.is-link a:not(.button):not(.dropdown-item):not(.tag),
-.hero.is-link strong {
-  color: inherit;
-}
-.hero.is-link .title {
-  color: #fff;
-}
-.hero.is-link .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-link .subtitle a:not(.button),
-.hero.is-link .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1087px) {
-  .hero.is-link .navbar-menu {
-    background-color: #086db1;
-  }
-}
-.hero.is-link .navbar-item,
-.hero.is-link .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-link a.navbar-item:hover, .hero.is-link a.navbar-item.is-active,
-.hero.is-link .navbar-link:hover,
-.hero.is-link .navbar-link.is-active {
-  background-color: #075e99;
-  color: #fff;
-}
-.hero.is-link .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-link .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-link .tabs li.is-active a {
-  opacity: 1;
-}
-.hero.is-link .tabs.is-boxed a, .hero.is-link .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-link .tabs.is-boxed a:hover, .hero.is-link .tabs.is-toggle a:hover {
-  background-color: rgba(10, 10, 10, 0.1);
-}
-.hero.is-link .tabs.is-boxed li.is-active a, .hero.is-link .tabs.is-boxed li.is-active a:hover, .hero.is-link .tabs.is-toggle li.is-active a, .hero.is-link .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: #086db1;
-}
-.hero.is-link.is-bold {
-  background-image: linear-gradient(141deg, #006686 0%, #086db1 71%, #045bcf 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-link.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #006686 0%, #086db1 71%, #045bcf 100%);
-  }
-}
-.hero.is-info {
-  background-color: hsl(204deg, 86%, 53%);
-  color: #fff;
-}
-.hero.is-info a:not(.button):not(.dropdown-item):not(.tag),
-.hero.is-info strong {
-  color: inherit;
-}
-.hero.is-info .title {
-  color: #fff;
-}
-.hero.is-info .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-info .subtitle a:not(.button),
-.hero.is-info .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1087px) {
-  .hero.is-info .navbar-menu {
-    background-color: hsl(204deg, 86%, 53%);
-  }
-}
-.hero.is-info .navbar-item,
-.hero.is-info .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-info a.navbar-item:hover, .hero.is-info a.navbar-item.is-active,
-.hero.is-info .navbar-link:hover,
-.hero.is-info .navbar-link.is-active {
-  background-color: #118fe4;
-  color: #fff;
-}
-.hero.is-info .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-info .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-info .tabs li.is-active a {
-  opacity: 1;
-}
-.hero.is-info .tabs.is-boxed a, .hero.is-info .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-info .tabs.is-boxed a:hover, .hero.is-info .tabs.is-toggle a:hover {
-  background-color: rgba(10, 10, 10, 0.1);
-}
-.hero.is-info .tabs.is-boxed li.is-active a, .hero.is-info .tabs.is-boxed li.is-active a:hover, .hero.is-info .tabs.is-toggle li.is-active a, .hero.is-info .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: hsl(204deg, 86%, 53%);
-}
-.hero.is-info.is-bold {
-  background-image: linear-gradient(141deg, #04a6d7 0%, hsl(204deg, 86%, 53%) 71%, #3287f5 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-info.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #04a6d7 0%, hsl(204deg, 86%, 53%) 71%, #3287f5 100%);
-  }
-}
-.hero.is-success {
-  background-color: #008412;
-  color: #fff;
-}
-.hero.is-success a:not(.button):not(.dropdown-item):not(.tag),
-.hero.is-success strong {
-  color: inherit;
-}
-.hero.is-success .title {
-  color: #fff;
-}
-.hero.is-success .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-success .subtitle a:not(.button),
-.hero.is-success .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1087px) {
-  .hero.is-success .navbar-menu {
+    color: #fff; }
+    .hero.is-primary a:not(.button):not(.dropdown-item):not(.tag),
+    .hero.is-primary strong {
+      color: inherit; }
+    .hero.is-primary .title {
+      color: #fff; }
+    .hero.is-primary .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-primary .subtitle a:not(.button),
+      .hero.is-primary .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1087px) {
+      .hero.is-primary .navbar-menu {
+        background-color: #b31b1b; } }
+    .hero.is-primary .navbar-item,
+    .hero.is-primary .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-primary a.navbar-item:hover, .hero.is-primary a.navbar-item.is-active,
+    .hero.is-primary .navbar-link:hover,
+    .hero.is-primary .navbar-link.is-active {
+      background-color: #9d1818;
+      color: #fff; }
+    .hero.is-primary .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-primary .tabs a:hover {
+        opacity: 1; }
+    .hero.is-primary .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-primary .tabs.is-boxed a, .hero.is-primary .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-primary .tabs.is-boxed a:hover, .hero.is-primary .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-primary .tabs.is-boxed li.is-active a, .hero.is-primary .tabs.is-boxed li.is-active a:hover, .hero.is-primary .tabs.is-toggle li.is-active a, .hero.is-primary .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #b31b1b; }
+    .hero.is-primary.is-bold {
+      background-image: linear-gradient(141deg, #8e0d22 0%, #b31b1b 71%, #cf3719 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-primary.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #8e0d22 0%, #b31b1b 71%, #cf3719 100%); } }
+  .hero.is-link {
+    background-color: #1565c0;
+    color: #fff; }
+    .hero.is-link a:not(.button):not(.dropdown-item):not(.tag),
+    .hero.is-link strong {
+      color: inherit; }
+    .hero.is-link .title {
+      color: #fff; }
+    .hero.is-link .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-link .subtitle a:not(.button),
+      .hero.is-link .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1087px) {
+      .hero.is-link .navbar-menu {
+        background-color: #1565c0; } }
+    .hero.is-link .navbar-item,
+    .hero.is-link .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-link a.navbar-item:hover, .hero.is-link a.navbar-item.is-active,
+    .hero.is-link .navbar-link:hover,
+    .hero.is-link .navbar-link.is-active {
+      background-color: #1259a9;
+      color: #fff; }
+    .hero.is-link .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-link .tabs a:hover {
+        opacity: 1; }
+    .hero.is-link .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-link .tabs.is-boxed a, .hero.is-link .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-link .tabs.is-boxed a:hover, .hero.is-link .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-link .tabs.is-boxed li.is-active a, .hero.is-link .tabs.is-boxed li.is-active a:hover, .hero.is-link .tabs.is-toggle li.is-active a, .hero.is-link .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #1565c0; }
+    .hero.is-link.is-bold {
+      background-image: linear-gradient(141deg, #08659a 0%, #1565c0 71%, #124fdd 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-link.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #08659a 0%, #1565c0 71%, #124fdd 100%); } }
+  .hero.is-info {
+    background-color: #209cee;
+    color: #fff; }
+    .hero.is-info a:not(.button):not(.dropdown-item):not(.tag),
+    .hero.is-info strong {
+      color: inherit; }
+    .hero.is-info .title {
+      color: #fff; }
+    .hero.is-info .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-info .subtitle a:not(.button),
+      .hero.is-info .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1087px) {
+      .hero.is-info .navbar-menu {
+        background-color: #209cee; } }
+    .hero.is-info .navbar-item,
+    .hero.is-info .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-info a.navbar-item:hover, .hero.is-info a.navbar-item.is-active,
+    .hero.is-info .navbar-link:hover,
+    .hero.is-info .navbar-link.is-active {
+      background-color: #118fe4;
+      color: #fff; }
+    .hero.is-info .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-info .tabs a:hover {
+        opacity: 1; }
+    .hero.is-info .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-info .tabs.is-boxed a, .hero.is-info .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-info .tabs.is-boxed a:hover, .hero.is-info .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-info .tabs.is-boxed li.is-active a, .hero.is-info .tabs.is-boxed li.is-active a:hover, .hero.is-info .tabs.is-toggle li.is-active a, .hero.is-info .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #209cee; }
+    .hero.is-info.is-bold {
+      background-image: linear-gradient(141deg, #04a6d7 0%, #209cee 71%, #3287f5 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-info.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #04a6d7 0%, #209cee 71%, #3287f5 100%); } }
+  .hero.is-success {
     background-color: #008412;
-  }
-}
-.hero.is-success .navbar-item,
-.hero.is-success .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-success a.navbar-item:hover, .hero.is-success a.navbar-item.is-active,
-.hero.is-success .navbar-link:hover,
-.hero.is-success .navbar-link.is-active {
-  background-color: #006b0f;
-  color: #fff;
-}
-.hero.is-success .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-success .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-success .tabs li.is-active a {
-  opacity: 1;
-}
-.hero.is-success .tabs.is-boxed a, .hero.is-success .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-success .tabs.is-boxed a:hover, .hero.is-success .tabs.is-toggle a:hover {
-  background-color: rgba(10, 10, 10, 0.1);
-}
-.hero.is-success .tabs.is-boxed li.is-active a, .hero.is-success .tabs.is-boxed li.is-active a:hover, .hero.is-success .tabs.is-toggle li.is-active a, .hero.is-success .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: #008412;
-}
-.hero.is-success.is-bold {
-  background-image: linear-gradient(141deg, #025100 0%, #008412 71%, #009e30 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-success.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #025100 0%, #008412 71%, #009e30 100%);
-  }
-}
-.hero.is-warning {
-  background-color: #b55c06;
-  color: #fff;
-}
-.hero.is-warning a:not(.button):not(.dropdown-item):not(.tag),
-.hero.is-warning strong {
-  color: inherit;
-}
-.hero.is-warning .title {
-  color: #fff;
-}
-.hero.is-warning .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-warning .subtitle a:not(.button),
-.hero.is-warning .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1087px) {
-  .hero.is-warning .navbar-menu {
+    color: #fff; }
+    .hero.is-success a:not(.button):not(.dropdown-item):not(.tag),
+    .hero.is-success strong {
+      color: inherit; }
+    .hero.is-success .title {
+      color: #fff; }
+    .hero.is-success .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-success .subtitle a:not(.button),
+      .hero.is-success .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1087px) {
+      .hero.is-success .navbar-menu {
+        background-color: #008412; } }
+    .hero.is-success .navbar-item,
+    .hero.is-success .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-success a.navbar-item:hover, .hero.is-success a.navbar-item.is-active,
+    .hero.is-success .navbar-link:hover,
+    .hero.is-success .navbar-link.is-active {
+      background-color: #006b0f;
+      color: #fff; }
+    .hero.is-success .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-success .tabs a:hover {
+        opacity: 1; }
+    .hero.is-success .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-success .tabs.is-boxed a, .hero.is-success .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-success .tabs.is-boxed a:hover, .hero.is-success .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-success .tabs.is-boxed li.is-active a, .hero.is-success .tabs.is-boxed li.is-active a:hover, .hero.is-success .tabs.is-toggle li.is-active a, .hero.is-success .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #008412; }
+    .hero.is-success.is-bold {
+      background-image: linear-gradient(141deg, #025100 0%, #008412 71%, #009e30 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-success.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #025100 0%, #008412 71%, #009e30 100%); } }
+  .hero.is-warning {
     background-color: #b55c06;
-  }
-}
-.hero.is-warning .navbar-item,
-.hero.is-warning .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-warning a.navbar-item:hover, .hero.is-warning a.navbar-item.is-active,
-.hero.is-warning .navbar-link:hover,
-.hero.is-warning .navbar-link.is-active {
-  background-color: #9c4f05;
-  color: #fff;
-}
-.hero.is-warning .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-warning .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-warning .tabs li.is-active a {
-  opacity: 1;
-}
-.hero.is-warning .tabs.is-boxed a, .hero.is-warning .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-warning .tabs.is-boxed a:hover, .hero.is-warning .tabs.is-toggle a:hover {
-  background-color: rgba(10, 10, 10, 0.1);
-}
-.hero.is-warning .tabs.is-boxed li.is-active a, .hero.is-warning .tabs.is-boxed li.is-active a:hover, .hero.is-warning .tabs.is-toggle li.is-active a, .hero.is-warning .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: #b55c06;
-}
-.hero.is-warning.is-bold {
-  background-image: linear-gradient(141deg, #882c00 0%, #b55c06 71%, #d38b02 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-warning.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #882c00 0%, #b55c06 71%, #d38b02 100%);
-  }
-}
-.hero.is-danger {
-  background-color: #cd0200;
-  color: #fff;
-}
-.hero.is-danger a:not(.button):not(.dropdown-item):not(.tag),
-.hero.is-danger strong {
-  color: inherit;
-}
-.hero.is-danger .title {
-  color: #fff;
-}
-.hero.is-danger .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-danger .subtitle a:not(.button),
-.hero.is-danger .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1087px) {
-  .hero.is-danger .navbar-menu {
+    color: #fff; }
+    .hero.is-warning a:not(.button):not(.dropdown-item):not(.tag),
+    .hero.is-warning strong {
+      color: inherit; }
+    .hero.is-warning .title {
+      color: #fff; }
+    .hero.is-warning .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-warning .subtitle a:not(.button),
+      .hero.is-warning .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1087px) {
+      .hero.is-warning .navbar-menu {
+        background-color: #b55c06; } }
+    .hero.is-warning .navbar-item,
+    .hero.is-warning .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-warning a.navbar-item:hover, .hero.is-warning a.navbar-item.is-active,
+    .hero.is-warning .navbar-link:hover,
+    .hero.is-warning .navbar-link.is-active {
+      background-color: #9c4f05;
+      color: #fff; }
+    .hero.is-warning .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-warning .tabs a:hover {
+        opacity: 1; }
+    .hero.is-warning .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-warning .tabs.is-boxed a, .hero.is-warning .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-warning .tabs.is-boxed a:hover, .hero.is-warning .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-warning .tabs.is-boxed li.is-active a, .hero.is-warning .tabs.is-boxed li.is-active a:hover, .hero.is-warning .tabs.is-toggle li.is-active a, .hero.is-warning .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #b55c06; }
+    .hero.is-warning.is-bold {
+      background-image: linear-gradient(141deg, #882c00 0%, #b55c06 71%, #d38b02 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-warning.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #882c00 0%, #b55c06 71%, #d38b02 100%); } }
+  .hero.is-danger {
     background-color: #cd0200;
-  }
-}
-.hero.is-danger .navbar-item,
-.hero.is-danger .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-danger a.navbar-item:hover, .hero.is-danger a.navbar-item.is-active,
-.hero.is-danger .navbar-link:hover,
-.hero.is-danger .navbar-link.is-active {
-  background-color: #b40200;
-  color: #fff;
-}
-.hero.is-danger .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-danger .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-danger .tabs li.is-active a {
-  opacity: 1;
-}
-.hero.is-danger .tabs.is-boxed a, .hero.is-danger .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-danger .tabs.is-boxed a:hover, .hero.is-danger .tabs.is-toggle a:hover {
-  background-color: rgba(10, 10, 10, 0.1);
-}
-.hero.is-danger .tabs.is-boxed li.is-active a, .hero.is-danger .tabs.is-boxed li.is-active a:hover, .hero.is-danger .tabs.is-toggle li.is-active a, .hero.is-danger .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: #cd0200;
-}
-.hero.is-danger.is-bold {
-  background-image: linear-gradient(141deg, #9a0018 0%, #cd0200 71%, #e72900 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-danger.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #9a0018 0%, #cd0200 71%, #e72900 100%);
-  }
-}
-.hero.is-small .hero-body {
-  padding-bottom: 1.5rem;
-  padding-top: 1.5rem;
-}
-@media screen and (min-width: 769px), print {
-  .hero.is-medium .hero-body {
-    padding-bottom: 9rem;
-    padding-top: 9rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .hero.is-large .hero-body {
-    padding-bottom: 18rem;
-    padding-top: 18rem;
-  }
-}
-.hero.is-halfheight .hero-body, .hero.is-fullheight .hero-body, .hero.is-fullheight-with-navbar .hero-body {
-  align-items: center;
-  display: flex;
-}
-.hero.is-halfheight .hero-body > .container, .hero.is-fullheight .hero-body > .container, .hero.is-fullheight-with-navbar .hero-body > .container {
-  flex-grow: 1;
-  flex-shrink: 1;
-}
-.hero.is-halfheight {
-  min-height: 50vh;
-}
-.hero.is-fullheight {
-  min-height: 100vh;
-}
-.hero.is-fullheight-with-navbar {
-  min-height: calc(100vh - 3.25rem);
-}
+    color: #fff; }
+    .hero.is-danger a:not(.button):not(.dropdown-item):not(.tag),
+    .hero.is-danger strong {
+      color: inherit; }
+    .hero.is-danger .title {
+      color: #fff; }
+    .hero.is-danger .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-danger .subtitle a:not(.button),
+      .hero.is-danger .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1087px) {
+      .hero.is-danger .navbar-menu {
+        background-color: #cd0200; } }
+    .hero.is-danger .navbar-item,
+    .hero.is-danger .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-danger a.navbar-item:hover, .hero.is-danger a.navbar-item.is-active,
+    .hero.is-danger .navbar-link:hover,
+    .hero.is-danger .navbar-link.is-active {
+      background-color: #b40200;
+      color: #fff; }
+    .hero.is-danger .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-danger .tabs a:hover {
+        opacity: 1; }
+    .hero.is-danger .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-danger .tabs.is-boxed a, .hero.is-danger .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-danger .tabs.is-boxed a:hover, .hero.is-danger .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-danger .tabs.is-boxed li.is-active a, .hero.is-danger .tabs.is-boxed li.is-active a:hover, .hero.is-danger .tabs.is-toggle li.is-active a, .hero.is-danger .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #cd0200; }
+    .hero.is-danger.is-bold {
+      background-image: linear-gradient(141deg, #9a0018 0%, #cd0200 71%, #e72900 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-danger.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #9a0018 0%, #cd0200 71%, #e72900 100%); } }
+  .hero.is-small .hero-body {
+    padding-bottom: 1.5rem;
+    padding-top: 1.5rem; }
+  @media screen and (min-width: 769px), print {
+    .hero.is-medium .hero-body {
+      padding-bottom: 9rem;
+      padding-top: 9rem; } }
+  @media screen and (min-width: 769px), print {
+    .hero.is-large .hero-body {
+      padding-bottom: 18rem;
+      padding-top: 18rem; } }
+  .hero.is-halfheight .hero-body, .hero.is-fullheight .hero-body, .hero.is-fullheight-with-navbar .hero-body {
+    align-items: center;
+    display: flex; }
+    .hero.is-halfheight .hero-body > .container, .hero.is-fullheight .hero-body > .container, .hero.is-fullheight-with-navbar .hero-body > .container {
+      flex-grow: 1;
+      flex-shrink: 1; }
+  .hero.is-halfheight {
+    min-height: 50vh; }
+  .hero.is-fullheight {
+    min-height: 100vh; }
+  .hero.is-fullheight-with-navbar {
+    min-height: calc(100vh - 3.25rem); }
 
 .hero-video {
-  overflow: hidden;
-}
-.hero-video video {
-  left: 50%;
-  min-height: 100%;
-  min-width: 100%;
-  position: absolute;
-  top: 50%;
-  transform: translate3d(-50%, -50%, 0);
-}
-.hero-video.is-transparent {
-  opacity: 0.3;
-}
-@media screen and (max-width: 768px) {
-  .hero-video {
-    display: none;
-  }
-}
-
+  overflow: hidden; }
+  .hero-video video {
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    position: absolute;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0); }
+  .hero-video.is-transparent {
+    opacity: 0.3; }
+  @media screen and (max-width: 768px) {
+    .hero-video {
+      display: none; } }
 .hero-buttons {
-  margin-top: 1.5rem;
-}
-@media screen and (max-width: 768px) {
-  .hero-buttons .button {
-    display: flex;
-  }
-  .hero-buttons .button:not(:last-child) {
-    margin-bottom: 0.75rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .hero-buttons {
-    display: flex;
-    justify-content: center;
-  }
-  .hero-buttons .button:not(:last-child) {
-    margin-right: 1.5rem;
-  }
-}
-
+  margin-top: 1.5rem; }
+  @media screen and (max-width: 768px) {
+    .hero-buttons .button {
+      display: flex; }
+      .hero-buttons .button:not(:last-child) {
+        margin-bottom: 0.75rem; } }
+  @media screen and (min-width: 769px), print {
+    .hero-buttons {
+      display: flex;
+      justify-content: center; }
+      .hero-buttons .button:not(:last-child) {
+        margin-right: 1.5rem; } }
 .hero-head,
 .hero-foot {
   flex-grow: 0;
-  flex-shrink: 0;
-}
+  flex-shrink: 0; }
 
 .hero-body {
   flex-grow: 1;
   flex-shrink: 0;
-  padding: 3rem 1.5rem;
-}
+  padding: 3rem 1.5rem; }
 
 .section {
-  padding: 3rem 1.5rem;
-}
-@media screen and (min-width: 1088px) {
-  .section.is-medium {
-    padding: 9rem 1.5rem;
-  }
-  .section.is-large {
-    padding: 18rem 1.5rem;
-  }
-}
-
+  padding: 3rem 1.5rem; }
+  @media screen and (min-width: 1088px) {
+    .section.is-medium {
+      padding: 9rem 1.5rem; }
+    .section.is-large {
+      padding: 18rem 1.5rem; } }
 .footer {
-  background-color: hsl(0deg, 0%, 98%);
-  padding: 3rem 1.5rem 6rem;
-}
+  background-color: #fafafa;
+  padding: 3rem 1.5rem 6rem; }
 
-.switch[type=checkbox] {
+.switch[type="checkbox"] {
   outline: 0;
   user-select: none;
   display: inline-block;
   position: absolute;
-  opacity: 0;
-}
-.switch[type=checkbox]:focus + label::before, .switch[type=checkbox]:focus + label:before, .switch[type=checkbox]:focus + label::after, .switch[type=checkbox]:focus + label:after {
-  outline: 1px dotted hsl(0deg, 0%, 60%);
-}
-.switch[type=checkbox][disabled] {
-  cursor: not-allowed;
-}
-.switch[type=checkbox][disabled] + label {
-  opacity: 0.5;
-}
-.switch[type=checkbox][disabled] + label::before, .switch[type=checkbox][disabled] + label:before {
-  opacity: 0.5;
-}
-.switch[type=checkbox][disabled] + label::after, .switch[type=checkbox][disabled] + label:after {
-  opacity: 0.5;
-}
-.switch[type=checkbox][disabled] + label:hover {
-  cursor: not-allowed;
-}
-.switch[type=checkbox] + label {
-  position: relative;
-  display: initial;
-  font-size: 1rem;
-  line-height: initial;
-  padding-left: 3.5rem;
-  padding-top: 0.2rem;
-  cursor: pointer;
-}
-.switch[type=checkbox] + label::before, .switch[type=checkbox] + label:before {
-  position: absolute;
-  display: block;
-  top: 0;
-  left: 0;
-  width: 3rem;
-  height: 1.5rem;
-  border: 0.1rem solid transparent;
-  border-radius: 4px;
-  background: hsl(0deg, 0%, 60%);
-  content: "";
-}
-.switch[type=checkbox] + label::after, .switch[type=checkbox] + label:after {
-  display: block;
-  position: absolute;
-  top: 0.25rem;
-  left: 0.25rem;
-  width: 1rem;
-  height: 1rem;
-  transform: translate3d(0, 0, 0);
-  border-radius: 4px;
-  background: hsl(0deg, 0%, 100%);
-  transition: all 0.25s ease-out;
-  content: "";
-}
-.switch[type=checkbox].is-rtl + label {
-  padding-left: 0;
-  padding-right: 3.5rem;
-}
-.switch[type=checkbox].is-rtl + label::before, .switch[type=checkbox].is-rtl + label:before {
-  left: auto;
-  right: 0;
-}
-.switch[type=checkbox].is-rtl + label::after, .switch[type=checkbox].is-rtl + label:after {
-  left: auto;
-  right: cacl(1.625rem);
-}
-.switch[type=checkbox]:checked + label::before, .switch[type=checkbox]:checked + label:before {
-  background: #b31b1b;
-}
-.switch[type=checkbox]:checked + label::after {
-  left: cacl(1.625rem);
-}
-.switch[type=checkbox]:checked.is-rtl + label::after, .switch[type=checkbox]:checked.is-rtl + label:after {
-  left: auto;
-  right: 0.25rem;
-}
-.switch[type=checkbox].is-outlined + label::before, .switch[type=checkbox].is-outlined + label:before {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 60%);
-}
-.switch[type=checkbox].is-outlined + label::after, .switch[type=checkbox].is-outlined + label:after {
-  background: hsl(0deg, 0%, 60%);
-}
-.switch[type=checkbox].is-outlined:checked + label::before, .switch[type=checkbox].is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: #b31b1b;
-}
-.switch[type=checkbox].is-outlined:checked + label::after, .switch[type=checkbox].is-outlined:checked + label:after {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-thin + label::before, .switch[type=checkbox].is-thin + label:before {
-  top: 0.5454545455rem;
-  height: 0.375rem;
-}
-.switch[type=checkbox].is-thin + label::after, .switch[type=checkbox].is-thin + label:after {
-  box-shadow: 0px 0px 3px #757575;
-}
-.switch[type=checkbox].is-rounded + label::before, .switch[type=checkbox].is-rounded + label:before {
-  border-radius: 24px;
-}
-.switch[type=checkbox].is-rounded + label::after, .switch[type=checkbox].is-rounded + label:after {
-  border-radius: 50%;
-}
-.switch[type=checkbox].is-small + label {
-  position: relative;
-  display: initial;
-  font-size: 0.85rem;
-  line-height: initial;
-  padding-left: 3.05rem;
-  padding-top: 0.2rem;
-  cursor: pointer;
-}
-.switch[type=checkbox].is-small + label::before, .switch[type=checkbox].is-small + label:before {
-  position: absolute;
-  display: block;
-  top: 0;
-  left: 0;
-  width: 2.55rem;
-  height: 1.275rem;
-  border: 0.1rem solid transparent;
-  border-radius: 4px;
-  background: hsl(0deg, 0%, 60%);
-  content: "";
-}
-.switch[type=checkbox].is-small + label::after, .switch[type=checkbox].is-small + label:after {
-  display: block;
-  position: absolute;
-  top: 0.25rem;
-  left: 0.25rem;
-  width: 0.775rem;
-  height: 0.775rem;
-  transform: translate3d(0, 0, 0);
-  border-radius: 4px;
-  background: hsl(0deg, 0%, 100%);
-  transition: all 0.25s ease-out;
-  content: "";
-}
-.switch[type=checkbox].is-small.is-rtl + label {
-  padding-left: 0;
-  padding-right: 3.05rem;
-}
-.switch[type=checkbox].is-small.is-rtl + label::before, .switch[type=checkbox].is-small.is-rtl + label:before {
-  left: auto;
-  right: 0;
-}
-.switch[type=checkbox].is-small.is-rtl + label::after, .switch[type=checkbox].is-small.is-rtl + label:after {
-  left: auto;
-  right: cacl(1.4rem);
-}
-.switch[type=checkbox].is-small:checked + label::before, .switch[type=checkbox].is-small:checked + label:before {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-small:checked + label::after {
-  left: cacl(1.4rem);
-}
-.switch[type=checkbox].is-small:checked.is-rtl + label::after, .switch[type=checkbox].is-small:checked.is-rtl + label:after {
-  left: auto;
-  right: 0.25rem;
-}
-.switch[type=checkbox].is-small.is-outlined + label::before, .switch[type=checkbox].is-small.is-outlined + label:before {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 60%);
-}
-.switch[type=checkbox].is-small.is-outlined + label::after, .switch[type=checkbox].is-small.is-outlined + label:after {
-  background: hsl(0deg, 0%, 60%);
-}
-.switch[type=checkbox].is-small.is-outlined:checked + label::before, .switch[type=checkbox].is-small.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: #b31b1b;
-}
-.switch[type=checkbox].is-small.is-outlined:checked + label::after, .switch[type=checkbox].is-small.is-outlined:checked + label:after {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-small.is-thin + label::before, .switch[type=checkbox].is-small.is-thin + label:before {
-  top: 0.4636363636rem;
-  height: 0.31875rem;
-}
-.switch[type=checkbox].is-small.is-thin + label::after, .switch[type=checkbox].is-small.is-thin + label:after {
-  box-shadow: 0px 0px 3px #757575;
-}
-.switch[type=checkbox].is-small.is-rounded + label::before, .switch[type=checkbox].is-small.is-rounded + label:before {
-  border-radius: 24px;
-}
-.switch[type=checkbox].is-small.is-rounded + label::after, .switch[type=checkbox].is-small.is-rounded + label:after {
-  border-radius: 50%;
-}
-.switch[type=checkbox].is-medium + label {
-  position: relative;
-  display: initial;
-  font-size: 1.25rem;
-  line-height: initial;
-  padding-left: 4.25rem;
-  padding-top: 0.2rem;
-  cursor: pointer;
-}
-.switch[type=checkbox].is-medium + label::before, .switch[type=checkbox].is-medium + label:before {
-  position: absolute;
-  display: block;
-  top: 0;
-  left: 0;
-  width: 3.75rem;
-  height: 1.875rem;
-  border: 0.1rem solid transparent;
-  border-radius: 4px;
-  background: hsl(0deg, 0%, 60%);
-  content: "";
-}
-.switch[type=checkbox].is-medium + label::after, .switch[type=checkbox].is-medium + label:after {
-  display: block;
-  position: absolute;
-  top: 0.25rem;
-  left: 0.25rem;
-  width: 1.375rem;
-  height: 1.375rem;
-  transform: translate3d(0, 0, 0);
-  border-radius: 4px;
-  background: hsl(0deg, 0%, 100%);
-  transition: all 0.25s ease-out;
-  content: "";
-}
-.switch[type=checkbox].is-medium.is-rtl + label {
-  padding-left: 0;
-  padding-right: 4.25rem;
-}
-.switch[type=checkbox].is-medium.is-rtl + label::before, .switch[type=checkbox].is-medium.is-rtl + label:before {
-  left: auto;
-  right: 0;
-}
-.switch[type=checkbox].is-medium.is-rtl + label::after, .switch[type=checkbox].is-medium.is-rtl + label:after {
-  left: auto;
-  right: cacl(2rem);
-}
-.switch[type=checkbox].is-medium:checked + label::before, .switch[type=checkbox].is-medium:checked + label:before {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-medium:checked + label::after {
-  left: cacl(2rem);
-}
-.switch[type=checkbox].is-medium:checked.is-rtl + label::after, .switch[type=checkbox].is-medium:checked.is-rtl + label:after {
-  left: auto;
-  right: 0.25rem;
-}
-.switch[type=checkbox].is-medium.is-outlined + label::before, .switch[type=checkbox].is-medium.is-outlined + label:before {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 60%);
-}
-.switch[type=checkbox].is-medium.is-outlined + label::after, .switch[type=checkbox].is-medium.is-outlined + label:after {
-  background: hsl(0deg, 0%, 60%);
-}
-.switch[type=checkbox].is-medium.is-outlined:checked + label::before, .switch[type=checkbox].is-medium.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: #b31b1b;
-}
-.switch[type=checkbox].is-medium.is-outlined:checked + label::after, .switch[type=checkbox].is-medium.is-outlined:checked + label:after {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-medium.is-thin + label::before, .switch[type=checkbox].is-medium.is-thin + label:before {
-  top: 0.6818181818rem;
-  height: 0.46875rem;
-}
-.switch[type=checkbox].is-medium.is-thin + label::after, .switch[type=checkbox].is-medium.is-thin + label:after {
-  box-shadow: 0px 0px 3px #757575;
-}
-.switch[type=checkbox].is-medium.is-rounded + label::before, .switch[type=checkbox].is-medium.is-rounded + label:before {
-  border-radius: 24px;
-}
-.switch[type=checkbox].is-medium.is-rounded + label::after, .switch[type=checkbox].is-medium.is-rounded + label:after {
-  border-radius: 50%;
-}
-.switch[type=checkbox].is-large + label {
-  position: relative;
-  display: initial;
-  font-size: 1.5rem;
-  line-height: initial;
-  padding-left: 5rem;
-  padding-top: 0.2rem;
-  cursor: pointer;
-}
-.switch[type=checkbox].is-large + label::before, .switch[type=checkbox].is-large + label:before {
-  position: absolute;
-  display: block;
-  top: 0;
-  left: 0;
-  width: 4.5rem;
-  height: 2.25rem;
-  border: 0.1rem solid transparent;
-  border-radius: 4px;
-  background: hsl(0deg, 0%, 60%);
-  content: "";
-}
-.switch[type=checkbox].is-large + label::after, .switch[type=checkbox].is-large + label:after {
-  display: block;
-  position: absolute;
-  top: 0.25rem;
-  left: 0.25rem;
-  width: 1.75rem;
-  height: 1.75rem;
-  transform: translate3d(0, 0, 0);
-  border-radius: 4px;
-  background: hsl(0deg, 0%, 100%);
-  transition: all 0.25s ease-out;
-  content: "";
-}
-.switch[type=checkbox].is-large.is-rtl + label {
-  padding-left: 0;
-  padding-right: 5rem;
-}
-.switch[type=checkbox].is-large.is-rtl + label::before, .switch[type=checkbox].is-large.is-rtl + label:before {
-  left: auto;
-  right: 0;
-}
-.switch[type=checkbox].is-large.is-rtl + label::after, .switch[type=checkbox].is-large.is-rtl + label:after {
-  left: auto;
-  right: cacl(2.375rem);
-}
-.switch[type=checkbox].is-large:checked + label::before, .switch[type=checkbox].is-large:checked + label:before {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-large:checked + label::after {
-  left: cacl(2.375rem);
-}
-.switch[type=checkbox].is-large:checked.is-rtl + label::after, .switch[type=checkbox].is-large:checked.is-rtl + label:after {
-  left: auto;
-  right: 0.25rem;
-}
-.switch[type=checkbox].is-large.is-outlined + label::before, .switch[type=checkbox].is-large.is-outlined + label:before {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 60%);
-}
-.switch[type=checkbox].is-large.is-outlined + label::after, .switch[type=checkbox].is-large.is-outlined + label:after {
-  background: hsl(0deg, 0%, 60%);
-}
-.switch[type=checkbox].is-large.is-outlined:checked + label::before, .switch[type=checkbox].is-large.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: #b31b1b;
-}
-.switch[type=checkbox].is-large.is-outlined:checked + label::after, .switch[type=checkbox].is-large.is-outlined:checked + label:after {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-large.is-thin + label::before, .switch[type=checkbox].is-large.is-thin + label:before {
-  top: 0.8181818182rem;
-  height: 0.5625rem;
-}
-.switch[type=checkbox].is-large.is-thin + label::after, .switch[type=checkbox].is-large.is-thin + label:after {
-  box-shadow: 0px 0px 3px #757575;
-}
-.switch[type=checkbox].is-large.is-rounded + label::before, .switch[type=checkbox].is-large.is-rounded + label:before {
-  border-radius: 24px;
-}
-.switch[type=checkbox].is-large.is-rounded + label::after, .switch[type=checkbox].is-large.is-rounded + label:after {
-  border-radius: 50%;
-}
-.switch[type=checkbox].is-white:checked + label::before, .switch[type=checkbox].is-white:checked + label:before {
-  background: hsl(0deg, 0%, 100%);
-}
-.switch[type=checkbox].is-white.is-outlined:checked + label::before, .switch[type=checkbox].is-white.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 100%) !important;
-}
-.switch[type=checkbox].is-white.is-outlined:checked + label::after, .switch[type=checkbox].is-white.is-outlined:checked + label:after {
-  background: hsl(0deg, 0%, 100%);
-}
-.switch[type=checkbox].is-white.is-thin.is-outlined + label::after, .switch[type=checkbox].is-white.is-thin.is-outlined + label:after {
-  box-shadow: none;
-}
-.switch[type=checkbox].is-unchecked-white + label::before, .switch[type=checkbox].is-unchecked-white + label:before {
-  background: hsl(0deg, 0%, 100%);
-}
-.switch[type=checkbox].is-unchecked-white.is-outlined + label::before, .switch[type=checkbox].is-unchecked-white.is-outlined + label:before {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 100%) !important;
-}
-.switch[type=checkbox].is-unchecked-white.is-outlined + label::after, .switch[type=checkbox].is-unchecked-white.is-outlined + label:after {
-  background: hsl(0deg, 0%, 100%);
-}
-.switch[type=checkbox].is-black:checked + label::before, .switch[type=checkbox].is-black:checked + label:before {
-  background: hsl(0deg, 0%, 4%);
-}
-.switch[type=checkbox].is-black.is-outlined:checked + label::before, .switch[type=checkbox].is-black.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 4%) !important;
-}
-.switch[type=checkbox].is-black.is-outlined:checked + label::after, .switch[type=checkbox].is-black.is-outlined:checked + label:after {
-  background: hsl(0deg, 0%, 4%);
-}
-.switch[type=checkbox].is-black.is-thin.is-outlined + label::after, .switch[type=checkbox].is-black.is-thin.is-outlined + label:after {
-  box-shadow: none;
-}
-.switch[type=checkbox].is-unchecked-black + label::before, .switch[type=checkbox].is-unchecked-black + label:before {
-  background: hsl(0deg, 0%, 4%);
-}
-.switch[type=checkbox].is-unchecked-black.is-outlined + label::before, .switch[type=checkbox].is-unchecked-black.is-outlined + label:before {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 4%) !important;
-}
-.switch[type=checkbox].is-unchecked-black.is-outlined + label::after, .switch[type=checkbox].is-unchecked-black.is-outlined + label:after {
-  background: hsl(0deg, 0%, 4%);
-}
-.switch[type=checkbox].is-light:checked + label::before, .switch[type=checkbox].is-light:checked + label:before {
-  background: hsl(0deg, 0%, 96%);
-}
-.switch[type=checkbox].is-light.is-outlined:checked + label::before, .switch[type=checkbox].is-light.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 96%) !important;
-}
-.switch[type=checkbox].is-light.is-outlined:checked + label::after, .switch[type=checkbox].is-light.is-outlined:checked + label:after {
-  background: hsl(0deg, 0%, 96%);
-}
-.switch[type=checkbox].is-light.is-thin.is-outlined + label::after, .switch[type=checkbox].is-light.is-thin.is-outlined + label:after {
-  box-shadow: none;
-}
-.switch[type=checkbox].is-unchecked-light + label::before, .switch[type=checkbox].is-unchecked-light + label:before {
-  background: hsl(0deg, 0%, 96%);
-}
-.switch[type=checkbox].is-unchecked-light.is-outlined + label::before, .switch[type=checkbox].is-unchecked-light.is-outlined + label:before {
-  background-color: transparent;
-  border-color: hsl(0deg, 0%, 96%) !important;
-}
-.switch[type=checkbox].is-unchecked-light.is-outlined + label::after, .switch[type=checkbox].is-unchecked-light.is-outlined + label:after {
-  background: hsl(0deg, 0%, 96%);
-}
-.switch[type=checkbox].is-dark:checked + label::before, .switch[type=checkbox].is-dark:checked + label:before {
-  background: #2d2d2d;
-}
-.switch[type=checkbox].is-dark.is-outlined:checked + label::before, .switch[type=checkbox].is-dark.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: #2d2d2d !important;
-}
-.switch[type=checkbox].is-dark.is-outlined:checked + label::after, .switch[type=checkbox].is-dark.is-outlined:checked + label:after {
-  background: #2d2d2d;
-}
-.switch[type=checkbox].is-dark.is-thin.is-outlined + label::after, .switch[type=checkbox].is-dark.is-thin.is-outlined + label:after {
-  box-shadow: none;
-}
-.switch[type=checkbox].is-unchecked-dark + label::before, .switch[type=checkbox].is-unchecked-dark + label:before {
-  background: #2d2d2d;
-}
-.switch[type=checkbox].is-unchecked-dark.is-outlined + label::before, .switch[type=checkbox].is-unchecked-dark.is-outlined + label:before {
-  background-color: transparent;
-  border-color: #2d2d2d !important;
-}
-.switch[type=checkbox].is-unchecked-dark.is-outlined + label::after, .switch[type=checkbox].is-unchecked-dark.is-outlined + label:after {
-  background: #2d2d2d;
-}
-.switch[type=checkbox].is-primary:checked + label::before, .switch[type=checkbox].is-primary:checked + label:before {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-primary.is-outlined:checked + label::before, .switch[type=checkbox].is-primary.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: #b31b1b !important;
-}
-.switch[type=checkbox].is-primary.is-outlined:checked + label::after, .switch[type=checkbox].is-primary.is-outlined:checked + label:after {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-primary.is-thin.is-outlined + label::after, .switch[type=checkbox].is-primary.is-thin.is-outlined + label:after {
-  box-shadow: none;
-}
-.switch[type=checkbox].is-unchecked-primary + label::before, .switch[type=checkbox].is-unchecked-primary + label:before {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-unchecked-primary.is-outlined + label::before, .switch[type=checkbox].is-unchecked-primary.is-outlined + label:before {
-  background-color: transparent;
-  border-color: #b31b1b !important;
-}
-.switch[type=checkbox].is-unchecked-primary.is-outlined + label::after, .switch[type=checkbox].is-unchecked-primary.is-outlined + label:after {
-  background: #b31b1b;
-}
-.switch[type=checkbox].is-link:checked + label::before, .switch[type=checkbox].is-link:checked + label:before {
-  background: #086db1;
-}
-.switch[type=checkbox].is-link.is-outlined:checked + label::before, .switch[type=checkbox].is-link.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: #086db1 !important;
-}
-.switch[type=checkbox].is-link.is-outlined:checked + label::after, .switch[type=checkbox].is-link.is-outlined:checked + label:after {
-  background: #086db1;
-}
-.switch[type=checkbox].is-link.is-thin.is-outlined + label::after, .switch[type=checkbox].is-link.is-thin.is-outlined + label:after {
-  box-shadow: none;
-}
-.switch[type=checkbox].is-unchecked-link + label::before, .switch[type=checkbox].is-unchecked-link + label:before {
-  background: #086db1;
-}
-.switch[type=checkbox].is-unchecked-link.is-outlined + label::before, .switch[type=checkbox].is-unchecked-link.is-outlined + label:before {
-  background-color: transparent;
-  border-color: #086db1 !important;
-}
-.switch[type=checkbox].is-unchecked-link.is-outlined + label::after, .switch[type=checkbox].is-unchecked-link.is-outlined + label:after {
-  background: #086db1;
-}
-.switch[type=checkbox].is-info:checked + label::before, .switch[type=checkbox].is-info:checked + label:before {
-  background: hsl(204deg, 86%, 53%);
-}
-.switch[type=checkbox].is-info.is-outlined:checked + label::before, .switch[type=checkbox].is-info.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: hsl(204deg, 86%, 53%) !important;
-}
-.switch[type=checkbox].is-info.is-outlined:checked + label::after, .switch[type=checkbox].is-info.is-outlined:checked + label:after {
-  background: hsl(204deg, 86%, 53%);
-}
-.switch[type=checkbox].is-info.is-thin.is-outlined + label::after, .switch[type=checkbox].is-info.is-thin.is-outlined + label:after {
-  box-shadow: none;
-}
-.switch[type=checkbox].is-unchecked-info + label::before, .switch[type=checkbox].is-unchecked-info + label:before {
-  background: hsl(204deg, 86%, 53%);
-}
-.switch[type=checkbox].is-unchecked-info.is-outlined + label::before, .switch[type=checkbox].is-unchecked-info.is-outlined + label:before {
-  background-color: transparent;
-  border-color: hsl(204deg, 86%, 53%) !important;
-}
-.switch[type=checkbox].is-unchecked-info.is-outlined + label::after, .switch[type=checkbox].is-unchecked-info.is-outlined + label:after {
-  background: hsl(204deg, 86%, 53%);
-}
-.switch[type=checkbox].is-success:checked + label::before, .switch[type=checkbox].is-success:checked + label:before {
-  background: #008412;
-}
-.switch[type=checkbox].is-success.is-outlined:checked + label::before, .switch[type=checkbox].is-success.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: #008412 !important;
-}
-.switch[type=checkbox].is-success.is-outlined:checked + label::after, .switch[type=checkbox].is-success.is-outlined:checked + label:after {
-  background: #008412;
-}
-.switch[type=checkbox].is-success.is-thin.is-outlined + label::after, .switch[type=checkbox].is-success.is-thin.is-outlined + label:after {
-  box-shadow: none;
-}
-.switch[type=checkbox].is-unchecked-success + label::before, .switch[type=checkbox].is-unchecked-success + label:before {
-  background: #008412;
-}
-.switch[type=checkbox].is-unchecked-success.is-outlined + label::before, .switch[type=checkbox].is-unchecked-success.is-outlined + label:before {
-  background-color: transparent;
-  border-color: #008412 !important;
-}
-.switch[type=checkbox].is-unchecked-success.is-outlined + label::after, .switch[type=checkbox].is-unchecked-success.is-outlined + label:after {
-  background: #008412;
-}
-.switch[type=checkbox].is-warning:checked + label::before, .switch[type=checkbox].is-warning:checked + label:before {
-  background: #b55c06;
-}
-.switch[type=checkbox].is-warning.is-outlined:checked + label::before, .switch[type=checkbox].is-warning.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: #b55c06 !important;
-}
-.switch[type=checkbox].is-warning.is-outlined:checked + label::after, .switch[type=checkbox].is-warning.is-outlined:checked + label:after {
-  background: #b55c06;
-}
-.switch[type=checkbox].is-warning.is-thin.is-outlined + label::after, .switch[type=checkbox].is-warning.is-thin.is-outlined + label:after {
-  box-shadow: none;
-}
-.switch[type=checkbox].is-unchecked-warning + label::before, .switch[type=checkbox].is-unchecked-warning + label:before {
-  background: #b55c06;
-}
-.switch[type=checkbox].is-unchecked-warning.is-outlined + label::before, .switch[type=checkbox].is-unchecked-warning.is-outlined + label:before {
-  background-color: transparent;
-  border-color: #b55c06 !important;
-}
-.switch[type=checkbox].is-unchecked-warning.is-outlined + label::after, .switch[type=checkbox].is-unchecked-warning.is-outlined + label:after {
-  background: #b55c06;
-}
-.switch[type=checkbox].is-danger:checked + label::before, .switch[type=checkbox].is-danger:checked + label:before {
-  background: #cd0200;
-}
-.switch[type=checkbox].is-danger.is-outlined:checked + label::before, .switch[type=checkbox].is-danger.is-outlined:checked + label:before {
-  background-color: transparent;
-  border-color: #cd0200 !important;
-}
-.switch[type=checkbox].is-danger.is-outlined:checked + label::after, .switch[type=checkbox].is-danger.is-outlined:checked + label:after {
-  background: #cd0200;
-}
-.switch[type=checkbox].is-danger.is-thin.is-outlined + label::after, .switch[type=checkbox].is-danger.is-thin.is-outlined + label:after {
-  box-shadow: none;
-}
-.switch[type=checkbox].is-unchecked-danger + label::before, .switch[type=checkbox].is-unchecked-danger + label:before {
-  background: #cd0200;
-}
-.switch[type=checkbox].is-unchecked-danger.is-outlined + label::before, .switch[type=checkbox].is-unchecked-danger.is-outlined + label:before {
-  background-color: transparent;
-  border-color: #cd0200 !important;
-}
-.switch[type=checkbox].is-unchecked-danger.is-outlined + label::after, .switch[type=checkbox].is-unchecked-danger.is-outlined + label:after {
-  background: #cd0200;
-}
+  opacity: 0; }
+  .switch[type="checkbox"]:focus + label::before, .switch[type="checkbox"]:focus + label:before, .switch[type="checkbox"]:focus + label::after, .switch[type="checkbox"]:focus + label:after {
+    outline: 1px dotted #999999; }
+  .switch[type="checkbox"][disabled] {
+    cursor: not-allowed; }
+    .switch[type="checkbox"][disabled] + label {
+      opacity: 0.5; }
+      .switch[type="checkbox"][disabled] + label::before, .switch[type="checkbox"][disabled] + label:before {
+        opacity: 0.5; }
+      .switch[type="checkbox"][disabled] + label::after, .switch[type="checkbox"][disabled] + label:after {
+        opacity: 0.5; }
+      .switch[type="checkbox"][disabled] + label:hover {
+        cursor: not-allowed; }
+  .switch[type="checkbox"] + label {
+    position: relative;
+    display: initial;
+    font-size: 1rem;
+    line-height: initial;
+    padding-left: 3.5rem;
+    padding-top: .2rem;
+    cursor: pointer; }
+    .switch[type="checkbox"] + label::before, .switch[type="checkbox"] + label:before {
+      position: absolute;
+      display: block;
+      top: 0;
+      left: 0;
+      width: 3rem;
+      height: 1.5rem;
+      border: 0.1rem solid transparent;
+      border-radius: 4px;
+      background: #999999;
+      content: ''; }
+    .switch[type="checkbox"] + label::after, .switch[type="checkbox"] + label:after {
+      display: block;
+      position: absolute;
+      top: 0.75rem-calc($switch-height - ($switch-paddle-offset * 2))/2;
+      left: 0.25rem;
+      width: calc($switch-height - ($switch-paddle-offset * 2));
+      height: calc($switch-height - ($switch-paddle-offset * 2));
+      transform: translate3d(0, 0, 0);
+      border-radius: 4px;
+      background: white;
+      transition: all 0.25s ease-out;
+      content: ''; }
+  .switch[type="checkbox"].is-rtl + label {
+    padding-left: 0;
+    padding-right: 3.5rem; }
+    .switch[type="checkbox"].is-rtl + label::before, .switch[type="checkbox"].is-rtl + label:before {
+      left: auto;
+      right: 0; }
+    .switch[type="checkbox"].is-rtl + label::after, .switch[type="checkbox"].is-rtl + label:after {
+      left: auto;
+      right: cacl(3rem-calc($switch-height - ($switch-paddle-offset * 2))-0.375rem); }
+  .switch[type="checkbox"]:checked + label::before, .switch[type="checkbox"]:checked + label:before {
+    background: #b31b1b; }
+  .switch[type="checkbox"]:checked + label::after {
+    left: cacl(3rem-calc($switch-height - ($switch-paddle-offset * 2))-0.375rem); }
+  .switch[type="checkbox"]:checked.is-rtl + label::after, .switch[type="checkbox"]:checked.is-rtl + label:after {
+    left: auto;
+    right: 0.25rem; }
+  .switch[type="checkbox"].is-outlined + label::before, .switch[type="checkbox"].is-outlined + label:before {
+    background-color: transparent;
+    border-color: #999999; }
+  .switch[type="checkbox"].is-outlined + label::after, .switch[type="checkbox"].is-outlined + label:after {
+    background: #999999; }
+  .switch[type="checkbox"].is-outlined:checked + label::before, .switch[type="checkbox"].is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #b31b1b; }
+  .switch[type="checkbox"].is-outlined:checked + label::after, .switch[type="checkbox"].is-outlined:checked + label:after {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-thin + label::before, .switch[type="checkbox"].is-thin + label:before {
+    top: 0.54545rem;
+    height: 0.375rem; }
+  .switch[type="checkbox"].is-thin + label::after, .switch[type="checkbox"].is-thin + label:after {
+    box-shadow: 0px 0px 3px #757575; }
+  .switch[type="checkbox"].is-rounded + label::before, .switch[type="checkbox"].is-rounded + label:before {
+    border-radius: 24px; }
+  .switch[type="checkbox"].is-rounded + label::after, .switch[type="checkbox"].is-rounded + label:after {
+    border-radius: 50%; }
+  .switch[type="checkbox"].is-small + label {
+    position: relative;
+    display: initial;
+    font-size: 0.85rem;
+    line-height: initial;
+    padding-left: 3.05rem;
+    padding-top: .2rem;
+    cursor: pointer; }
+    .switch[type="checkbox"].is-small + label::before, .switch[type="checkbox"].is-small + label:before {
+      position: absolute;
+      display: block;
+      top: 0;
+      left: 0;
+      width: 2.55rem;
+      height: 1.275rem;
+      border: 0.1rem solid transparent;
+      border-radius: 4px;
+      background: #999999;
+      content: ''; }
+    .switch[type="checkbox"].is-small + label::after, .switch[type="checkbox"].is-small + label:after {
+      display: block;
+      position: absolute;
+      top: 0.6375rem-calc($switch-height - ($switch-paddle-offset * 2))/2;
+      left: 0.25rem;
+      width: calc($switch-height - ($switch-paddle-offset * 2));
+      height: calc($switch-height - ($switch-paddle-offset * 2));
+      transform: translate3d(0, 0, 0);
+      border-radius: 4px;
+      background: white;
+      transition: all 0.25s ease-out;
+      content: ''; }
+  .switch[type="checkbox"].is-small.is-rtl + label {
+    padding-left: 0;
+    padding-right: 3.05rem; }
+    .switch[type="checkbox"].is-small.is-rtl + label::before, .switch[type="checkbox"].is-small.is-rtl + label:before {
+      left: auto;
+      right: 0; }
+    .switch[type="checkbox"].is-small.is-rtl + label::after, .switch[type="checkbox"].is-small.is-rtl + label:after {
+      left: auto;
+      right: cacl(2.55rem-calc($switch-height - ($switch-paddle-offset * 2))-0.375rem); }
+  .switch[type="checkbox"].is-small:checked + label::before, .switch[type="checkbox"].is-small:checked + label:before {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-small:checked + label::after {
+    left: cacl(2.55rem-calc($switch-height - ($switch-paddle-offset * 2))-0.375rem); }
+  .switch[type="checkbox"].is-small:checked.is-rtl + label::after, .switch[type="checkbox"].is-small:checked.is-rtl + label:after {
+    left: auto;
+    right: 0.25rem; }
+  .switch[type="checkbox"].is-small.is-outlined + label::before, .switch[type="checkbox"].is-small.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #999999; }
+  .switch[type="checkbox"].is-small.is-outlined + label::after, .switch[type="checkbox"].is-small.is-outlined + label:after {
+    background: #999999; }
+  .switch[type="checkbox"].is-small.is-outlined:checked + label::before, .switch[type="checkbox"].is-small.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #b31b1b; }
+  .switch[type="checkbox"].is-small.is-outlined:checked + label::after, .switch[type="checkbox"].is-small.is-outlined:checked + label:after {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-small.is-thin + label::before, .switch[type="checkbox"].is-small.is-thin + label:before {
+    top: 0.46364rem;
+    height: 0.31875rem; }
+  .switch[type="checkbox"].is-small.is-thin + label::after, .switch[type="checkbox"].is-small.is-thin + label:after {
+    box-shadow: 0px 0px 3px #757575; }
+  .switch[type="checkbox"].is-small.is-rounded + label::before, .switch[type="checkbox"].is-small.is-rounded + label:before {
+    border-radius: 24px; }
+  .switch[type="checkbox"].is-small.is-rounded + label::after, .switch[type="checkbox"].is-small.is-rounded + label:after {
+    border-radius: 50%; }
+  .switch[type="checkbox"].is-medium + label {
+    position: relative;
+    display: initial;
+    font-size: 1.25rem;
+    line-height: initial;
+    padding-left: 4.25rem;
+    padding-top: .2rem;
+    cursor: pointer; }
+    .switch[type="checkbox"].is-medium + label::before, .switch[type="checkbox"].is-medium + label:before {
+      position: absolute;
+      display: block;
+      top: 0;
+      left: 0;
+      width: 3.75rem;
+      height: 1.875rem;
+      border: 0.1rem solid transparent;
+      border-radius: 4px;
+      background: #999999;
+      content: ''; }
+    .switch[type="checkbox"].is-medium + label::after, .switch[type="checkbox"].is-medium + label:after {
+      display: block;
+      position: absolute;
+      top: 0.9375rem-calc($switch-height - ($switch-paddle-offset * 2))/2;
+      left: 0.25rem;
+      width: calc($switch-height - ($switch-paddle-offset * 2));
+      height: calc($switch-height - ($switch-paddle-offset * 2));
+      transform: translate3d(0, 0, 0);
+      border-radius: 4px;
+      background: white;
+      transition: all 0.25s ease-out;
+      content: ''; }
+  .switch[type="checkbox"].is-medium.is-rtl + label {
+    padding-left: 0;
+    padding-right: 4.25rem; }
+    .switch[type="checkbox"].is-medium.is-rtl + label::before, .switch[type="checkbox"].is-medium.is-rtl + label:before {
+      left: auto;
+      right: 0; }
+    .switch[type="checkbox"].is-medium.is-rtl + label::after, .switch[type="checkbox"].is-medium.is-rtl + label:after {
+      left: auto;
+      right: cacl(3.75rem-calc($switch-height - ($switch-paddle-offset * 2))-0.375rem); }
+  .switch[type="checkbox"].is-medium:checked + label::before, .switch[type="checkbox"].is-medium:checked + label:before {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-medium:checked + label::after {
+    left: cacl(3.75rem-calc($switch-height - ($switch-paddle-offset * 2))-0.375rem); }
+  .switch[type="checkbox"].is-medium:checked.is-rtl + label::after, .switch[type="checkbox"].is-medium:checked.is-rtl + label:after {
+    left: auto;
+    right: 0.25rem; }
+  .switch[type="checkbox"].is-medium.is-outlined + label::before, .switch[type="checkbox"].is-medium.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #999999; }
+  .switch[type="checkbox"].is-medium.is-outlined + label::after, .switch[type="checkbox"].is-medium.is-outlined + label:after {
+    background: #999999; }
+  .switch[type="checkbox"].is-medium.is-outlined:checked + label::before, .switch[type="checkbox"].is-medium.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #b31b1b; }
+  .switch[type="checkbox"].is-medium.is-outlined:checked + label::after, .switch[type="checkbox"].is-medium.is-outlined:checked + label:after {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-medium.is-thin + label::before, .switch[type="checkbox"].is-medium.is-thin + label:before {
+    top: 0.68182rem;
+    height: 0.46875rem; }
+  .switch[type="checkbox"].is-medium.is-thin + label::after, .switch[type="checkbox"].is-medium.is-thin + label:after {
+    box-shadow: 0px 0px 3px #757575; }
+  .switch[type="checkbox"].is-medium.is-rounded + label::before, .switch[type="checkbox"].is-medium.is-rounded + label:before {
+    border-radius: 24px; }
+  .switch[type="checkbox"].is-medium.is-rounded + label::after, .switch[type="checkbox"].is-medium.is-rounded + label:after {
+    border-radius: 50%; }
+  .switch[type="checkbox"].is-large + label {
+    position: relative;
+    display: initial;
+    font-size: 1.5rem;
+    line-height: initial;
+    padding-left: 5rem;
+    padding-top: .2rem;
+    cursor: pointer; }
+    .switch[type="checkbox"].is-large + label::before, .switch[type="checkbox"].is-large + label:before {
+      position: absolute;
+      display: block;
+      top: 0;
+      left: 0;
+      width: 4.5rem;
+      height: 2.25rem;
+      border: 0.1rem solid transparent;
+      border-radius: 4px;
+      background: #999999;
+      content: ''; }
+    .switch[type="checkbox"].is-large + label::after, .switch[type="checkbox"].is-large + label:after {
+      display: block;
+      position: absolute;
+      top: 1.125rem-calc($switch-height - ($switch-paddle-offset * 2))/2;
+      left: 0.25rem;
+      width: calc($switch-height - ($switch-paddle-offset * 2));
+      height: calc($switch-height - ($switch-paddle-offset * 2));
+      transform: translate3d(0, 0, 0);
+      border-radius: 4px;
+      background: white;
+      transition: all 0.25s ease-out;
+      content: ''; }
+  .switch[type="checkbox"].is-large.is-rtl + label {
+    padding-left: 0;
+    padding-right: 5rem; }
+    .switch[type="checkbox"].is-large.is-rtl + label::before, .switch[type="checkbox"].is-large.is-rtl + label:before {
+      left: auto;
+      right: 0; }
+    .switch[type="checkbox"].is-large.is-rtl + label::after, .switch[type="checkbox"].is-large.is-rtl + label:after {
+      left: auto;
+      right: cacl(4.5rem-calc($switch-height - ($switch-paddle-offset * 2))-0.375rem); }
+  .switch[type="checkbox"].is-large:checked + label::before, .switch[type="checkbox"].is-large:checked + label:before {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-large:checked + label::after {
+    left: cacl(4.5rem-calc($switch-height - ($switch-paddle-offset * 2))-0.375rem); }
+  .switch[type="checkbox"].is-large:checked.is-rtl + label::after, .switch[type="checkbox"].is-large:checked.is-rtl + label:after {
+    left: auto;
+    right: 0.25rem; }
+  .switch[type="checkbox"].is-large.is-outlined + label::before, .switch[type="checkbox"].is-large.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #999999; }
+  .switch[type="checkbox"].is-large.is-outlined + label::after, .switch[type="checkbox"].is-large.is-outlined + label:after {
+    background: #999999; }
+  .switch[type="checkbox"].is-large.is-outlined:checked + label::before, .switch[type="checkbox"].is-large.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #b31b1b; }
+  .switch[type="checkbox"].is-large.is-outlined:checked + label::after, .switch[type="checkbox"].is-large.is-outlined:checked + label:after {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-large.is-thin + label::before, .switch[type="checkbox"].is-large.is-thin + label:before {
+    top: 0.81818rem;
+    height: 0.5625rem; }
+  .switch[type="checkbox"].is-large.is-thin + label::after, .switch[type="checkbox"].is-large.is-thin + label:after {
+    box-shadow: 0px 0px 3px #757575; }
+  .switch[type="checkbox"].is-large.is-rounded + label::before, .switch[type="checkbox"].is-large.is-rounded + label:before {
+    border-radius: 24px; }
+  .switch[type="checkbox"].is-large.is-rounded + label::after, .switch[type="checkbox"].is-large.is-rounded + label:after {
+    border-radius: 50%; }
+  .switch[type="checkbox"].is-white:checked + label::before, .switch[type="checkbox"].is-white:checked + label:before {
+    background: white; }
+  .switch[type="checkbox"].is-white.is-outlined:checked + label::before, .switch[type="checkbox"].is-white.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: white !important; }
+  .switch[type="checkbox"].is-white.is-outlined:checked + label::after, .switch[type="checkbox"].is-white.is-outlined:checked + label:after {
+    background: white; }
+  .switch[type="checkbox"].is-white.is-thin.is-outlined + label::after, .switch[type="checkbox"].is-white.is-thin.is-outlined + label:after {
+    box-shadow: none; }
+  .switch[type="checkbox"].is-unchecked-white + label::before, .switch[type="checkbox"].is-unchecked-white + label:before {
+    background: white; }
+  .switch[type="checkbox"].is-unchecked-white.is-outlined + label::before, .switch[type="checkbox"].is-unchecked-white.is-outlined + label:before {
+    background-color: transparent;
+    border-color: white !important; }
+  .switch[type="checkbox"].is-unchecked-white.is-outlined + label::after, .switch[type="checkbox"].is-unchecked-white.is-outlined + label:after {
+    background: white; }
+  .switch[type="checkbox"].is-black:checked + label::before, .switch[type="checkbox"].is-black:checked + label:before {
+    background: #0a0a0a; }
+  .switch[type="checkbox"].is-black.is-outlined:checked + label::before, .switch[type="checkbox"].is-black.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #0a0a0a !important; }
+  .switch[type="checkbox"].is-black.is-outlined:checked + label::after, .switch[type="checkbox"].is-black.is-outlined:checked + label:after {
+    background: #0a0a0a; }
+  .switch[type="checkbox"].is-black.is-thin.is-outlined + label::after, .switch[type="checkbox"].is-black.is-thin.is-outlined + label:after {
+    box-shadow: none; }
+  .switch[type="checkbox"].is-unchecked-black + label::before, .switch[type="checkbox"].is-unchecked-black + label:before {
+    background: #0a0a0a; }
+  .switch[type="checkbox"].is-unchecked-black.is-outlined + label::before, .switch[type="checkbox"].is-unchecked-black.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #0a0a0a !important; }
+  .switch[type="checkbox"].is-unchecked-black.is-outlined + label::after, .switch[type="checkbox"].is-unchecked-black.is-outlined + label:after {
+    background: #0a0a0a; }
+  .switch[type="checkbox"].is-light:checked + label::before, .switch[type="checkbox"].is-light:checked + label:before {
+    background: whitesmoke; }
+  .switch[type="checkbox"].is-light.is-outlined:checked + label::before, .switch[type="checkbox"].is-light.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: whitesmoke !important; }
+  .switch[type="checkbox"].is-light.is-outlined:checked + label::after, .switch[type="checkbox"].is-light.is-outlined:checked + label:after {
+    background: whitesmoke; }
+  .switch[type="checkbox"].is-light.is-thin.is-outlined + label::after, .switch[type="checkbox"].is-light.is-thin.is-outlined + label:after {
+    box-shadow: none; }
+  .switch[type="checkbox"].is-unchecked-light + label::before, .switch[type="checkbox"].is-unchecked-light + label:before {
+    background: whitesmoke; }
+  .switch[type="checkbox"].is-unchecked-light.is-outlined + label::before, .switch[type="checkbox"].is-unchecked-light.is-outlined + label:before {
+    background-color: transparent;
+    border-color: whitesmoke !important; }
+  .switch[type="checkbox"].is-unchecked-light.is-outlined + label::after, .switch[type="checkbox"].is-unchecked-light.is-outlined + label:after {
+    background: whitesmoke; }
+  .switch[type="checkbox"].is-dark:checked + label::before, .switch[type="checkbox"].is-dark:checked + label:before {
+    background: #2d2d2d; }
+  .switch[type="checkbox"].is-dark.is-outlined:checked + label::before, .switch[type="checkbox"].is-dark.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #2d2d2d !important; }
+  .switch[type="checkbox"].is-dark.is-outlined:checked + label::after, .switch[type="checkbox"].is-dark.is-outlined:checked + label:after {
+    background: #2d2d2d; }
+  .switch[type="checkbox"].is-dark.is-thin.is-outlined + label::after, .switch[type="checkbox"].is-dark.is-thin.is-outlined + label:after {
+    box-shadow: none; }
+  .switch[type="checkbox"].is-unchecked-dark + label::before, .switch[type="checkbox"].is-unchecked-dark + label:before {
+    background: #2d2d2d; }
+  .switch[type="checkbox"].is-unchecked-dark.is-outlined + label::before, .switch[type="checkbox"].is-unchecked-dark.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #2d2d2d !important; }
+  .switch[type="checkbox"].is-unchecked-dark.is-outlined + label::after, .switch[type="checkbox"].is-unchecked-dark.is-outlined + label:after {
+    background: #2d2d2d; }
+  .switch[type="checkbox"].is-primary:checked + label::before, .switch[type="checkbox"].is-primary:checked + label:before {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-primary.is-outlined:checked + label::before, .switch[type="checkbox"].is-primary.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #b31b1b !important; }
+  .switch[type="checkbox"].is-primary.is-outlined:checked + label::after, .switch[type="checkbox"].is-primary.is-outlined:checked + label:after {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-primary.is-thin.is-outlined + label::after, .switch[type="checkbox"].is-primary.is-thin.is-outlined + label:after {
+    box-shadow: none; }
+  .switch[type="checkbox"].is-unchecked-primary + label::before, .switch[type="checkbox"].is-unchecked-primary + label:before {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-unchecked-primary.is-outlined + label::before, .switch[type="checkbox"].is-unchecked-primary.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #b31b1b !important; }
+  .switch[type="checkbox"].is-unchecked-primary.is-outlined + label::after, .switch[type="checkbox"].is-unchecked-primary.is-outlined + label:after {
+    background: #b31b1b; }
+  .switch[type="checkbox"].is-link:checked + label::before, .switch[type="checkbox"].is-link:checked + label:before {
+    background: #1565c0; }
+  .switch[type="checkbox"].is-link.is-outlined:checked + label::before, .switch[type="checkbox"].is-link.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #1565c0 !important; }
+  .switch[type="checkbox"].is-link.is-outlined:checked + label::after, .switch[type="checkbox"].is-link.is-outlined:checked + label:after {
+    background: #1565c0; }
+  .switch[type="checkbox"].is-link.is-thin.is-outlined + label::after, .switch[type="checkbox"].is-link.is-thin.is-outlined + label:after {
+    box-shadow: none; }
+  .switch[type="checkbox"].is-unchecked-link + label::before, .switch[type="checkbox"].is-unchecked-link + label:before {
+    background: #1565c0; }
+  .switch[type="checkbox"].is-unchecked-link.is-outlined + label::before, .switch[type="checkbox"].is-unchecked-link.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #1565c0 !important; }
+  .switch[type="checkbox"].is-unchecked-link.is-outlined + label::after, .switch[type="checkbox"].is-unchecked-link.is-outlined + label:after {
+    background: #1565c0; }
+  .switch[type="checkbox"].is-info:checked + label::before, .switch[type="checkbox"].is-info:checked + label:before {
+    background: #209cee; }
+  .switch[type="checkbox"].is-info.is-outlined:checked + label::before, .switch[type="checkbox"].is-info.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #209cee !important; }
+  .switch[type="checkbox"].is-info.is-outlined:checked + label::after, .switch[type="checkbox"].is-info.is-outlined:checked + label:after {
+    background: #209cee; }
+  .switch[type="checkbox"].is-info.is-thin.is-outlined + label::after, .switch[type="checkbox"].is-info.is-thin.is-outlined + label:after {
+    box-shadow: none; }
+  .switch[type="checkbox"].is-unchecked-info + label::before, .switch[type="checkbox"].is-unchecked-info + label:before {
+    background: #209cee; }
+  .switch[type="checkbox"].is-unchecked-info.is-outlined + label::before, .switch[type="checkbox"].is-unchecked-info.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #209cee !important; }
+  .switch[type="checkbox"].is-unchecked-info.is-outlined + label::after, .switch[type="checkbox"].is-unchecked-info.is-outlined + label:after {
+    background: #209cee; }
+  .switch[type="checkbox"].is-success:checked + label::before, .switch[type="checkbox"].is-success:checked + label:before {
+    background: #008412; }
+  .switch[type="checkbox"].is-success.is-outlined:checked + label::before, .switch[type="checkbox"].is-success.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #008412 !important; }
+  .switch[type="checkbox"].is-success.is-outlined:checked + label::after, .switch[type="checkbox"].is-success.is-outlined:checked + label:after {
+    background: #008412; }
+  .switch[type="checkbox"].is-success.is-thin.is-outlined + label::after, .switch[type="checkbox"].is-success.is-thin.is-outlined + label:after {
+    box-shadow: none; }
+  .switch[type="checkbox"].is-unchecked-success + label::before, .switch[type="checkbox"].is-unchecked-success + label:before {
+    background: #008412; }
+  .switch[type="checkbox"].is-unchecked-success.is-outlined + label::before, .switch[type="checkbox"].is-unchecked-success.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #008412 !important; }
+  .switch[type="checkbox"].is-unchecked-success.is-outlined + label::after, .switch[type="checkbox"].is-unchecked-success.is-outlined + label:after {
+    background: #008412; }
+  .switch[type="checkbox"].is-warning:checked + label::before, .switch[type="checkbox"].is-warning:checked + label:before {
+    background: #b55c06; }
+  .switch[type="checkbox"].is-warning.is-outlined:checked + label::before, .switch[type="checkbox"].is-warning.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #b55c06 !important; }
+  .switch[type="checkbox"].is-warning.is-outlined:checked + label::after, .switch[type="checkbox"].is-warning.is-outlined:checked + label:after {
+    background: #b55c06; }
+  .switch[type="checkbox"].is-warning.is-thin.is-outlined + label::after, .switch[type="checkbox"].is-warning.is-thin.is-outlined + label:after {
+    box-shadow: none; }
+  .switch[type="checkbox"].is-unchecked-warning + label::before, .switch[type="checkbox"].is-unchecked-warning + label:before {
+    background: #b55c06; }
+  .switch[type="checkbox"].is-unchecked-warning.is-outlined + label::before, .switch[type="checkbox"].is-unchecked-warning.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #b55c06 !important; }
+  .switch[type="checkbox"].is-unchecked-warning.is-outlined + label::after, .switch[type="checkbox"].is-unchecked-warning.is-outlined + label:after {
+    background: #b55c06; }
+  .switch[type="checkbox"].is-danger:checked + label::before, .switch[type="checkbox"].is-danger:checked + label:before {
+    background: #cd0200; }
+  .switch[type="checkbox"].is-danger.is-outlined:checked + label::before, .switch[type="checkbox"].is-danger.is-outlined:checked + label:before {
+    background-color: transparent;
+    border-color: #cd0200 !important; }
+  .switch[type="checkbox"].is-danger.is-outlined:checked + label::after, .switch[type="checkbox"].is-danger.is-outlined:checked + label:after {
+    background: #cd0200; }
+  .switch[type="checkbox"].is-danger.is-thin.is-outlined + label::after, .switch[type="checkbox"].is-danger.is-thin.is-outlined + label:after {
+    box-shadow: none; }
+  .switch[type="checkbox"].is-unchecked-danger + label::before, .switch[type="checkbox"].is-unchecked-danger + label:before {
+    background: #cd0200; }
+  .switch[type="checkbox"].is-unchecked-danger.is-outlined + label::before, .switch[type="checkbox"].is-unchecked-danger.is-outlined + label:before {
+    background-color: transparent;
+    border-color: #cd0200 !important; }
+  .switch[type="checkbox"].is-unchecked-danger.is-outlined + label::after, .switch[type="checkbox"].is-unchecked-danger.is-outlined + label:after {
+    background: #cd0200; }
 
 /* sets base font scale for all other font sizes */
 html {
-  font-size: 14px;
-}
+  font-size: 14px; }
 
 /* sticky footer solution as written by Philip Walton */
 /* https://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/ */
 body {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-}
+  height: 100vh; }
 
 header,
 footer {
-  flex-shrink: 0;
-}
+  flex-shrink: 0; }
 
 main {
-  flex: 1 0 auto;
-}
+  flex: 1 0 auto; }
 
 /* overrides Bulma defaults which have bigger differences */
 .content h1 {
-  font-size: 1.75em;
-}
+  font-size: 1.75em; }
+
 .content h2 {
-  font-size: 1.5em;
-}
+  font-size: 1.5em; }
+
 .content h3 {
-  font-size: 1.35em;
-}
+  font-size: 1.35em; }
 
 .help,
 .is-small {
-  font-family: "Lucida Grande", "Helvetica Neue", Helvetica, Arial, sans-serif;
-}
+  font-family: "Lucida Grande", "Helvetica Neue", Helvetica, Arial, sans-serif; }
 
 .field.has-addons-tablet .control:not(:last-child) {
-  margin-bottom: 0.5rem;
-}
+  margin-bottom: .5rem; }
+
 @media screen and (min-width: 769px) {
   .field.has-addons-tablet {
     display: flex;
-    justify-content: flex-start;
-  }
-  .field.has-addons-tablet .control:not(:last-child) {
-    margin-right: -1px;
-    margin-bottom: 0;
-  }
-  .field.has-addons-tablet .control:first-child .button,
-  .field.has-addons-tablet .control:first-child .input,
-  .field.has-addons-tablet .control:first-child .select select {
-    border-bottom-left-radius: 3px;
-    border-top-left-radius: 3px;
-  }
-  .field.has-addons-tablet .control:last-child .button,
-  .field.has-addons-tablet .control:last-child .input,
-  .field.has-addons-tablet .control:last-child .select select {
-    border-bottom-right-radius: 3px;
-    border-top-right-radius: 3px;
-  }
-  .field.has-addons-tablet .control .button,
-  .field.has-addons-tablet .control .input,
-  .field.has-addons-tablet .control .select select {
-    border-radius: 0;
-  }
-  .field.has-addons-tablet .control .button:hover, .field.has-addons-tablet .control .button.is-hovered,
-  .field.has-addons-tablet .control .input:hover,
-  .field.has-addons-tablet .control .input.is-hovered,
-  .field.has-addons-tablet .control .select select:hover,
-  .field.has-addons-tablet .control .select select.is-hovered {
-    z-index: 2;
-  }
-  .field.has-addons-tablet .control .button:focus, .field.has-addons-tablet .control .button.is-focused, .field.has-addons-tablet .control .button:active, .field.has-addons-tablet .control .button.is-active,
-  .field.has-addons-tablet .control .input:focus,
-  .field.has-addons-tablet .control .input.is-focused,
-  .field.has-addons-tablet .control .input:active,
-  .field.has-addons-tablet .control .input.is-active,
-  .field.has-addons-tablet .control .select select:focus,
-  .field.has-addons-tablet .control .select select.is-focused,
-  .field.has-addons-tablet .control .select select:active,
-  .field.has-addons-tablet .control .select select.is-active {
-    z-index: 3;
-  }
-  .field.has-addons-tablet .control .button:focus:hover, .field.has-addons-tablet .control .button.is-focused:hover, .field.has-addons-tablet .control .button:active:hover, .field.has-addons-tablet .control .button.is-active:hover,
-  .field.has-addons-tablet .control .input:focus:hover,
-  .field.has-addons-tablet .control .input.is-focused:hover,
-  .field.has-addons-tablet .control .input:active:hover,
-  .field.has-addons-tablet .control .input.is-active:hover,
-  .field.has-addons-tablet .control .select select:focus:hover,
-  .field.has-addons-tablet .control .select select.is-focused:hover,
-  .field.has-addons-tablet .control .select select:active:hover,
-  .field.has-addons-tablet .control .select select.is-active:hover {
-    z-index: 4;
-  }
-  .field.has-addons-tablet .control.is-expanded {
-    flex-grow: 1;
-  }
-  .field.has-addons-tablet.has-addons-centered {
-    justify-content: center;
-  }
-  .field.has-addons-tablet.has-addons-right {
-    justify-content: flex-end;
-  }
-  .field.has-addons-tablet.has-addons-fullwidth .control {
-    flex-grow: 1;
-    flex-shrink: 0;
-  }
-}
+    justify-content: flex-start; }
+    .field.has-addons-tablet .control:not(:last-child) {
+      margin-right: -1px;
+      margin-bottom: 0; }
+    .field.has-addons-tablet .control:first-child .button,
+    .field.has-addons-tablet .control:first-child .input,
+    .field.has-addons-tablet .control:first-child .select select {
+      border-bottom-left-radius: 3px;
+      border-top-left-radius: 3px; }
+    .field.has-addons-tablet .control:last-child .button,
+    .field.has-addons-tablet .control:last-child .input,
+    .field.has-addons-tablet .control:last-child .select select {
+      border-bottom-right-radius: 3px;
+      border-top-right-radius: 3px; }
+    .field.has-addons-tablet .control .button,
+    .field.has-addons-tablet .control .input,
+    .field.has-addons-tablet .control .select select {
+      border-radius: 0; }
+      .field.has-addons-tablet .control .button:hover, .field.has-addons-tablet .control .button.is-hovered,
+      .field.has-addons-tablet .control .input:hover,
+      .field.has-addons-tablet .control .input.is-hovered,
+      .field.has-addons-tablet .control .select select:hover,
+      .field.has-addons-tablet .control .select select.is-hovered {
+        z-index: 2; }
+      .field.has-addons-tablet .control .button:focus, .field.has-addons-tablet .control .button.is-focused, .field.has-addons-tablet .control .button:active, .field.has-addons-tablet .control .button.is-active,
+      .field.has-addons-tablet .control .input:focus,
+      .field.has-addons-tablet .control .input.is-focused,
+      .field.has-addons-tablet .control .input:active,
+      .field.has-addons-tablet .control .input.is-active,
+      .field.has-addons-tablet .control .select select:focus,
+      .field.has-addons-tablet .control .select select.is-focused,
+      .field.has-addons-tablet .control .select select:active,
+      .field.has-addons-tablet .control .select select.is-active {
+        z-index: 3; }
+        .field.has-addons-tablet .control .button:focus:hover, .field.has-addons-tablet .control .button.is-focused:hover, .field.has-addons-tablet .control .button:active:hover, .field.has-addons-tablet .control .button.is-active:hover,
+        .field.has-addons-tablet .control .input:focus:hover,
+        .field.has-addons-tablet .control .input.is-focused:hover,
+        .field.has-addons-tablet .control .input:active:hover,
+        .field.has-addons-tablet .control .input.is-active:hover,
+        .field.has-addons-tablet .control .select select:focus:hover,
+        .field.has-addons-tablet .control .select select.is-focused:hover,
+        .field.has-addons-tablet .control .select select:active:hover,
+        .field.has-addons-tablet .control .select select.is-active:hover {
+          z-index: 4; }
+    .field.has-addons-tablet .control.is-expanded {
+      flex-grow: 1; }
+    .field.has-addons-tablet.has-addons-centered {
+      justify-content: center; }
+    .field.has-addons-tablet.has-addons-right {
+      justify-content: flex-end; }
+    .field.has-addons-tablet.has-addons-fullwidth .control {
+      flex-grow: 1;
+      flex-shrink: 0; } }
 
 .notification.is-white {
   background-color: white;
-  border: 1px solid hsl(0deg, 0%, 100%);
-  color: #4d4d4d;
-}
+  border: 1px solid white;
+  color: #4d4d4d; }
+
 .notification.is-black {
   background-color: #fafafa;
-  border: 1px solid hsl(0deg, 0%, 4%);
-  color: #0a0a0a;
-}
+  border: 1px solid #0a0a0a;
+  color: #090909; }
+
 .notification.is-light {
   background-color: #fafafa;
-  border: 1px solid hsl(0deg, 0%, 96%);
-  color: #4f4f4f;
-}
+  border: 1px solid whitesmoke;
+  color: #505050; }
+
 .notification.is-dark {
   background-color: #fafafa;
   border: 1px solid #2d2d2d;
-  color: #242424;
-}
+  color: #242424; }
+
 .notification.is-primary {
   background-color: #fef6f6;
   border: 1px solid #b31b1b;
-  color: #881818;
-}
+  color: #881818; }
+
 .notification.is-link {
-  background-color: #f5fbff;
-  border: 1px solid #086db1;
-  color: #08456e;
-}
+  background-color: #f6fafe;
+  border: 1px solid #1565c0;
+  color: #134783; }
+
 .notification.is-info {
   background-color: #f6fbfe;
-  border: 1px solid hsl(204deg, 86%, 53%);
-  color: #12537e;
-}
+  border: 1px solid #209cee;
+  color: #12537e; }
+
 .notification.is-success {
   background-color: #f5fff6;
   border: 1px solid #008412;
-  color: #023709;
-}
+  color: #023709; }
+
 .notification.is-warning {
   background-color: #fffaf5;
   border: 1px solid #b55c06;
-  color: #643507;
-}
+  color: #643507; }
+
 .notification.is-danger {
   background-color: #fff5f5;
   border: 1px solid #cd0200;
-  color: #970503;
-}
+  color: #970503; }
 
 .button.is-white {
-  background-color: hsl(0deg, 0%, 100%);
+  background-color: white;
   border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-white:hover, .button.is-white.is-hovered {
-  background-color: #f0f0f0;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-white:focus, .button.is-white.is-focused {
-  border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
-.button.is-white:focus:not(:active), .button.is-white.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.35);
-}
-.button.is-white:active, .button.is-white.is-active {
-  background-color: #e6e6e6;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 4%);
-}
+  color: #0a0a0a; }
+  .button.is-white:hover, .button.is-white.is-hovered {
+    background-color: #f0f0f0;
+    border-color: transparent;
+    color: #0a0a0a; }
+  .button.is-white:focus, .button.is-white.is-focused {
+    border-color: transparent;
+    color: #0a0a0a; }
+    .button.is-white:focus:not(:active), .button.is-white.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.35); }
+  .button.is-white:active, .button.is-white.is-active {
+    background-color: #e6e6e6;
+    border-color: transparent;
+    color: #0a0a0a; }
+
 .button.is-black {
-  background-color: hsl(0deg, 0%, 4%);
+  background-color: #0a0a0a;
   border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-black:hover, .button.is-black.is-hovered {
-  background-color: black;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-black:focus, .button.is-black.is-focused {
-  border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
-.button.is-black:focus:not(:active), .button.is-black.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.35);
-}
-.button.is-black:active, .button.is-black.is-active {
-  background-color: black;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 100%);
-}
+  color: white; }
+  .button.is-black:hover, .button.is-black.is-hovered {
+    background-color: black;
+    border-color: transparent;
+    color: white; }
+  .button.is-black:focus, .button.is-black.is-focused {
+    border-color: transparent;
+    color: white; }
+    .button.is-black:focus:not(:active), .button.is-black.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.35); }
+  .button.is-black:active, .button.is-black.is-active {
+    background-color: black;
+    border-color: transparent;
+    color: white; }
+
 .button.is-light {
-  background-color: hsl(0deg, 0%, 96%);
+  background-color: whitesmoke;
   border-color: transparent;
-  color: #2d2d2d;
-}
-.button.is-light:hover, .button.is-light.is-hovered {
-  background-color: #e6e6e6;
-  border-color: transparent;
-  color: #2d2d2d;
-}
-.button.is-light:focus, .button.is-light.is-focused {
-  border-color: transparent;
-  color: #2d2d2d;
-}
-.button.is-light:focus:not(:active), .button.is-light.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.35);
-}
-.button.is-light:active, .button.is-light.is-active {
-  background-color: #dbdbdb;
-  border-color: transparent;
-  color: #2d2d2d;
-}
+  color: #2d2d2d; }
+  .button.is-light:hover, .button.is-light.is-hovered {
+    background-color: #e6e6e6;
+    border-color: transparent;
+    color: #2d2d2d; }
+  .button.is-light:focus, .button.is-light.is-focused {
+    border-color: transparent;
+    color: #2d2d2d; }
+    .button.is-light:focus:not(:active), .button.is-light.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.35); }
+  .button.is-light:active, .button.is-light.is-active {
+    background-color: #dbdbdb;
+    border-color: transparent;
+    color: #2d2d2d; }
+
 .button.is-dark {
   background-color: #2d2d2d;
   border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-dark:hover, .button.is-dark.is-hovered {
-  background-color: #1e1e1e;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-dark:focus, .button.is-dark.is-focused {
-  border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
-.button.is-dark:focus:not(:active), .button.is-dark.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(45, 45, 45, 0.35);
-}
-.button.is-dark:active, .button.is-dark.is-active {
-  background-color: #141414;
-  border-color: transparent;
-  color: hsl(0deg, 0%, 96%);
-}
+  color: whitesmoke; }
+  .button.is-dark:hover, .button.is-dark.is-hovered {
+    background-color: #1e1e1e;
+    border-color: transparent;
+    color: whitesmoke; }
+  .button.is-dark:focus, .button.is-dark.is-focused {
+    border-color: transparent;
+    color: whitesmoke; }
+    .button.is-dark:focus:not(:active), .button.is-dark.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(45, 45, 45, 0.35); }
+  .button.is-dark:active, .button.is-dark.is-active {
+    background-color: #141414;
+    border-color: transparent;
+    color: whitesmoke; }
+
 .button.is-primary {
   background-color: #b31b1b;
   border-color: transparent;
-  color: #fff;
-}
-.button.is-primary:hover, .button.is-primary.is-hovered {
-  background-color: #981717;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-primary:focus, .button.is-primary.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-primary:focus:not(:active), .button.is-primary.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(179, 27, 27, 0.35);
-}
-.button.is-primary:active, .button.is-primary.is-active {
-  background-color: #871414;
-  border-color: transparent;
-  color: #fff;
-}
+  color: #fff; }
+  .button.is-primary:hover, .button.is-primary.is-hovered {
+    background-color: #981717;
+    border-color: transparent;
+    color: #fff; }
+  .button.is-primary:focus, .button.is-primary.is-focused {
+    border-color: transparent;
+    color: #fff; }
+    .button.is-primary:focus:not(:active), .button.is-primary.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(179, 27, 27, 0.35); }
+  .button.is-primary:active, .button.is-primary.is-active {
+    background-color: #871414;
+    border-color: transparent;
+    color: #fff; }
+
 .button.is-link {
-  background-color: #086db1;
+  background-color: #1565c0;
   border-color: transparent;
-  color: #fff;
-}
-.button.is-link:hover, .button.is-link.is-hovered {
-  background-color: #075b94;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-link:focus, .button.is-link.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-link:focus:not(:active), .button.is-link.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(8, 109, 177, 0.35);
-}
-.button.is-link:active, .button.is-link.is-active {
-  background-color: #064f80;
-  border-color: transparent;
-  color: #fff;
-}
+  color: #fff; }
+  .button.is-link:hover, .button.is-link.is-hovered {
+    background-color: #1256a4;
+    border-color: transparent;
+    color: #fff; }
+  .button.is-link:focus, .button.is-link.is-focused {
+    border-color: transparent;
+    color: #fff; }
+    .button.is-link:focus:not(:active), .button.is-link.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(21, 101, 192, 0.35); }
+  .button.is-link:active, .button.is-link.is-active {
+    background-color: #104d92;
+    border-color: transparent;
+    color: #fff; }
+
 .button.is-info {
-  background-color: hsl(204deg, 86%, 53%);
+  background-color: #209cee;
   border-color: transparent;
-  color: #fff;
-}
-.button.is-info:hover, .button.is-info.is-hovered {
-  background-color: #118cdf;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-info:focus, .button.is-info.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-info:focus:not(:active), .button.is-info.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(32, 156, 238, 0.35);
-}
-.button.is-info:active, .button.is-info.is-active {
-  background-color: #0f81cc;
-  border-color: transparent;
-  color: #fff;
-}
+  color: #fff; }
+  .button.is-info:hover, .button.is-info.is-hovered {
+    background-color: #118cdf;
+    border-color: transparent;
+    color: #fff; }
+  .button.is-info:focus, .button.is-info.is-focused {
+    border-color: transparent;
+    color: #fff; }
+    .button.is-info:focus:not(:active), .button.is-info.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(32, 156, 238, 0.35); }
+  .button.is-info:active, .button.is-info.is-active {
+    background-color: #0f81cc;
+    border-color: transparent;
+    color: #fff; }
+
 .button.is-success {
   background-color: #008412;
   border-color: transparent;
-  color: #fff;
-}
-.button.is-success:hover, .button.is-success.is-hovered {
-  background-color: #00650e;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-success:focus, .button.is-success.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-success:focus:not(:active), .button.is-success.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(0, 132, 18, 0.35);
-}
-.button.is-success:active, .button.is-success.is-active {
-  background-color: #00510b;
-  border-color: transparent;
-  color: #fff;
-}
+  color: #fff; }
+  .button.is-success:hover, .button.is-success.is-hovered {
+    background-color: #00650e;
+    border-color: transparent;
+    color: #fff; }
+  .button.is-success:focus, .button.is-success.is-focused {
+    border-color: transparent;
+    color: #fff; }
+    .button.is-success:focus:not(:active), .button.is-success.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(0, 132, 18, 0.35); }
+  .button.is-success:active, .button.is-success.is-active {
+    background-color: #00510b;
+    border-color: transparent;
+    color: #fff; }
+
 .button.is-warning {
   background-color: #b55c06;
   border-color: transparent;
-  color: #fff;
-}
-.button.is-warning:hover, .button.is-warning.is-hovered {
-  background-color: #974d05;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-warning:focus, .button.is-warning.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-warning:focus:not(:active), .button.is-warning.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(181, 92, 6, 0.35);
-}
-.button.is-warning:active, .button.is-warning.is-active {
-  background-color: #844304;
-  border-color: transparent;
-  color: #fff;
-}
+  color: #fff; }
+  .button.is-warning:hover, .button.is-warning.is-hovered {
+    background-color: #974d05;
+    border-color: transparent;
+    color: #fff; }
+  .button.is-warning:focus, .button.is-warning.is-focused {
+    border-color: transparent;
+    color: #fff; }
+    .button.is-warning:focus:not(:active), .button.is-warning.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(181, 92, 6, 0.35); }
+  .button.is-warning:active, .button.is-warning.is-active {
+    background-color: #844304;
+    border-color: transparent;
+    color: #fff; }
+
 .button.is-danger {
   background-color: #cd0200;
   border-color: transparent;
-  color: #fff;
-}
-.button.is-danger:hover, .button.is-danger.is-hovered {
-  background-color: #ae0200;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-danger:focus, .button.is-danger.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-danger:focus:not(:active), .button.is-danger.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(205, 2, 0, 0.35);
-}
-.button.is-danger:active, .button.is-danger.is-active {
-  background-color: #9a0200;
-  border-color: transparent;
-  color: #fff;
-}
+  color: #fff; }
+  .button.is-danger:hover, .button.is-danger.is-hovered {
+    background-color: #ae0200;
+    border-color: transparent;
+    color: #fff; }
+  .button.is-danger:focus, .button.is-danger.is-focused {
+    border-color: transparent;
+    color: #fff; }
+    .button.is-danger:focus:not(:active), .button.is-danger.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(205, 2, 0, 0.35); }
+  .button.is-danger:active, .button.is-danger.is-active {
+    background-color: #9a0200;
+    border-color: transparent;
+    color: #fff; }
 
 .message.is-success .message-header {
-  color: #ffffff;
-}
+  color: #ffffff; }
 
 #support-ack-url {
-  color: #fff;
-}
+  color: #fff; }
 
 #support-ack-url a {
   color: #fff;
   border: none;
-  text-decoration: underline;
-}
-#support-ack-url a:hover {
-  color: #1e8bc3;
-}
+  text-decoration: underline; }
+  #support-ack-url a:hover {
+    color: #1e8bc3; }
 
 /** All of the custom styles for arXiv-NG - related to specific graphical style rather than overrides of Bulma - are placed here. **/
 header h1 {
   font-size: 2em;
   font-weight: bold;
-  padding: 0.25em 0 0.5em;
-}
+  padding: .25em 0 .5em; }
+
 header .columns .column {
-  padding-bottom: 0;
-}
+  padding-bottom: 0; }
 
 footer {
-  background-color: hsl(0deg, 0%, 95%);
+  background-color: #f2f2f2;
   color: #000;
-  padding: 1em 2em;
-}
-footer h2 {
-  margin-bottom: 0.5em;
-  text-transform: uppercase;
-}
-footer a {
-  color: #000;
-  font-size: 0.9rem;
-  border-bottom: 1px solid transparent;
-}
-footer a:hover, footer a:active {
-  border-bottom: 1px dotted #005e9d;
-  color: #005e9d;
-}
-footer svg.icon {
-  height: 0.85rem;
-  width: 0.85rem;
-  margin-right: 0.45em;
-  top: 0;
-}
-footer .nav-spaced {
-  line-height: 1.75;
-}
-footer .nav-spaced li {
-  display: flex;
-  align-items: center;
-}
-footer .sorry-app-links .a11y-main-link {
-  font-size: 120%;
-  line-height: 0px;
-}
-footer .sorry-app-links .is-link:not(.button) {
-  border-bottom: 1px dotted #000;
-}
-footer .sorry-app-links .button.is-link.is-outlined {
-  background-color: transparent;
-  border-color: #c3c3c3;
-  color: #ffffff;
-  padding: 0 0.4em 0.1em 0.4em;
-  height: auto;
-  margin-bottom: 0.25em;
-}
-footer .sorry-app-links svg.icon,
-footer .sorry-app-links .button svg.icon,
-footer .sorry-app-links .button svg.icon:first-child:last-child {
-  margin-right: 2px;
-  margin-left: 2px;
-  top: 0.09em;
-  height: 0.85em !important;
-  width: 0.85em !important;
-}
-footer .sorry-app-links .help {
-  font-size: 0.75rem;
-  line-height: 1.75em;
-}
-footer .sorry-app-links a:hover .filter-black {
-  fill: #005e9d;
-}
+  padding: 1em 2em; }
+  footer h2 {
+    margin-bottom: .5em;
+    text-transform: uppercase; }
+  footer a {
+    color: #000;
+    font-size: .9rem;
+    border-bottom: 1px solid transparent; }
+    footer a:hover, footer a:active {
+      border-bottom: 1px dotted #005e9d;
+      color: #005e9d; }
+  footer svg.icon {
+    height: .85rem;
+    width: .85rem;
+    margin-right: .45em;
+    top: 0; }
+  footer .nav-spaced {
+    line-height: 1.75; }
+  footer .nav-spaced li {
+    display: flex;
+    align-items: center; }
+  footer .sorry-app-links .a11y-main-link {
+    font-size: 120%;
+    line-height: 0px; }
+  footer .sorry-app-links .is-link:not(.button) {
+    border-bottom: 1px dotted #000; }
+  footer .sorry-app-links .button.is-link.is-outlined {
+    background-color: transparent;
+    border-color: #c3c3c3;
+    color: #ffffff;
+    padding: 0 .4em .1em .4em;
+    height: auto;
+    margin-bottom: .25em; }
+  footer .sorry-app-links svg.icon,
+  footer .sorry-app-links .button svg.icon,
+  footer .sorry-app-links .button svg.icon:first-child:last-child {
+    margin-right: 2px;
+    margin-left: 2px;
+    top: 0.09em;
+    height: .85em !important;
+    width: .85em !important; }
+  footer .sorry-app-links .help {
+    font-size: .75rem;
+    line-height: 1.75em; }
+  footer .sorry-app-links a:hover .filter-black {
+    fill: #005e9d; }
 
 /**** Primary content default styling ****/
 main {
   padding: 3rem 1.5rem;
-}
-main a {
-  border-bottom: 1px solid transparent;
-  /*font-weight: bold*/
-}
-main a:hover {
-  border-bottom: 1px dotted #086db1;
-}
-main p:not(:last-child),
-main dl:not(:last-child),
-main ol:not(:last-child),
-main ul:not(:last-child),
-main blockquote:not(:last-child),
-main pre:not(:last-child),
-main table:not(:last-child) {
-  margin-bottom: 1em;
-}
-main h1,
-main h2,
-main h3,
-main h4,
-main h5,
-main h6 {
-  font-weight: 600;
-  margin-bottom: 0.8em;
-}
-main h1:not(:first-child),
-main h2:not(:first-child),
-main h3:not(:first-child),
-main h4:not(:first-child),
-main h5:not(:first-child),
-main h6:not(:first-child) {
-  margin-top: 1em;
-}
-main h1 {
-  font-size: 1.75em;
-}
-main h2 {
-  font-size: 1.5em;
-  margin-bottom: 0.5em;
-}
-main h3 {
-  font-size: 1.35em;
-}
-main h4 {
-  font-size: 1.25em;
-}
-main h5 {
-  font-size: 1.15em;
-}
-main ul {
-  list-style: disc outside;
-  margin-left: 2em;
-}
-main ul ul {
-  list-style-type: circle;
-  margin-top: 0.5em;
-}
-main ol {
-  list-style-position: outside;
-  margin-left: 2em;
-  margin-top: 1em;
-}
-main li {
-  margin-bottom: 0.5em;
-}
+  /* Inline links within paragraphs get underlines for accessibility */ }
+  main a:hover {
+    color: #1050a0; }
+  main a:visited {
+    color: #7b2fbe; }
+  main p a, main dd a, main blockquote a, main .content a:not(.button):not(.tag):not(.pagination-link):not(.pagination-previous):not(.pagination-next) {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1px; }
+    main p a:hover, main dd a:hover, main blockquote a:hover, main .content a:not(.button):not(.tag):not(.pagination-link):not(.pagination-previous):not(.pagination-next):hover {
+      text-decoration-thickness: 2px; }
+  main p:not(:last-child),
+  main dl:not(:last-child),
+  main ol:not(:last-child),
+  main ul:not(:last-child),
+  main blockquote:not(:last-child),
+  main pre:not(:last-child),
+  main table:not(:last-child) {
+    margin-bottom: 1em; }
+  main h1,
+  main h2,
+  main h3,
+  main h4,
+  main h5,
+  main h6 {
+    font-weight: 600;
+    margin-bottom: .8em; }
+    main h1:not(:first-child),
+    main h2:not(:first-child),
+    main h3:not(:first-child),
+    main h4:not(:first-child),
+    main h5:not(:first-child),
+    main h6:not(:first-child) {
+      margin-top: 1em; }
+  main h1 {
+    font-size: 1.75em; }
+  main h2 {
+    font-size: 1.5em;
+    margin-bottom: .5em; }
+  main h3 {
+    font-size: 1.35em; }
+  main h4 {
+    font-size: 1.25em; }
+  main h5 {
+    font-size: 1.15em; }
+  main ul {
+    list-style: disc outside;
+    margin-left: 2em; }
+    main ul ul {
+      list-style-type: circle;
+      margin-top: .5em; }
+  main ol {
+    list-style-position: outside;
+    margin-left: 2em;
+    margin-top: 1em; }
+  main li {
+    margin-bottom: .5em; }
 
 .breadcrumb ul {
-  margin-left: 0;
-}
+  margin-left: 0; }
 
 /**** End primary content default styling ****/
 .nav-spaced {
-  line-height: 2;
-}
+  line-height: 2; }
 
 .attribution {
   align-items: center;
   background-color: #222;
   color: #fff;
-  line-height: 1;
-}
-.attribution .level-left {
-  padding: 0.25em;
-}
+  line-height: 1; }
+  .attribution .level-left {
+    padding: .25em; }
 
 .identity {
   background-color: #b31b1b;
   color: #fff;
-  padding: 0 0.75em;
-}
-.identity a {
-  color: #fff;
-  border-bottom: 1px solid transparent;
-}
-.identity a:visited {
-  color: #fff;
-}
-.identity a:hover {
-  border-bottom: 1px dotted #fff;
-  color: #fff;
-}
-.identity .arxiv {
-  margin: 0.5em 0;
-}
-.identity .search-block {
-  margin-top: 0.5em;
-  margin-bottom: 0.25em;
-}
+  padding: 0 .75em; }
+  .identity a {
+    color: #fff;
+    border-bottom: 1px solid transparent; }
+    .identity a:visited {
+      color: #fff; }
+    .identity a:hover {
+      border-bottom: 1px dotted #fff;
+      color: #fff; }
+  .identity .arxiv {
+    margin: .5em 0; }
+  .identity .search-block {
+    margin-top: .5em;
+    margin-bottom: .25em; }
 
 .logo {
   height: 45px;
-  margin: 0.2em;
-  vertical-align: middle;
-}
+  margin: .2em;
+  vertical-align: middle; }
 
 .button.is-cul-darker {
   background-color: #711111;
-  color: hsl(0deg, 0%, 100%);
-  border-color: transparent;
-}
-.button.is-cul-darker:hover, .button.is-cul-darker:active {
-  background-color: #440a0a;
-}
+  color: white;
+  border-color: transparent; }
+  .button.is-cul-darker:hover, .button.is-cul-darker:active {
+    background-color: #440a0a; }
 
 .sponsors {
-  font-size: 0.9em;
+  font-size: .9em;
   font-weight: 600;
   line-height: 1.3;
   margin: 4px;
-  padding-right: 0.75em;
-  text-align: right;
-}
-.sponsors a {
-  color: #fff;
-}
-.sponsors a:visited {
-  color: #fff;
-}
-.sponsors a:hover {
-  background-color: hsl(0deg, 0%, 60%);
-  color: #fff;
-}
+  padding-right: .75em;
+  text-align: right; }
+  .sponsors a {
+    color: #fff; }
+    .sponsors a:visited {
+      color: #fff; }
+    .sponsors a:hover {
+      background-color: #999999;
+      color: #fff; }
 
 .status-code {
   color: #585858;
   font-size: 16em;
-  font-family: "Courier", monospace;
+  font-family: 'Courier', monospace;
   font-weight: bold;
   width: max-content;
   line-height: 1em;
-  padding: 0.1em 0.25em;
+  padding: .1em .25em;
   margin-left: auto !important;
-  margin-right: auto !important;
-}
+  margin-right: auto !important; }
 
 .beta::after {
-  content: "β";
-  color: hsl(0deg, 0%, 80%);
+  content: '\03b2';
+  color: #cccccc;
   font-size: 25em;
   position: absolute;
   top: 0;
   left: 0;
-  line-height: 0.75em;
+  line-height: .75em;
   font-family: serif;
-  z-index: -10;
-}
+  z-index: -10; }
 
 .is-monospace {
-  font-family: monospace;
-}
+  font-family: monospace; }
 
 .button-fancy {
   border-radius: 4px;
@@ -10146,297 +7737,240 @@ main li {
   border-left-color: #cae0ec;
   border-bottom-color: #f3fbff;
   border-right-color: #f3fbff;
-  box-shadow: 2px 2px 3px 1px hsl(0deg, 0%, 80%);
-}
-.button-fancy:hover {
-  border-bottom: 1px solid #f3fbff;
-  color: black;
-}
-.button-fancy span {
-  cursor: pointer;
-  display: inline-block;
-  position: relative;
-  transition: 0.4s;
-}
-.button-fancy span:after {
-  content: "»";
-  position: relative;
-  opacity: 0;
-  top: 1px;
-  right: -5px;
-  padding-left: 10px;
-  transition: 0.5s;
-  font-size: 20px;
-  color: #1772a0;
-}
-.button-fancy:hover span {
-  padding-right: 15px;
-}
-.button-fancy:hover span:after {
-  opacity: 1;
-  right: 0;
-}
+  box-shadow: 2px 2px 3px 1px #cccccc; }
+  .button-fancy:hover {
+    border-bottom: 1px solid #f3fbff;
+    color: black; }
+  .button-fancy span {
+    cursor: pointer;
+    display: inline-block;
+    position: relative;
+    transition: 0.4s; }
+    .button-fancy span:after {
+      content: '\00bb';
+      position: relative;
+      opacity: 0;
+      top: 1px;
+      right: -5px;
+      padding-left: 10px;
+      transition: 0.5s;
+      font-size: 20px;
+      color: #1772a0; }
+  .button-fancy:hover span {
+    padding-right: 15px; }
+    .button-fancy:hover span:after {
+      opacity: 1;
+      right: 0; }
 
 /* specific styles for search lists with classic dl/dt/dd structure and classes */
 .list-identifier {
-  font-weight: 600;
-}
+  font-weight: 600; }
 
 .list-title {
   font-size: 1.25em;
-  font-weight: 600;
-}
+  font-weight: 600; }
 
 dt {
-  margin-top: 1em;
-}
+  margin-top: 1em; }
 
 /* utility styles for forms */
 .fieldset {
-  border: 1px solid hsl(0deg, 0%, 80%);
+  border: 1px solid #cccccc;
   border-radius: 2px;
-  padding: 0.5em 1em 1em 1em;
-  margin: 1em 0;
-}
+  padding: .5em 1em 1em 1em;
+  margin: 1em 0; }
 
 .fieldset.is-warning {
-  border: 1px solid #d47500;
-}
+  border: 1px solid #d47500; }
 
 .fieldset.is-danger {
-  border: 1px solid #cd0200;
-}
+  border: 1px solid #cd0200; }
 
 .legend {
   font-weight: 600;
   background-color: inherit;
-  padding: 0 0.5em;
-  margin-left: -0.5em;
-}
+  padding: 0 .5em;
+  margin-left: -.5em; }
 
 .is-baseline {
-  align-items: baseline;
-}
+  align-items: baseline; }
 
 .is-centered-vertically {
   margin-top: auto !important;
-  margin-bottom: auto !important;
-}
+  margin-bottom: auto !important; }
 
 .is-datefield {
-  max-width: 8rem;
-}
+  max-width: 8rem; }
 
 .is-short-field {
-  max-width: 25rem;
-}
+  max-width: 25rem; }
 
 /* table and file tree styles */
 .is-subdirectory {
-  margin-left: 2em;
-}
+  margin-left: 2em; }
 
 li.is-danger {
   background-color: #fff5f5;
   color: #970503;
   border: 1px solid #cd0200;
-  padding: 2px;
-}
-li.is-danger p {
-  padding-left: 2em;
-}
-li.is-danger p:before {
-  content: "\f071";
-  font-family: "FontAwesome";
-  color: #cd0200;
-  position: relative;
-  left: -0.5em;
-}
+  padding: 2px; }
+  li.is-danger p {
+    padding-left: 2em; }
+    li.is-danger p:before {
+      content: '\f071';
+      font-family: 'FontAwesome';
+      color: #cd0200;
+      position: relative;
+      left: -.5em; }
 
 li.is-warning {
   background-color: #fffaf5;
   color: #5d3605;
   border: 1px solid #d47500;
-  padding: 2px;
-}
-li.is-warning p {
-  padding-left: 2em;
-}
-li.is-warning p:before {
-  content: "\f071";
-  font-family: "FontAwesome";
-  color: #d47500;
-  position: relative;
-  left: -0.5em;
-}
+  padding: 2px; }
+  li.is-warning p {
+    padding-left: 2em; }
+    li.is-warning p:before {
+      content: '\f071';
+      font-family: 'FontAwesome';
+      color: #d47500;
+      position: relative;
+      left: -.5em; }
 
 li.is-success {
   background-color: #f8fdf6;
   color: #1F6B0E;
   border: 1px solid #3CB521;
-  padding: 2px;
-}
-li.is-success p {
-  padding-left: 2em;
-}
-li.is-success p:before {
-  content: "\f058";
-  font-family: "FontAwesome";
-  color: #1F6B0E;
-  position: relative;
-  left: -0.5em;
-}
+  padding: 2px; }
+  li.is-success p {
+    padding-left: 2em; }
+    li.is-success p:before {
+      content: '\f058';
+      font-family: 'FontAwesome';
+      color: #1F6B0E;
+      position: relative;
+      left: -.5em; }
 
 /* whitespace styles */
 .breathe-vertical {
   margin-top: 4rem;
-  margin-bottom: 4rem;
-}
+  margin-bottom: 4rem; }
 
 @media screen and (min-width: 769px) {
   .breathe-horizontal {
     margin-left: 4rem !important;
-    margin-right: 4rem !important;
-  }
-}
+    margin-right: 4rem !important; } }
+
 @media screen and (min-width: 980px) {
   .breathe-horizontal {
     margin-left: 6rem !important;
-    margin-right: 6rem !important;
-  }
-}
+    margin-right: 6rem !important; } }
 
 /* pagination styles */
 .pagination {
   margin-top: 3rem;
-  margin-bottom: 2rem;
-}
+  margin-bottom: 2rem; }
 
 .pagination-list {
-  margin: 0 !important;
-}
+  margin: 0 !important; }
 
 .pagination-list li {
-  list-style: none;
-}
+  list-style: none; }
 
 .pagination-list li + li {
-  margin: 0;
-}
+  margin: 0; }
 
 /* info and help bubbles - moved from submission-ui styles for sitewide use */
 .help-bubble {
   position: relative;
-  display: inline-block;
-}
-.help-bubble:hover .bubble-text {
-  visibility: visible;
-}
-.help-bubble:focus .bubble-text {
-  visibility: visible;
-}
-.help-bubble .bubble-text {
-  position: absolute;
-  visibility: hidden;
-  width: 160px;
-  background-color: #F5FAFE;
-  border: 1px solid #086db1;
-  color: #005e9d;
-  text-align: center;
-  padding: 5px;
-  border-radius: 4px;
-  bottom: 125%;
-  left: 50%;
-  margin-left: -80px;
-  font-size: 0.8rem;
-}
-.help-bubble .bubble-text:after {
-  content: " ";
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  margin-left: -5px;
-  border-width: 5px;
-  border-style: solid;
-  border-color: #086db1 transparent transparent transparent;
-}
+  display: inline-block; }
+  .help-bubble:hover .bubble-text {
+    visibility: visible; }
+  .help-bubble:focus .bubble-text {
+    visibility: visible; }
+  .help-bubble .bubble-text {
+    position: absolute;
+    visibility: hidden;
+    width: 160px;
+    background-color: #F5FAFE;
+    border: 1px solid #1565c0;
+    color: #005e9d;
+    text-align: center;
+    padding: 5px;
+    border-radius: 4px;
+    bottom: 125%;
+    left: 50%;
+    margin-left: -80px;
+    font-size: .8rem; }
+    .help-bubble .bubble-text:after {
+      content: " ";
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      margin-left: -5px;
+      border-width: 5px;
+      border-style: solid;
+      border-color: #1565c0 transparent transparent transparent; }
 
 /*icon styles*/
 svg.icon {
   height: 1em !important;
   width: 1em !important;
-  top: 0.125em;
-  position: relative;
-}
+  top: .125em;
+  position: relative; }
 
 .filter-white {
-  fill: #FFFFFF;
-}
+  fill: #FFFFFF; }
 
 .filter-black {
-  fill: #000000;
-}
+  fill: #000000; }
 
 .filter-grey {
-  fill: #f5f5f5;
-}
+  fill: #f5f5f5; }
 
 .filter-dark_grey {
-  fill: #cccccc;
-}
+  fill: #cccccc; }
 
 .filter-blue {
-  fill: #1c8bd6;
-}
+  fill: #1c8bd6; }
 
 .filter-dark_blue {
-  fill: #086db1;
-}
+  fill: #1565c0; }
 
 .filter-light_red {
-  fill: #e30906;
-}
+  fill: #e30906; }
 
 .filter-red {
-  fill: #cd0200;
-}
+  fill: #cd0200; }
 
 .filter-dark_red {
-  fill: #5a0e0e;
-}
+  fill: #5a0e0e; }
 
 .filter-orange {
-  fill: #d47500;
-}
+  fill: #d47500; }
 
 .filter-dark_orange {
-  fill: #994d04;
-}
+  fill: #994d04; }
 
 .filter-yellow {
-  fill: #d9af14;
-}
+  fill: #d9af14; }
 
 .filter-dark_yellow {
-  fill: #8d7109;
-}
+  fill: #8d7109; }
 
 .filter-green {
-  fill: #009917;
-}
+  fill: #009917; }
 
 .filter-dark_green {
-  fill: #004507;
-}
+  fill: #004507; }
 
 a .icon {
-  transition: fill 0.3s ease;
-}
+  transition: fill 0.3s ease; }
 
 a:hover .filter-grey,
 a:hover .filter-dark_grey {
-  fill: #000000;
-}
+  fill: #000000; }
+
 a:hover .filter-black,
 a:hover .filter-blue,
 a:hover .filter-dark_blue,
@@ -10448,7 +7982,4 @@ a:hover .filter-yellow,
 a:hover .filter-dark_yellow,
 a:hover .filter-green,
 a:hover .filter-dark_green {
-  fill: #f5f5f5;
-}
-
-/*# sourceMappingURL=arxivstyle.css.map */
+  fill: #f5f5f5; }

--- a/arxiv/base/static/sass/_custom.sass
+++ b/arxiv/base/static/sass/_custom.sass
@@ -66,10 +66,17 @@ footer
 main
   padding: 3rem 1.5rem
   a
-    border-bottom: 1px solid transparent
-    /*font-weight: bold*/
     &:hover
-      border-bottom: 1px dotted $blue
+      color: $blue-hover
+    &:visited
+      color: $link-visited
+  /* Inline links within paragraphs get underlines for accessibility */
+  p a, dd a, blockquote a, .content a:not(.button):not(.tag):not(.pagination-link):not(.pagination-previous):not(.pagination-next)
+    text-decoration: underline
+    text-underline-offset: 2px
+    text-decoration-thickness: 1px
+    &:hover
+      text-decoration-thickness: 2px
   p,
   dl,
   ol,

--- a/arxiv/base/static/sass/arxivstyle.sass
+++ b/arxiv/base/static/sass/arxivstyle.sass
@@ -1,9 +1,11 @@
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,700')
 
-// accessible color scheme added 01-27-2020:
-$blue: #086db1
+// accessible color scheme updated per 2026 accessibility audit:
+$blue: #1565c0
+$blue-hover: #1050a0
 $blue-light: #1c8bd6
 $blue-dark: #005e9d
+$link-visited: #7b2fbe
 $red: #cd0200
 $red-light: #e30906
 $red-dark: #b31b1b


### PR DESCRIPTION
## Summary
- Update link color from `#086db1` to `#1565c0` per design spec (5.74:1 contrast on white, passes AA)
- Add hover color `#1050a0` and visited color `#7b2fbe`
- Add underlines to inline links within paragraphs (`text-underline-offset: 2px`, `text-decoration-thickness: 1px`, thicker on hover)
- Standalone links, navigation links, and list links remain without underlines
- Recompiled SASS to CSS

## WCAG criteria addressed
- 1.4.1 Use of Color (A) — audit finding 1962

## Note
This is a site-wide change. The link color affects all arXiv services that use arxiv-base. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)