### PR TITLE
Bugfix: Allow nullable submission fields in SubmitEventInfo

### DIFF
--- a/qa/qa/checks/models.py
+++ b/qa/qa/checks/models.py
@@ -88,12 +88,10 @@ class FulltextReport(BaseReport):
 class SubmitEventInfo(BaseModel):
     """Information about the submission."""
 
-    type: Literal["new", "rep", "wdr", "jref", "cross"] | None = None
-    is_oversize: bool | None = None
-    submitter_name: str | None = None
-    source_format: (
-        Literal["pdf", "tex", "pdftex", "withdrawn", "docx", "invalid", "ps", "html"] | None
-    ) = None
+    type: Literal["new", "rep", "wdr", "jref", "cross"] | None
+    is_oversize: bool | None
+    submitter_name: str | None
+    source_format: Literal["pdf", "tex", "pdftex", "withdrawn", "docx", "invalid", "ps", "html"] | None
 
 
 class SubmitterProfile(BaseModel):

--- a/qa/qa/checks/models.py
+++ b/qa/qa/checks/models.py
@@ -88,10 +88,12 @@ class FulltextReport(BaseReport):
 class SubmitEventInfo(BaseModel):
     """Information about the submission."""
 
-    type: Literal["new", "rep", "wdr", "jref", "cross"]
-    is_oversize: bool
-    submitter_name: str
-    source_format: Literal["pdf", "tex", "pdftex", "withdrawn", "docx", "invalid", "ps", "html"]
+    type: Literal["new", "rep", "wdr", "jref", "cross"] | None = None
+    is_oversize: bool | None = None
+    submitter_name: str | None = None
+    source_format: (
+        Literal["pdf", "tex", "pdftex", "withdrawn", "docx", "invalid", "ps", "html"] | None
+    ) = None
 
 
 class SubmitterProfile(BaseModel):

--- a/qa/qa/checks/submission/user.py
+++ b/qa/qa/checks/submission/user.py
@@ -109,12 +109,13 @@ class AuthorsContainsSubmitterName(BaseCheck):
         authors = data_registry.metadata.authors
 
         submitter_name = data_registry.submit_event_info.submitter_name
-        submitter_names = AuthorsContainsSubmitterName.normalize_author_name(submitter_name).split()
 
         passed = False
 
-        if authors is None:
+        if authors is None or submitter_name is None:
             return self._result(passed=True)
+
+        submitter_names = AuthorsContainsSubmitterName.normalize_author_name(submitter_name).split()
 
         if AuthorsContainsSubmitterName.known_collaboration(authors):
             return self._result(passed=True)

--- a/qa/tests/checks/submission/test_files.py
+++ b/qa/tests/checks/submission/test_files.py
@@ -24,6 +24,12 @@ class TestOversizeCheck:
         with pytest.raises(MissingDataError):
             DoesNotExceedTheFileSizeLimit().run(QaDataRegistry())
 
+    def test_oversize_none_passes(self):
+        sub_metadata = make_test_submit_event_info(is_oversize=None)
+        result = DoesNotExceedTheFileSizeLimit().run(QaDataRegistry(submit_event_info=sub_metadata))
+
+        assert result.passed
+
 
 class TestHtmlFileType:
     def test_htmlfiletype_pass(self):
@@ -41,3 +47,9 @@ class TestHtmlFileType:
     def test_missing_submit_event_info_raises(self):
         with pytest.raises(MissingDataError):
             FileTypeDoesNotRequireReview().run(QaDataRegistry())
+
+    def test_source_format_none_passes(self):
+        sub_metadata = make_test_submit_event_info(source_format=None)
+        result = FileTypeDoesNotRequireReview().run(QaDataRegistry(submit_event_info=sub_metadata))
+
+        assert result.passed

--- a/qa/tests/checks/submission/test_type.py
+++ b/qa/tests/checks/submission/test_type.py
@@ -24,3 +24,9 @@ class TestWithdrawalCheck:
     def test_missing_submit_event_info_raises(self):
         with pytest.raises(MissingDataError):
             IsNotAWithdrawal().run(QaDataRegistry())
+
+    def test_type_none_passes(self):
+        sub_metadata = make_test_submit_event_info(type=None)
+        result = IsNotAWithdrawal().run(QaDataRegistry(submit_event_info=sub_metadata))
+
+        assert result.passed

--- a/qa/tests/checks/test_models.py
+++ b/qa/tests/checks/test_models.py
@@ -3,7 +3,7 @@
 from pydantic import ValidationError
 from unittest import TestCase
 
-from qa.checks.models import BaseReport, Disposition, Flag, Result
+from qa.checks.models import BaseReport, Disposition, Flag, Result, SubmitEventInfo
 
 
 def base_report(
@@ -96,6 +96,31 @@ class TestResultMessages(TestCase):
             ],
         )
         self.assertEqual(result._messages(Disposition.OK), "passed message\nignored message")
+
+
+class TestSubmitEventInfo(TestCase):
+    def test_accepts_explicit_none_for_nullable_fields(self):
+        info = SubmitEventInfo(type=None, is_oversize=None, submitter_name=None, source_format=None)
+        self.assertIsNone(info.type)
+        self.assertIsNone(info.is_oversize)
+        self.assertIsNone(info.submitter_name)
+        self.assertIsNone(info.source_format)
+
+    def test_requires_type_field(self):
+        with self.assertRaises(ValidationError):
+            SubmitEventInfo.model_validate({"is_oversize": None, "submitter_name": None, "source_format": None})
+
+    def test_requires_is_oversize_field(self):
+        with self.assertRaises(ValidationError):
+            SubmitEventInfo.model_validate({"type": None, "submitter_name": None, "source_format": None})
+
+    def test_requires_submitter_name_field(self):
+        with self.assertRaises(ValidationError):
+            SubmitEventInfo.model_validate({"type": None, "is_oversize": None, "source_format": None})
+
+    def test_requires_source_format_field(self):
+        with self.assertRaises(ValidationError):
+            SubmitEventInfo.model_validate({"type": None, "is_oversize": None, "submitter_name": None})
 
 
 class TestFlag(TestCase):


### PR DESCRIPTION
arXiv_submissions.is_oversize, type, source_format, and submitter_name are all nullable in the DB, but SubmitEventInfo declared them as required, causing pubsub validation errors on rows with NULL values. Guard AuthorsContainsSubmitterName against a None submitter_name to avoid a crash now that the field is optional.