### PR TITLE
[QA-71] Separate lists of checks

### DIFF
--- a/qa/qa/checks/__init__.py
+++ b/qa/qa/checks/__init__.py
@@ -17,7 +17,7 @@ from qa.checks.submission.type import IsNotAWithdrawal  # noqa
 from qa.checks.fulltext.extraction import TextExtractionSuccessful  # noqa
 from qa.checks.fulltext.structure import FulltextNotTooShort  # noqa
 
-checks: list[BaseCheck] = [
+submit_event_checks: list[BaseCheck] = [
     TitleIsValid(),
     AuthorsAreValid(),
     AbstractIsValid(),
@@ -29,6 +29,11 @@ checks: list[BaseCheck] = [
     AcmClassIsValid(),
     DoesNotExceedTheFileSizeLimit(),
     IsNotAWithdrawal(),
+]
+
+fulltext_checks: list[BaseCheck] = [
     TextExtractionSuccessful(),
     FulltextNotTooShort(),
 ]
+
+checks: list[BaseCheck] = submit_event_checks + fulltext_checks


### PR DESCRIPTION
[Changes from https://github.com/arXiv/arxiv-base/pull/439 on a fresh branch]

This PR exposes two lists of checks - those run in response to the submit event and those run after text extraction - for use in the qa service. the complete list of `checks` is also still provided for the registry.