### PR TITLE
Fix the fastly purge's db code

### DIFF
--- a/arxiv/integration/fastly/purge.py
+++ b/arxiv/integration/fastly/purge.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 SERVICE_IDS=json.loads(settings.FASTLY_SERVICE_IDS)
 MAX_PURGE_KEYS=256
 
-def purge_cache_for_paper(paper_id:str, old_cats:Optional[str]=None):
+def purge_cache_for_paper(paper_id:str, old_cats:Optional[str]=None) -> None:
     """purges all keys needed for an unspecified change to a paper
     clears everything related to the paper, as well as any list and year pages it is on
     old_cats: include this string if the paper undergoes a category change to also purge pages the paper may have been removed from (or new year pages it is added to)
@@ -44,20 +44,23 @@ def _get_category_and_date(arxiv_id:Identifier)-> Tuple[str, Optional[date]]:
     with Session() as session:
         result=(
             session.query(
-            meta.abs_categories, 
-            func.max(up.date)
+                meta.abs_categories,
+                session.query(func.max(up.date))
+                    .filter(up.document_id == meta.document_id)
+                    .filter(up.action != "absonly")
+                    .correlate(meta)
+                    .scalar_subquery()
             )
-            .outerjoin(up, (up.document_id == meta.document_id)  & (up.action != "absonly")) #left join
             .filter(meta.paper_id==arxiv_id.id)
             .filter(meta.is_current==1)
             .first()
         )
-        
+
+    if not result or not result[0]:
+        raise IdentifierException(f'paper id not found: {arxiv_id.id}')
+
     new_cats: str=result[0]
     recent_date: Optional[date] = result[1]  #Papers that havent been changed since 2007 may not be in updates table
-
-    if not new_cats:
-        raise IdentifierException(f'paper id not found: {arxiv_id.id}')
 
     return new_cats, recent_date
 

--- a/arxiv/integration/tests/test_fastly.py
+++ b/arxiv/integration/tests/test_fastly.py
@@ -7,6 +7,8 @@ from fastly.api.purge_api import PurgeApi
 from arxiv.identifier import Identifier, IdentifierException
 from arxiv.integration.fastly.purge import purge_fastly_keys, _purge_category_change, purge_cache_for_paper, _get_category_and_date
 from arxiv.integration.fastly.headers import add_surrogate_key
+from arxiv.db import Session
+from arxiv.db.models import Document, Metadata, Updates
 
 #tests for the purge keys utility function
 class TestPurgeFastlyKeys(unittest.TestCase):
@@ -216,9 +218,59 @@ def test_purge_cache_for_paper(mockToday,mockPurge, mockDBQuery):
     assert sorted(actual_keys) == sorted (expected_keys)
 
 def test_get_category_and_date_nonexstant_ids(db_configed):
-    #there is no paper with this id 
+    #there is no paper with this id
     #also base has no test db so any paper would return none, but this will work even if it gets data
     bad_id=Identifier("0807.9999")
     with pytest.raises(IdentifierException):
         _get_category_and_date(bad_id)
+
+def test_get_category_and_date_with_data(db_configed):
+    """Verifies query works on MySQL (GROUP BY required for ONLY_FULL_GROUP_BY mode)."""
+    paper_id = "0807.1234"
+    update_date = date(2008, 7, 15)
+
+    with Session() as session:
+        doc = Document(
+            paper_id=paper_id,
+            title="Test Paper",
+            submitter_email="test@arxiv.org",
+            dated=0,
+        )
+        session.add(doc)
+        session.flush()
+
+        meta = Metadata(
+            document_id=doc.document_id,
+            paper_id=paper_id,
+            submitter_name="Test User",
+            submitter_email="test@arxiv.org",
+            abs_categories="cs.LG",
+            is_current=1,
+            is_withdrawn=0,
+            version=1,
+        )
+        session.add(meta)
+
+        upd = Updates(
+            document_id=doc.document_id,
+            version=1,
+            date=update_date,
+            action="new",
+            archive="cs",
+            category="cs.LG",
+        )
+        session.add(upd)
+        session.commit()
+        doc_id = doc.document_id
+
+    try:
+        cats, recent_date = _get_category_and_date(Identifier(paper_id))
+        assert cats == "cs.LG"
+        assert recent_date == update_date
+    finally:
+        with Session() as session:
+            session.query(Updates).filter(Updates.document_id == doc_id).delete()
+            session.query(Metadata).filter(Metadata.paper_id == paper_id).delete()
+            session.query(Document).filter(Document.paper_id == paper_id).delete()
+            session.commit()
    

--- a/development/run_mysql_container.py
+++ b/development/run_mysql_container.py
@@ -23,26 +23,23 @@ def is_port_open(host: str, port: int) -> bool:
 def run_mysql_container(port: int, container_name: str ="mysql-test", db_name: str ="testdb",
                         root_password: str = "rootpassword") -> None:
     """Start a mysql docker"""
-    # mysql_image = "mysql:8.0.40"
-    mysql_image = "mysql:5.7.20"
+    mysql_image = "mysql:8.4"
 
     subprocess.run(["docker", "pull", mysql_image], check=True)
-    # subprocess.run(["docker", "kill", container_name], check=False)
     subprocess.run(["docker", "rm", container_name], check=False)
 
-    # for mysql mode, don't use ONLY_FULL_GROUP_BY
     argv = [
         "docker", "run", "-d", "--name", container_name,
         "-e", f"MYSQL_ROOT_PASSWORD={root_password}",
         "-e", "MYSQL_USER=testuser",
         "-e", "MYSQL_PASSWORD=testpassword",
         "-e", "MYSQL_DATABASE=" + db_name,
-        "-e", "MYSQL_SQL_MODE=STRICT_TRANS_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO",
         "-p", f"{port}:3306",
         mysql_image,
-        # Add this for mysql 8 and up to turn off SSL connection
-        # "--require_secure_transport=OFF"
-        "--sql-mode=STRICT_TRANS_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO"
+        "--require_secure_transport=OFF",
+        "--mysql-native-password=ON",
+        "--authentication_policy=mysql_native_password",
+        "--sql-mode=STRICT_TRANS_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,ONLY_FULL_GROUP_BY"
     ]
 
     try:


### PR DESCRIPTION
(a) It could access the non-existing data before raising an exception.

(b) the db statement relied on not having "STRICT_TRANS_TABLES". (it works for sqlite3 as it is lax, and the prod db is okay with it) but, the query can and should select the document record first and then pick the abs_category so the STRICT_TRANS_TABLES does not come in play.

The test checks to see the query works with the option present.

Note that, the old code works for sqlite3 just because sqlite3 doesn't care about it. Since I was near (a), I fixed (b) as well. This does not work for the default installation of MySQL 8.4, fox example.