### PR TITLE
[QA-270] Bugfix: empty metadata fields should fail, not raise an exception

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -127,7 +127,6 @@ class FooIsValid(BaseAggregateCheck):
         return cls().run(Inputs(metadata=Metadata(foo=foo)))
 
     _checks = (
-        NotEmpty(on_failure_policy=OnFailurePolicy.REJECT, data="metadata", field="foo"),
         NotTooLong(2000, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="foo"),
         NoBoundaryWhitespace(on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="foo"),
     )

--- a/qa/qa/checks/base.py
+++ b/qa/qa/checks/base.py
@@ -4,14 +4,22 @@ from abc import ABC, abstractmethod
 import re
 
 
-from qa.checks.models import Result, Offset, OnFailurePolicy, Inputs, Disposition
+from qa.checks.models import Result, Offset, OnFailurePolicy, Disposition, QaDataRegistry
 
 
 class MissingDataError(Exception):
     pass
 
 
+class EmptyFieldError(Exception):
+    pass
+
+
 class BaseCheck(ABC):
+    """
+    Raises a MissingDataError if any of the required data are missing.
+    """
+
     name: str
     display_name: str
     id: int
@@ -20,7 +28,7 @@ class BaseCheck(ABC):
     on_failure_policy: OnFailurePolicy
     failure_message: str
 
-    required_inputs: set[str] = set()
+    required_data: set[str] = set()
 
     @property
     def config(self) -> dict:
@@ -29,6 +37,7 @@ class BaseCheck(ABC):
             "display_name": self.display_name,
             "id": self.id,
             "version": self.version,
+            "required_data": self.required_data,
             "on_failure_policy": self.on_failure_policy,
             "failure_message": self.failure_message,
         }
@@ -37,16 +46,15 @@ class BaseCheck(ABC):
         return {
             **self.config,
             "description": self.description,
-            "required_inputs": self.required_inputs,
         }
 
-    def _validate_inputs(self, inputs: Inputs) -> None:
-        for data in self.required_inputs:
-            if getattr(inputs, data) is None:
-                raise MissingDataError(f"Required data '{data}' is missing.")
+    def _validate_data(self, data_registry: QaDataRegistry) -> None:
+        for d in self.required_data:
+            if getattr(data_registry, d) is None:
+                raise MissingDataError(f"Required data '{d}' is missing.")
 
     @abstractmethod
-    def _run(self, inputs: Inputs) -> Result:
+    def _run(self, data_registry: QaDataRegistry) -> Result:
         pass
 
     def _disposition(self, passed: bool) -> Disposition:
@@ -70,13 +78,16 @@ class BaseCheck(ABC):
             offsets=offsets,
         )
 
-    def run(self, inputs: Inputs) -> Result:
-        self._validate_inputs(inputs)
-        return self._run(inputs)
+    def run(self, data_registry: QaDataRegistry) -> Result:
+        self._validate_data(data_registry)
+        return self._run(data_registry)
 
 
 class BaseGenericCheck(BaseCheck):
-    """A check that can be instantiated to run on different fields with different on failure policies."""
+    """
+    An extension of BaseCheck that can be instantiated to run on different fields with different on failure policies.
+    Raises a MissingDataError if either the required data is missing or the field is empty.
+    """
 
     def __init__(
         self,
@@ -90,6 +101,7 @@ class BaseGenericCheck(BaseCheck):
         """
         super().__init__()
         self.on_failure_policy = on_failure_policy
+        self.required_data = {data}
         self.data = data
         self.field = field
 
@@ -100,25 +112,23 @@ class BaseGenericCheck(BaseCheck):
         """
         return {
             **super().config,
-            "data": self.data,
             "field": self.field,
         }
 
-    def _validate_inputs(self, inputs: Inputs) -> None:
-        super()._validate_inputs(inputs)
-        if getattr(inputs, self.data) is None:
-            raise MissingDataError(f"Required data '{self.data}' is missing.")
+    def _validate_data(self, data_registry: QaDataRegistry) -> None:
+        """Validate that the data and field are not missing or empty."""
+        super()._validate_data(data_registry)
 
-        if getattr(getattr(inputs, self.data), self.field, None) is None:
-            raise MissingDataError(f"Required field '{self.data}' '{self.field}' is missing.")
+        if getattr(getattr(data_registry, self.data), self.field) in (None, ""):
+            raise EmptyFieldError(f"Field {self.field} in required data '{self.data}' is empty.")
 
     @abstractmethod
-    def _run(self, inputs: Inputs) -> Result:
+    def _run(self, data_registry: QaDataRegistry) -> Result:
         pass
 
 
 class BaseGenericPatternCheck(BaseGenericCheck):
-    """A generic check that applies a regex pattern (matches are failing)."""
+    """An extension of BaseGenericCheck that applies a regex pattern (matches are failing)."""
 
     _pattern: str
 
@@ -139,9 +149,9 @@ class BaseGenericPatternCheck(BaseGenericCheck):
             "pattern": self._pattern,
         }
 
-    def _run(self, inputs: Inputs) -> Result:
+    def _run(self, data_registry: QaDataRegistry) -> Result:
         """The pattern applied to the configured field should not return any matches."""
-        v = getattr(getattr(inputs, self.data), self.field)
+        v = getattr(getattr(data_registry, self.data), self.field)
 
         offsets = []
 
@@ -159,7 +169,11 @@ class BaseGenericPatternCheck(BaseGenericCheck):
 
 
 class BaseAggregateCheck(BaseCheck):
-    """A check that comprises many generic sub-checks."""
+    """
+    An extension of BaseCheck that runs many generic sub-checks.
+    Raises a MissingDataError if any of the required data is missing.
+    Returns a failure if a field required by a sub-check is empty.
+    """
 
     _checks: tuple[BaseGenericCheck, ...]
 
@@ -169,17 +183,22 @@ class BaseAggregateCheck(BaseCheck):
             "checks": [c._describe() for c in self._checks],
         }
 
-    def _run(self, inputs: Inputs) -> Result:
+    def _run(self, data_registry: QaDataRegistry) -> Result:
         """Run all sub-checks and return results."""
 
         results: list[Result] = []
 
         for check in self._checks:
-            result = check.run(inputs)
-            results.append(result)
+            try:
+                result = check.run(data_registry)
+                results.append(result)
+            except EmptyFieldError:
+                return self._result(passed=False, results=[], message=self.failure_message)
 
-        passed = self._passed(results)
-        return self._result(passed=passed, results=results)
+        if self._passed(results):
+            return self._result(passed=True, results=results)
+        else:
+            return self._result(passed=False, results=results, message=self.failure_message)
 
     def _passed(self, results: list[Result]) -> bool:
         """The aggregate passes unless a sub-check with REJECT policy has failed."""

--- a/qa/qa/checks/generic/author_name.py
+++ b/qa/qa/checks/generic/author_name.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 from arxiv.authors import parse_author_affil
 
 from qa.checks.base import BaseGenericCheck
-from qa.checks.models import Inputs, OnFailurePolicy, Result
+from qa.checks.models import QaDataRegistry, OnFailurePolicy, Result
 
 
 _LLM_NAMES = {
@@ -42,8 +42,8 @@ class BaseAuthorCheck(BaseGenericCheck):
         """Return True if the author passes, False if it fails."""
         ...
 
-    def _run(self, inputs: Inputs) -> Result:
-        v = getattr(getattr(inputs, self.data), self.field)
+    def _run(self, data_registry: QaDataRegistry) -> Result:
+        v = getattr(getattr(data_registry, self.data), self.field)
         for author in parse_author_affil(v):
             keyname, firstname, suffix, *_ = author
             if not self._check_author(keyname, firstname, suffix):

--- a/qa/qa/checks/generic/text.py
+++ b/qa/qa/checks/generic/text.py
@@ -1,6 +1,6 @@
 """Generic text checks."""
 
-from qa.checks.models import Result, Offset, OnFailurePolicy, Inputs
+from qa.checks.models import Result, Offset, OnFailurePolicy, QaDataRegistry
 from qa.checks.base import BaseGenericCheck, BaseGenericPatternCheck
 from qa.checks.generic.all_caps_words import KNOWN_WORDS_IN_ALL_CAPS
 
@@ -24,8 +24,8 @@ class NoExcessiveCapitals(BaseGenericCheck):
     description = "The value does not contain excessive capitals."
     failure_message = "Likely excessive capitalization."
 
-    def _run(self, inputs: Inputs) -> Result:
-        v = getattr(getattr(inputs, self.data), self.field)
+    def _run(self, data_registry: QaDataRegistry) -> Result:
+        v = getattr(getattr(data_registry, self.data), self.field)
 
         num_caps = sum([c.isupper() for c in v])
         num_lower = sum([c.islower() for c in v])
@@ -46,8 +46,8 @@ class NoUnapprovedLongCapsWords(BaseGenericPatternCheck):
 
     _pattern = r"\b[A-Z][A-Z-]*[A-Z]\b"
 
-    def _run(self, inputs: Inputs) -> Result:
-        v = getattr(getattr(inputs, self.data), self.field)
+    def _run(self, data_registry: QaDataRegistry) -> Result:
+        v = getattr(getattr(data_registry, self.data), self.field)
 
         offsets = []
 
@@ -136,8 +136,8 @@ class AllBracketsBalanced(BaseGenericCheck):
     description = "All parentheses, square brackets, and curly braces are properly closed."
     failure_message = "Unbalanced brackets."
 
-    def _run(self, inputs: Inputs) -> Result:
-        v = getattr(getattr(inputs, self.data), self.field)
+    def _run(self, data_registry: QaDataRegistry) -> Result:
+        v = getattr(getattr(data_registry, self.data), self.field)
 
         bracket_pairs = {"(": ")", "[": "]", "{": "}"}
 
@@ -190,8 +190,8 @@ class NotTooLong(BaseGenericCheck):
     def config(self) -> dict:
         return {**super().config, "max_chars": self.max_chars}
 
-    def _run(self, inputs: Inputs) -> Result:
-        v = getattr(getattr(inputs, self.data), self.field)
+    def _run(self, data_registry: QaDataRegistry) -> Result:
+        v = getattr(getattr(data_registry, self.data), self.field)
 
         if len(v) <= self.max_chars:
             return self._result(passed=True)
@@ -226,8 +226,8 @@ class NotTooShort(BaseGenericCheck):
     def config(self) -> dict:
         return {**super().config, "min_chars": self.min_chars}
 
-    def _run(self, inputs: Inputs) -> Result:
-        v = getattr(getattr(inputs, self.data), self.field)
+    def _run(self, data_registry: QaDataRegistry) -> Result:
+        v = getattr(getattr(data_registry, self.data), self.field)
 
         if len(v) >= self.min_chars:
             return self._result(passed=True)
@@ -237,23 +237,6 @@ class NotTooShort(BaseGenericCheck):
             message=self.failure_message,
             offsets=[Offset(start=0, end=len(v))],
         )
-
-
-class NotEmpty(BaseGenericCheck):
-    name = "not_empty"
-    display_name = "Not Empty"
-    id = 1
-    version = "1.0.0"
-    description = "The value is not an empty string."
-    failure_message = "Cannot be empty."
-
-    def _run(self, inputs: Inputs) -> Result:
-        v = getattr(getattr(inputs, self.data), self.field)
-
-        if v != "":
-            return self._result(passed=True)
-
-        return self._result(passed=False, message=self.failure_message)
 
 
 class DoesNotBeginWithTitle(BaseGenericPatternCheck):
@@ -553,8 +536,8 @@ class DoiHasValidFormat(BaseGenericPatternCheck):
 
     _pattern = r"(?i)^(?![0-9][0-9]*\.[0-9][0-9]*/[A-Za-z0-9():;._/-]*$)"
 
-    def _run(self, inputs: Inputs) -> Result:
-        v = getattr(getattr(inputs, self.data), self.field)
+    def _run(self, data_registry: QaDataRegistry) -> Result:
+        v = getattr(getattr(data_registry, self.data), self.field)
         offsets = []
         start = 0
         for doi in v.split():

--- a/qa/qa/checks/metadata/abstract.py
+++ b/qa/qa/checks/metadata/abstract.py
@@ -1,7 +1,7 @@
 """Abstract metadata checks."""
 
 from qa.checks.base import BaseAggregateCheck
-from qa.checks.models import Inputs, OnFailurePolicy, Metadata, Result
+from qa.checks.models import QaDataRegistry, OnFailurePolicy, Metadata, Result
 from qa.checks.generic.text import (
     AllBracketsBalanced,
     DoesNotBeginWithAbstract,
@@ -16,7 +16,6 @@ from qa.checks.generic.text import (
     NoHtmlElements,
     NoUnnecessarySpaceInParens,
     NoUtf8DecodingErrors,
-    NotEmpty,
     NotTooLong,
     NotTooShort,
 )
@@ -32,16 +31,15 @@ class AbstractIsValid(BaseAggregateCheck):
     version = "1.0.0"
     description = "The metadata abstract field is valid."
     on_failure_policy = OnFailurePolicy.REJECT
-    failure_message = "Abstract is invalid."
+    failure_message = "Abstract is invalid or empty."
 
-    required_inputs = {"metadata"}
+    required_data = {"metadata"}
 
     @classmethod
     def check(cls, abstract: str | None) -> Result:
-        return cls().run(Inputs(metadata=Metadata(abstract=abstract)))
+        return cls().run(QaDataRegistry(metadata=Metadata(abstract=abstract)))
 
     _checks = (
-        NotEmpty(on_failure_policy=OnFailurePolicy.REJECT, data="metadata", field="abstract"),
         NotTooShort(5, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="abstract"),
         NotTooLong(2000, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="abstract"),
         DoesNotBeginWithAbstract(on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="abstract"),

--- a/qa/qa/checks/metadata/acm_class.py
+++ b/qa/qa/checks/metadata/acm_class.py
@@ -1,7 +1,7 @@
 """ACM class metadata checks."""
 
 from qa.checks.base import BaseAggregateCheck
-from qa.checks.models import Inputs, OnFailurePolicy, Metadata, Result
+from qa.checks.models import QaDataRegistry, OnFailurePolicy, Metadata, Result
 from qa.checks.generic.text import (
     NotTooLong,
     DoesNotContainUrl,
@@ -25,17 +25,17 @@ class AcmClassIsValid(BaseAggregateCheck):
     on_failure_policy = OnFailurePolicy.REJECT
     failure_message = "ACM class is invalid."
 
-    required_inputs = {"metadata"}
+    required_data = {"metadata"}
 
     @classmethod
     def check(cls, acm_class: str | None) -> Result:
-        return cls().run(Inputs(metadata=Metadata(acm_class=acm_class)))
+        return cls().run(QaDataRegistry(metadata=Metadata(acm_class=acm_class)))
 
-    def _run(self, inputs: Inputs) -> Result:
+    def _run(self, data_registry: QaDataRegistry) -> Result:
         """Both None and empty string are valid and should pass without running sub-checks."""
-        if not inputs.metadata.acm_class:  # type: ignore
+        if data_registry.metadata.acm_class in (None, ""):  # type: ignore
             return self._result(passed=True, results=[])
-        return super()._run(inputs)
+        return super()._run(data_registry)
 
     _checks = (
         NotTooLong(1000, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="acm_class"),

--- a/qa/qa/checks/metadata/authors.py
+++ b/qa/qa/checks/metadata/authors.py
@@ -1,7 +1,7 @@
 """Author metadata checks."""
 
 from qa.checks.base import BaseAggregateCheck
-from qa.checks.models import Inputs, OnFailurePolicy, Metadata, Result
+from qa.checks.models import QaDataRegistry, OnFailurePolicy, Metadata, Result
 from qa.checks.generic.text import (
     AllBracketsBalanced,
     DoesNotBeginWithAuthor,
@@ -18,7 +18,6 @@ from qa.checks.generic.text import (
     NoHtmlElements,
     NoUnnecessarySpaceInParens,
     NoUtf8DecodingErrors,
-    NotEmpty,
     NotTooLong,
     NotTooShort,
 )
@@ -41,16 +40,15 @@ class AuthorsAreValid(BaseAggregateCheck):
     version = "1.0.0"
     description = "The metadata authors field is valid."
     on_failure_policy = OnFailurePolicy.REJECT
-    failure_message = "Authors are invalid."
+    failure_message = "Authors are invalid or empty."
 
-    required_inputs = {"metadata"}
+    required_data = {"metadata"}
 
     @classmethod
     def check(cls, authors: str | None) -> Result:
-        return cls().run(Inputs(metadata=Metadata(authors=authors)))
+        return cls().run(QaDataRegistry(metadata=Metadata(authors=authors)))
 
     _checks = (
-        NotEmpty(on_failure_policy=OnFailurePolicy.REJECT, data="metadata", field="authors"),
         NotTooShort(4, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="authors"),
         NotTooLong(10000, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="authors"),
         DoesNotContainLinebreak(on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="authors"),

--- a/qa/qa/checks/metadata/comments.py
+++ b/qa/qa/checks/metadata/comments.py
@@ -1,7 +1,7 @@
 """Comments metadata checks."""
 
 from qa.checks.base import BaseAggregateCheck
-from qa.checks.models import Inputs, OnFailurePolicy, Metadata, Result
+from qa.checks.models import QaDataRegistry, OnFailurePolicy, Metadata, Result
 from qa.checks.generic.text import (
     NotTooLong,
     DoesNotContainLinebreak,
@@ -28,17 +28,17 @@ class CommentsAreValid(BaseAggregateCheck):
     on_failure_policy = OnFailurePolicy.REJECT
     failure_message = "Comments are invalid."
 
-    required_inputs = {"metadata"}
+    required_data = {"metadata"}
 
     @classmethod
     def check(cls, comments: str | None) -> Result:
-        return cls().run(Inputs(metadata=Metadata(comments=comments)))
+        return cls().run(QaDataRegistry(metadata=Metadata(comments=comments)))
 
-    def _run(self, inputs: Inputs) -> Result:
+    def _run(self, data_registry: QaDataRegistry) -> Result:
         """Both None and empty string are valid and should pass without running sub-checks."""
-        if not inputs.metadata.comments:  # type: ignore
+        if data_registry.metadata.comments in (None, ""):  # type: ignore
             return self._result(passed=True, results=[])
-        return super()._run(inputs)
+        return super()._run(data_registry)
 
     _checks = (
         NotTooLong(10000, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="comments"),

--- a/qa/qa/checks/metadata/doi.py
+++ b/qa/qa/checks/metadata/doi.py
@@ -1,7 +1,7 @@
 """DOI metadata checks."""
 
 from qa.checks.base import BaseAggregateCheck
-from qa.checks.models import Inputs, OnFailurePolicy, Metadata, Result
+from qa.checks.models import QaDataRegistry, OnFailurePolicy, Metadata, Result
 from qa.checks.generic.text import (
     NotTooShort,
     NotTooLong,
@@ -28,17 +28,17 @@ class DoiIsValid(BaseAggregateCheck):
     on_failure_policy = OnFailurePolicy.REJECT
     failure_message = "DOI is invalid."
 
-    required_inputs = {"metadata"}
+    required_data = {"metadata"}
 
     @classmethod
     def check(cls, doi: str | None) -> Result:
-        return cls().run(Inputs(metadata=Metadata(doi=doi)))
+        return cls().run(QaDataRegistry(metadata=Metadata(doi=doi)))
 
-    def _run(self, inputs: Inputs) -> Result:
+    def _run(self, data_registry: QaDataRegistry) -> Result:
         """Both None and empty string are valid and should pass without running sub-checks."""
-        if not inputs.metadata.doi:  # type: ignore
+        if data_registry.metadata.doi in (None, ""):  # type: ignore
             return self._result(passed=True, results=[])
-        return super()._run(inputs)
+        return super()._run(data_registry)
 
     _checks = (
         NotTooShort(10, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="doi"),

--- a/qa/qa/checks/metadata/journal_ref.py
+++ b/qa/qa/checks/metadata/journal_ref.py
@@ -1,7 +1,7 @@
 """Journal reference metadata checks."""
 
 from qa.checks.base import BaseAggregateCheck
-from qa.checks.models import Inputs, OnFailurePolicy, Metadata, Result
+from qa.checks.models import QaDataRegistry, OnFailurePolicy, Metadata, Result
 from qa.checks.generic.text import (
     NotTooShort,
     NotTooLong,
@@ -30,17 +30,17 @@ class JournalRefIsValid(BaseAggregateCheck):
     on_failure_policy = OnFailurePolicy.REJECT
     failure_message = "Journal reference is invalid."
 
-    required_inputs = {"metadata"}
+    required_data = {"metadata"}
 
     @classmethod
     def check(cls, journal_ref: str | None) -> Result:
-        return cls().run(Inputs(metadata=Metadata(journal_ref=journal_ref)))
+        return cls().run(QaDataRegistry(metadata=Metadata(journal_ref=journal_ref)))
 
-    def _run(self, inputs: Inputs) -> Result:
+    def _run(self, data_registry: QaDataRegistry) -> Result:
         """Both None and empty string are valid and should pass without running sub-checks."""
-        if not inputs.metadata.journal_ref:  # type: ignore
+        if data_registry.metadata.journal_ref in (None, ""):  # type: ignore
             return self._result(passed=True, results=[])
-        return super()._run(inputs)
+        return super()._run(data_registry)
 
     _checks = (
         NotTooShort(5, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="journal_ref"),

--- a/qa/qa/checks/metadata/msc_class.py
+++ b/qa/qa/checks/metadata/msc_class.py
@@ -1,7 +1,7 @@
 """MSC class metadata checks."""
 
 from qa.checks.base import BaseAggregateCheck
-from qa.checks.models import Inputs, OnFailurePolicy, Metadata, Result
+from qa.checks.models import QaDataRegistry, OnFailurePolicy, Metadata, Result
 from qa.checks.generic.text import (
     NotTooLong,
     DoesNotContainUrl,
@@ -26,17 +26,17 @@ class MscClassIsValid(BaseAggregateCheck):
     on_failure_policy = OnFailurePolicy.REJECT
     failure_message = "MSC class is invalid."
 
-    required_inputs = {"metadata"}
+    required_data = {"metadata"}
 
     @classmethod
     def check(cls, msc_class: str | None) -> Result:
-        return cls().run(Inputs(metadata=Metadata(msc_class=msc_class)))
+        return cls().run(QaDataRegistry(metadata=Metadata(msc_class=msc_class)))
 
-    def _run(self, inputs: Inputs) -> Result:
+    def _run(self, data_registry: QaDataRegistry) -> Result:
         """Both None and empty string are valid and should pass without running sub-checks."""
-        if not inputs.metadata.msc_class:  # type: ignore
+        if data_registry.metadata.msc_class in (None, ""):  # type: ignore
             return self._result(passed=True, results=[])
-        return super()._run(inputs)
+        return super()._run(data_registry)
 
     _checks = (
         NotTooLong(1000, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="msc_class"),

--- a/qa/qa/checks/metadata/report_num.py
+++ b/qa/qa/checks/metadata/report_num.py
@@ -1,7 +1,7 @@
 """Report number metadata checks."""
 
 from qa.checks.base import BaseAggregateCheck
-from qa.checks.models import Inputs, OnFailurePolicy, Metadata, Result
+from qa.checks.models import QaDataRegistry, OnFailurePolicy, Metadata, Result
 from qa.checks.generic.text import (
     NotTooShort,
     NotTooLong,
@@ -28,17 +28,17 @@ class ReportNumIsValid(BaseAggregateCheck):
     on_failure_policy = OnFailurePolicy.REJECT
     failure_message = "Report number is invalid."
 
-    required_inputs = {"metadata"}
+    required_data = {"metadata"}
 
     @classmethod
     def check(cls, report_num: str | None) -> Result:
-        return cls().run(Inputs(metadata=Metadata(report_num=report_num)))
+        return cls().run(QaDataRegistry(metadata=Metadata(report_num=report_num)))
 
-    def _run(self, inputs: Inputs) -> Result:
+    def _run(self, data_registry: QaDataRegistry) -> Result:
         """Both None and empty string are valid and should pass without running sub-checks."""
-        if not inputs.metadata.report_num:  # type: ignore
+        if data_registry.metadata.report_num in (None, ""):  # type: ignore
             return self._result(passed=True, results=[])
-        return super()._run(inputs)
+        return super()._run(data_registry)
 
     _checks = (
         NotTooShort(4, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="report_num"),

--- a/qa/qa/checks/metadata/title.py
+++ b/qa/qa/checks/metadata/title.py
@@ -1,7 +1,6 @@
 from qa.checks.base import BaseAggregateCheck
-from qa.checks.models import Inputs, OnFailurePolicy, Metadata, Result
+from qa.checks.models import QaDataRegistry, OnFailurePolicy, Metadata, Result
 from qa.checks.generic.text import (
-    NotEmpty,
     NotTooShort,
     NotTooLong,
     DoesNotBeginWithTitle,
@@ -30,16 +29,15 @@ class TitleIsValid(BaseAggregateCheck):
     version = "1.0.0"
     description = "The metadata title field is valid."
     on_failure_policy = OnFailurePolicy.REJECT
-    failure_message = "Title is invalid."
+    failure_message = "Title is invalid or empty."
 
-    required_inputs = {"metadata"}
+    required_data = {"metadata"}
 
     @classmethod
     def check(cls, title: str | None) -> Result:
-        return cls().run(Inputs(metadata=Metadata(title=title)))
+        return cls().run(QaDataRegistry(metadata=Metadata(title=title)))
 
     _checks = (
-        NotEmpty(on_failure_policy=OnFailurePolicy.REJECT, data="metadata", field="title"),
         NotTooShort(5, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="title"),
         NotTooLong(2000, on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="title"),
         DoesNotBeginWithTitle(on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="title"),

--- a/qa/qa/checks/models.py
+++ b/qa/qa/checks/models.py
@@ -85,7 +85,7 @@ class MetadataProtocol(Protocol):
     acm_class: str | None
 
 
-class Inputs(BaseModel):
+class QaDataRegistry(BaseModel):
     """Data dependencies for checks."""
 
     fulltext: str | None = None

--- a/qa/tests/checks/generic/test_text.py
+++ b/qa/tests/checks/generic/test_text.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from qa.checks.base import MissingDataError
-from qa.checks.models import Inputs, Metadata, OnFailurePolicy
+from qa.checks.base import EmptyFieldError, MissingDataError
+from qa.checks.models import QaDataRegistry, Metadata, OnFailurePolicy
 from qa.checks.generic.text import (
     AllBracketsBalanced,
     DoesNotBeginWithTitle,
@@ -19,44 +19,49 @@ from qa.checks.generic.text import (
     NoUnapprovedLongCapsWords,
     NoUnnecessarySpaceInParens,
     NoUtf8DecodingErrors,
-    NotEmpty,
     NotTooLong,
     NotTooShort,
 )
 
 
-def inputs(title: str) -> Inputs:
-    return Inputs(metadata=Metadata(title=title))
+def inputs(title: str | None) -> QaDataRegistry:
+    return QaDataRegistry(metadata=Metadata(title=title))
 
 
 def make(cls, **kwargs):
     return cls(on_failure_policy=OnFailurePolicy.WARN, data="metadata", field="title", **kwargs)
 
 
-class TestNotEmpty:
-    check = make(NotEmpty)
+class TestBaseGenericCheckValidation:
+    check = make(NotTooShort, min_chars=5)
 
-    def test_pass(self):
-        assert self.check.run(inputs("hello")).passed
-
-    def test_pass_on_failure_policy_warn(self):
-        assert self.check.run(inputs("hello")).check_config["on_failure_policy"] == OnFailurePolicy.WARN
-
-    def test_fail_empty(self):
-        result = self.check.run(inputs(""))
-        assert not result.passed
-        assert result.message
-
-    def test_fail_on_failure_policy_warn(self):
-        assert self.check.run(inputs("")).check_config["on_failure_policy"] == OnFailurePolicy.WARN
-
-    def test_fail_missing_field(self):
+    def test_missing_data_raises(self):
         with pytest.raises(MissingDataError):
-            self.check.run(Inputs(metadata=Metadata(title=None)))
+            self.check.run(QaDataRegistry())
 
-    def test_fail_missing_data(self):
+    def test_none_field_raises(self):
+        with pytest.raises(EmptyFieldError):
+            self.check.run(inputs(None))
+
+    def test_empty_field_raises(self):
+        with pytest.raises(EmptyFieldError):
+            self.check.run(inputs(""))
+
+
+class TestBaseGenericPatternCheckValidation:
+    check = make(DoesNotBeginWithTitle)
+
+    def test_missing_data_raises(self):
         with pytest.raises(MissingDataError):
-            self.check.run(Inputs())
+            self.check.run(QaDataRegistry())
+
+    def test_none_field_raises(self):
+        with pytest.raises(EmptyFieldError):
+            self.check.run(inputs(None))
+
+    def test_empty_field_raises(self):
+        with pytest.raises(EmptyFieldError):
+            self.check.run(inputs(""))
 
 
 class TestNotTooShort:
@@ -146,9 +151,6 @@ class TestNoExcessiveCapitals:
 
     def test_fail_greek_caps(self):
         assert not self.check.run(inputs("ΠΡΟΓΡΑΜΜΑΤΙΣΜΟΎ")).passed
-
-    def test_pass_empty(self):
-        assert self.check.run(inputs("")).passed
 
 
 class TestNoUnapprovedLongCapsWords:

--- a/qa/tests/checks/metadata/test_abstract.py
+++ b/qa/tests/checks/metadata/test_abstract.py
@@ -3,7 +3,7 @@
 import pytest
 
 from qa.checks.base import MissingDataError
-from qa.checks.models import OnFailurePolicy, Inputs, Metadata, Result
+from qa.checks.models import OnFailurePolicy, QaDataRegistry, Metadata, Result
 from qa.checks.metadata.abstract import AbstractIsValid
 
 
@@ -65,9 +65,11 @@ class TestAbstractIsValid:
         result = AbstractIsValid.check("")
         assert not result.passed
 
-    def test_fail_empty_has_sub_results(self):
+    def test_fail_empty_short_circuits(self):
         result = AbstractIsValid.check("")
-        assert not sub_result(result, "not_empty").passed
+        assert not result.passed
+        assert result.results == []
+        assert result.message == "Abstract is invalid or empty."
 
     def test_warn_too_short(self):
         result = AbstractIsValid.check("Hi")
@@ -84,18 +86,15 @@ class TestAbstractIsValid:
         assert result.passed
         assert not sub_result(result, "does_not_contain_tex_begin_env").passed
 
-    def test_all_sub_checks_run_on_empty(self):
-        result = AbstractIsValid.check("")
-        assert result.results is not None
-        assert len(result.results) == len(AbstractIsValid._checks)
+    def test_none_field_short_circuits(self):
+        result = AbstractIsValid().run(QaDataRegistry(metadata=Metadata(abstract=None)))
+        assert not result.passed
+        assert result.results == []
+        assert result.message == "Abstract is invalid or empty."
 
     def test_missing_metadata_raises(self):
         with pytest.raises(MissingDataError):
-            AbstractIsValid().run(Inputs())
-
-    def test_none_abstract_raises(self):
-        with pytest.raises(MissingDataError):
-            AbstractIsValid().run(Inputs(metadata=Metadata(abstract=None)))
+            AbstractIsValid().run(QaDataRegistry())
 
     def test_result_has_check_metadata(self):
         result = AbstractIsValid.check("A fine abstract with enough text.")

--- a/qa/tests/checks/metadata/test_acm_class.py
+++ b/qa/tests/checks/metadata/test_acm_class.py
@@ -3,7 +3,7 @@
 import pytest
 
 from qa.checks.base import MissingDataError
-from qa.checks.models import OnFailurePolicy, Inputs, Result
+from qa.checks.models import OnFailurePolicy, QaDataRegistry, Result
 from qa.checks.metadata.acm_class import AcmClassIsValid
 
 
@@ -17,13 +17,13 @@ class TestAcmClassIsValid:
         assert AcmClassIsValid.check("F.2.2; I.2.7").passed
 
     def test_pass_none(self):
-        assert AcmClassIsValid.check(None).passed
+        result = AcmClassIsValid.check(None)
+        assert result.passed
+        assert result.results == []
 
     def test_pass_empty(self):
-        assert AcmClassIsValid.check("").passed
-
-    def test_pass_none_has_no_sub_results(self):
-        result = AcmClassIsValid.check(None)
+        result = AcmClassIsValid.check("")
+        assert result.passed
         assert result.results == []
 
     def test_warn_too_long(self):
@@ -51,7 +51,7 @@ class TestAcmClassIsValid:
 
     def test_missing_metadata_raises(self):
         with pytest.raises(MissingDataError):
-            AcmClassIsValid().run(Inputs())
+            AcmClassIsValid().run(QaDataRegistry())
 
     def test_result_has_check_metadata(self):
         result = AcmClassIsValid.check("F.2.2")

--- a/qa/tests/checks/metadata/test_authors.py
+++ b/qa/tests/checks/metadata/test_authors.py
@@ -3,7 +3,7 @@
 import pytest
 
 from qa.checks.base import MissingDataError
-from qa.checks.models import OnFailurePolicy, Inputs, Metadata, Result
+from qa.checks.models import OnFailurePolicy, QaDataRegistry, Metadata, Result
 from qa.checks.metadata.authors import AuthorsAreValid
 
 
@@ -28,9 +28,11 @@ class TestAuthorsAreValid:
     def test_fail_empty(self):
         assert not AuthorsAreValid.check("").passed
 
-    def test_fail_empty_has_sub_results(self):
+    def test_fail_empty_short_circuits(self):
         result = AuthorsAreValid.check("")
-        assert not sub_result(result, "not_empty").passed
+        assert not result.passed
+        assert result.results == []
+        assert result.message == "Authors are invalid or empty."
 
     def test_warn_too_short(self):
         result = AuthorsAreValid.check("C C")
@@ -264,18 +266,15 @@ class TestAuthorsAreValid:
             "Thomas Brettschneider and Giovanni Volpe and Laurent Helden and Jan Wehr and Clemens Bechinger"
         ).passed
 
-    def test_all_sub_checks_run_on_empty(self):
-        result = AuthorsAreValid.check("")
-        assert result.results is not None
-        assert len(result.results) == len(AuthorsAreValid._checks)
+    def test_none_field_short_circuits(self):
+        result = AuthorsAreValid().run(QaDataRegistry(metadata=Metadata(authors=None)))
+        assert not result.passed
+        assert result.results == []
+        assert result.message == "Authors are invalid or empty."
 
     def test_missing_metadata_raises(self):
         with pytest.raises(MissingDataError):
-            AuthorsAreValid().run(Inputs())
-
-    def test_none_authors_raises(self):
-        with pytest.raises(MissingDataError):
-            AuthorsAreValid().run(Inputs(metadata=Metadata(authors=None)))
+            AuthorsAreValid().run(QaDataRegistry())
 
     def test_result_has_check_metadata(self):
         result = AuthorsAreValid.check("Fred Smith")

--- a/qa/tests/checks/metadata/test_comments.py
+++ b/qa/tests/checks/metadata/test_comments.py
@@ -3,7 +3,7 @@
 import pytest
 
 from qa.checks.base import MissingDataError
-from qa.checks.models import OnFailurePolicy, Inputs, Result
+from qa.checks.models import OnFailurePolicy, QaDataRegistry, Result
 from qa.checks.metadata.comments import CommentsAreValid
 
 
@@ -17,13 +17,13 @@ class TestCommentsAreValid:
         assert CommentsAreValid.check("12 pages, 3 figures").passed
 
     def test_pass_none(self):
-        assert CommentsAreValid.check(None).passed
+        result = CommentsAreValid.check(None)
+        assert result.passed
+        assert result.results == []
 
     def test_pass_empty(self):
-        assert CommentsAreValid.check("").passed
-
-    def test_pass_none_has_no_sub_results(self):
-        result = CommentsAreValid.check(None)
+        result = CommentsAreValid.check("")
+        assert result.passed
         assert result.results == []
 
     def test_warn_too_long(self):
@@ -48,7 +48,7 @@ class TestCommentsAreValid:
 
     def test_missing_metadata_raises(self):
         with pytest.raises(MissingDataError):
-            CommentsAreValid().run(Inputs())
+            CommentsAreValid().run(QaDataRegistry())
 
     def test_result_has_check_metadata(self):
         result = CommentsAreValid.check("12 pages, 3 figures")

--- a/qa/tests/checks/metadata/test_doi.py
+++ b/qa/tests/checks/metadata/test_doi.py
@@ -3,7 +3,7 @@
 import pytest
 
 from qa.checks.base import MissingDataError
-from qa.checks.models import OnFailurePolicy, Inputs, Result
+from qa.checks.models import OnFailurePolicy, QaDataRegistry, Result
 from qa.checks.metadata.doi import DoiIsValid
 
 
@@ -17,13 +17,13 @@ class TestDoiIsValid:
         assert DoiIsValid.check("10.1103/PhysRevLett.132.011001").passed
 
     def test_pass_none(self):
-        assert DoiIsValid.check(None).passed
+        result = DoiIsValid.check(None)
+        assert result.passed
+        assert result.results == []
 
     def test_pass_empty(self):
-        assert DoiIsValid.check("").passed
-
-    def test_pass_none_has_no_sub_results(self):
-        result = DoiIsValid.check(None)
+        result = DoiIsValid.check("")
+        assert result.passed
         assert result.results == []
 
     def test_warn_too_short(self):
@@ -82,7 +82,7 @@ class TestDoiIsValid:
 
     def test_missing_metadata_raises(self):
         with pytest.raises(MissingDataError):
-            DoiIsValid().run(Inputs())
+            DoiIsValid().run(QaDataRegistry())
 
     def test_result_has_check_metadata(self):
         result = DoiIsValid.check("10.1103/PhysRevLett.132.011001")

--- a/qa/tests/checks/metadata/test_journal_ref.py
+++ b/qa/tests/checks/metadata/test_journal_ref.py
@@ -3,7 +3,7 @@
 import pytest
 
 from qa.checks.base import MissingDataError
-from qa.checks.models import OnFailurePolicy, Inputs, Result
+from qa.checks.models import OnFailurePolicy, QaDataRegistry, Result
 from qa.checks.metadata.journal_ref import JournalRefIsValid
 
 
@@ -17,13 +17,13 @@ class TestJournalRefIsValid:
         assert JournalRefIsValid.check("Phys. Rev. Lett. 132, 011001 (2024)").passed
 
     def test_pass_none(self):
-        assert JournalRefIsValid.check(None).passed
+        result = JournalRefIsValid.check(None)
+        assert result.passed
+        assert result.results == []
 
     def test_pass_empty(self):
-        assert JournalRefIsValid.check("").passed
-
-    def test_pass_none_has_no_sub_results(self):
-        result = JournalRefIsValid.check(None)
+        result = JournalRefIsValid.check("")
+        assert result.passed
         assert result.results == []
 
     def test_warn_too_short(self):
@@ -73,7 +73,7 @@ class TestJournalRefIsValid:
 
     def test_missing_metadata_raises(self):
         with pytest.raises(MissingDataError):
-            JournalRefIsValid().run(Inputs())
+            JournalRefIsValid().run(QaDataRegistry())
 
     def test_result_has_check_metadata(self):
         result = JournalRefIsValid.check("Phys. Rev. Lett. 132, 011001 (2024)")

--- a/qa/tests/checks/metadata/test_msc_class.py
+++ b/qa/tests/checks/metadata/test_msc_class.py
@@ -3,7 +3,7 @@
 import pytest
 
 from qa.checks.base import MissingDataError
-from qa.checks.models import OnFailurePolicy, Inputs, Result
+from qa.checks.models import OnFailurePolicy, QaDataRegistry, Result
 from qa.checks.metadata.msc_class import MscClassIsValid
 
 
@@ -17,13 +17,13 @@ class TestMscClassIsValid:
         assert MscClassIsValid.check("35K55; 65M06").passed
 
     def test_pass_none(self):
-        assert MscClassIsValid.check(None).passed
+        result = MscClassIsValid.check(None)
+        assert result.passed
+        assert result.results == []
 
     def test_pass_empty(self):
-        assert MscClassIsValid.check("").passed
-
-    def test_pass_none_has_no_sub_results(self):
-        result = MscClassIsValid.check(None)
+        result = MscClassIsValid.check("")
+        assert result.passed
         assert result.results == []
 
     def test_warn_too_long(self):
@@ -59,7 +59,7 @@ class TestMscClassIsValid:
 
     def test_missing_metadata_raises(self):
         with pytest.raises(MissingDataError):
-            MscClassIsValid().run(Inputs())
+            MscClassIsValid().run(QaDataRegistry())
 
     def test_result_has_check_metadata(self):
         result = MscClassIsValid.check("35K55")

--- a/qa/tests/checks/metadata/test_report_num.py
+++ b/qa/tests/checks/metadata/test_report_num.py
@@ -3,7 +3,7 @@
 import pytest
 
 from qa.checks.base import MissingDataError
-from qa.checks.models import OnFailurePolicy, Inputs, Result
+from qa.checks.models import OnFailurePolicy, QaDataRegistry, Result
 from qa.checks.metadata.report_num import ReportNumIsValid
 
 
@@ -17,13 +17,13 @@ class TestReportNumIsValid:
         assert ReportNumIsValid.check("CERN-EP-2024-001").passed
 
     def test_pass_none(self):
-        assert ReportNumIsValid.check(None).passed
+        result = ReportNumIsValid.check(None)
+        assert result.passed
+        assert result.results == []
 
     def test_pass_empty(self):
-        assert ReportNumIsValid.check("").passed
-
-    def test_pass_none_has_no_sub_results(self):
-        result = ReportNumIsValid.check(None)
+        result = ReportNumIsValid.check("")
+        assert result.passed
         assert result.results == []
 
     def test_warn_too_short(self):
@@ -91,7 +91,7 @@ class TestReportNumIsValid:
 
     def test_missing_metadata_raises(self):
         with pytest.raises(MissingDataError):
-            ReportNumIsValid().run(Inputs())
+            ReportNumIsValid().run(QaDataRegistry())
 
     def test_result_has_check_metadata(self):
         result = ReportNumIsValid.check("CERN-EP-2024-001")

--- a/qa/tests/checks/metadata/test_title.py
+++ b/qa/tests/checks/metadata/test_title.py
@@ -3,7 +3,7 @@
 import pytest
 
 from qa.checks.base import MissingDataError
-from qa.checks.models import OnFailurePolicy, Inputs, Metadata, Result
+from qa.checks.models import OnFailurePolicy, QaDataRegistry, Metadata, Result
 from qa.checks.metadata.title import TitleIsValid
 
 
@@ -25,10 +25,11 @@ class TestTitleIsValid:
         result = TitleIsValid.check("")
         assert not result.passed
 
-    def test_fail_empty_has_sub_results(self):
+    def test_fail_empty_short_circuits(self):
         result = TitleIsValid.check("")
-        not_empty = sub_result(result, "not_empty")
-        assert not not_empty.passed
+        assert not result.passed
+        assert result.results == []
+        assert result.message == "Title is invalid or empty."
 
     def test_warn_too_short(self):
         result = TitleIsValid.check("Tiny")
@@ -69,18 +70,15 @@ class TestTitleIsValid:
         result = TitleIsValid.check(title)
         assert result.passed
 
-    def test_all_sub_checks_run_on_empty(self):
-        result = TitleIsValid.check("")
-        assert result.results is not None
-        assert len(result.results) == len(TitleIsValid._checks)
+    def test_none_field_short_circuits(self):
+        result = TitleIsValid().run(QaDataRegistry(metadata=Metadata(title=None)))
+        assert not result.passed
+        assert result.results == []
+        assert result.message == "Title is invalid or empty."
 
     def test_missing_metadata_raises(self):
         with pytest.raises(MissingDataError):
-            TitleIsValid().run(Inputs())
-
-    def test_none_title_raises(self):
-        with pytest.raises(MissingDataError):
-            TitleIsValid().run(Inputs(metadata=Metadata(title=None)))
+            TitleIsValid().run(QaDataRegistry())
 
     def test_result_has_check_metadata(self):
         result = TitleIsValid.check("A fine title")


### PR DESCRIPTION
This PR updates the base checks in the qa package to return a failure when a required field is empty. Previously they raised an (uncaught) exception.

This PR also renames the "Inputs" model to "QaDataRegistry" to clarify some recent confusion.

Changes made:
- Models: Renamed Inputs to QaDataRegistry.
- Base classes: Added EmptyFieldError for when a required field is None or empty string, distinct from MissingDataError (missing data object). Aggregate checks now catch EmptyFieldError and return a failed result instead of raising.
- Metadata checks: Optional fields (doi, comments, journal_ref, etc.) pass silently when None or "". Required fields (title, abstract, authors) fail with an empty sub-results list and the check's failure message.  
- Tests: Updated to match the new behavior and added coverage for None/"" inputs on all checks.