### PR TITLE
Accept HTTP 204 status code for revoking the user session on Keycloak

### DIFF
--- a/arxiv/auth/openid/oidc_idp.py
+++ b/arxiv/auth/openid/oidc_idp.py
@@ -411,7 +411,7 @@ class ArxivOidcIdpClient:
 
         try:
             response = requests.post(url, headers=header, data=data, timeout=30, verify=self._ssl_cert_verify)
-            if response.status_code == 200:
+            if response.status_code in [200, 204]:
                 self._logger.info("User %s tokens revoked.", user.user_id)
                 return True
             self._logger.warning(f"User %s tokens is not revoked. {response!r}", user.user_id)


### PR DESCRIPTION
IIRC, 200 was working so it might be because newer KC changed the response status code to 204, which is better.