### PR TITLE
Add arxiv.schedule: business-calendar and holiday helpers

### DIFF
--- a/arxiv/schedule/__init__.py
+++ b/arxiv/schedule/__init__.py
@@ -1,0 +1,1 @@
+"""Business-calendar and holiday helpers for arXiv's freeze/publish cycle."""

--- a/arxiv/schedule/calendar.py
+++ b/arxiv/schedule/calendar.py
@@ -1,0 +1,250 @@
+"""Business-calendar helpers for arXiv's freeze/publish cycle.
+
+Single source of truth for the business timezone and the daily
+freeze/publish time calculations, so every consumer computes the same
+schedule instead of each keeping its own copy.
+
+The business TZ is a constant (``America/New_York``), not a setting:
+arXiv's publish calendar is tied to a specific physical timezone, so
+configurability buys nothing and creates a drift hazard.
+
+Holiday-aware functions take an injected ``is_holiday`` callable so
+they remain pure / unit-testable; callers pass in a DB-backed callable
+(see ``arxiv.schedule.holidays.is_holiday``) that reads
+``arXiv_holidays``.
+
+Functions accept an optional ``now`` argument so callers can pass an
+explicit timestamp (tests, replays) without monkey-patching ``datetime``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+BUSINESS_TZ = ZoneInfo("America/New_York")
+
+# Freeze occurs at 14:00 (2pm) BUSINESS_TZ daily, weekdays only.
+# Reference: lib/arXiv/Submit/Util.pm:348 (freeze_hour_policy)
+_FREEZE_HOUR = 14
+# Publish (announcement) occurs at 20:00 BUSINESS_TZ.
+# Reference: lib/arXiv/Submit/Util.pm:350 (publish_hour_policy)
+_PUBLISH_HOUR = 20
+
+HolidayLookup = Callable[[date], bool]
+
+
+def _never_holiday(_d: date) -> bool:
+    return False
+
+
+def local_date(dt: datetime) -> date:
+    """Convert an aware datetime to its date in the business TZ."""
+    return dt.astimezone(BUSINESS_TZ).date()
+
+
+def last_freeze_time(now: datetime | None = None, *, is_holiday: HolidayLookup = _never_holiday) -> datetime:
+    """Most recent freeze datetime in the business TZ.
+
+    Freeze is 14:00 weekdays. If ``now`` is before today's freeze the
+    previous day's freeze is returned; weekends (and holidays, when
+    ``is_holiday`` is passed) fall back further. With the default
+    ``is_holiday`` this is a weekends-only walk-back, matching this
+    function's original caller (the daily-listing received-window
+    line, which doesn't need holiday awareness).
+
+    Reference: lib/arXiv/Submit/Util.pm:310-320 (last_freeze_time),
+    Util.pm:220-233 (last_workday).
+    """
+    if now is None:
+        now = datetime.now(BUSINESS_TZ)
+    else:
+        now = now.astimezone(BUSINESS_TZ)
+    candidate = now.date()
+    if now.hour < _FREEZE_HOUR:
+        candidate -= timedelta(days=1)
+    for _ in range(30):
+        if is_freeze_day(candidate, is_holiday=is_holiday):
+            return datetime(
+                candidate.year,
+                candidate.month,
+                candidate.day,
+                _FREEZE_HOUR,
+                tzinfo=BUSINESS_TZ,
+            )
+        candidate -= timedelta(days=1)
+    raise RuntimeError("no freeze day within 30 days; holiday lookup likely broken")
+
+
+def is_freeze_day(d: date, *, is_holiday: HolidayLookup = _never_holiday) -> bool:
+    """Return True iff `d` is a freeze day: Mon-Fri AND not a holiday.
+
+    Freezes happen on workdays (no weekends, no holidays).
+    Reference: lib/arXiv/Submit/Util.pm:273-295 (next_freeze_time loop)
+    + lib/arXiv/Config/Holidays.pm:168-178 (nextWorkDay).
+    """
+    if d.weekday() >= 5:  # Sat=5, Sun=6
+        return False
+    return not is_holiday(d)
+
+
+def is_publish_day(d: date, *, is_holiday: HolidayLookup = _never_holiday) -> bool:
+    """Return True iff `d` is a publish (announcement) day.
+
+    Mon-Thu when not a holiday; Sun only when the previous Friday was
+    not a holiday. Friday and Saturday are NEVER publish days because
+    Friday's freeze publishes on Sunday.
+    Reference: lib/arXiv/Config/Holidays.pm:192-210 (isPublishDay).
+    """
+    wd = d.weekday()  # Mon=0 .. Sun=6
+    if wd in (4, 5):  # Friday, Saturday
+        return False
+    if wd == 6:  # Sunday
+        friday = d - timedelta(days=2)
+        return not is_holiday(friday)
+    # Mon-Thu
+    return not is_holiday(d)
+
+
+def next_freeze_time(now: datetime | None = None, *, is_holiday: HolidayLookup = _never_holiday) -> datetime:
+    """Next freeze datetime (14:00 BUSINESS_TZ) on or after ``now``.
+
+    Boundary: strictly before today's 14:00 returns today's freeze;
+    at or after 14:00 (``now_et.hour >= 14``) advances to the next
+    freeze day. Skips weekends and holidays.
+    Reference: lib/arXiv/Submit/Util.pm:273-295 (next_freeze_time),
+    matches the perl ``>= freeze_hour_policy`` semantics at line 286.
+    """
+    if now is None:
+        now = datetime.now(BUSINESS_TZ)
+    else:
+        now = now.astimezone(BUSINESS_TZ)
+    candidate = now.date()
+    if now.hour >= _FREEZE_HOUR:
+        candidate += timedelta(days=1)
+    # Bounded scan; perl Holidays.pm:nextWorkDay caps at 30.
+    for _ in range(30):
+        if is_freeze_day(candidate, is_holiday=is_holiday):
+            return datetime(
+                candidate.year,
+                candidate.month,
+                candidate.day,
+                _FREEZE_HOUR,
+                tzinfo=BUSINESS_TZ,
+            )
+        candidate += timedelta(days=1)
+    raise RuntimeError("no freeze day within 30 days; holiday lookup likely broken")
+
+
+def next_publish_time(now: datetime | None = None, *, is_holiday: HolidayLookup = _never_holiday) -> datetime:
+    """Next publish datetime (20:00 BUSINESS_TZ) on or after ``now``.
+
+    Boundary: strictly before today's 20:00 returns today's publish;
+    at or after 20:00 (``now_et.hour >= 20``) advances to the next
+    publish day.
+    Reference: lib/arXiv/Submit/Util.pm:103-121 (next_publish_time),
+    matches the perl ``>= publish_hour_policy`` semantics at line 112.
+    """
+    if now is None:
+        now = datetime.now(BUSINESS_TZ)
+    else:
+        now = now.astimezone(BUSINESS_TZ)
+    candidate = now.date()
+    if now.hour >= _PUBLISH_HOUR:
+        candidate += timedelta(days=1)
+    for _ in range(30):
+        if is_publish_day(candidate, is_holiday=is_holiday):
+            return datetime(
+                candidate.year,
+                candidate.month,
+                candidate.day,
+                _PUBLISH_HOUR,
+                tzinfo=BUSINESS_TZ,
+            )
+        candidate += timedelta(days=1)
+    raise RuntimeError("no publish day within 30 days; holiday lookup likely broken")
+
+
+def last_publish_time(now: datetime | None = None, *, is_holiday: HolidayLookup = _never_holiday) -> datetime:
+    """Most recent publish datetime (20:00 BUSINESS_TZ) at or before ``now``.
+
+    The backward-walking counterpart to ``next_publish_time``, for callers
+    that need "when did/does the most recently-due publish run start"
+    rather than "when is the next one." Holiday-aware, unlike
+    ``last_freeze_time``'s simpler weekends-only walk-back (fine for that
+    function's one existing caller -- the daily-listing received-window
+    line -- but not fine for a caller that must not false-fire on a
+    holiday, e.g. production monitoring for a missed publish run).
+
+    Boundary: at or after today's 20:00 returns today's publish time;
+    strictly before walks back to the most recent prior publish day.
+    """
+    if now is None:
+        now = datetime.now(BUSINESS_TZ)
+    else:
+        now = now.astimezone(BUSINESS_TZ)
+    candidate = now.date()
+    if now.hour < _PUBLISH_HOUR:
+        candidate -= timedelta(days=1)
+    for _ in range(30):
+        if is_publish_day(candidate, is_holiday=is_holiday):
+            return datetime(
+                candidate.year,
+                candidate.month,
+                candidate.day,
+                _PUBLISH_HOUR,
+                tzinfo=BUSINESS_TZ,
+            )
+        candidate -= timedelta(days=1)
+    raise RuntimeError("no publish day within 30 days; holiday lookup likely broken")
+
+
+def publish_time(submit_dt: datetime | None = None, *, is_holiday: HolidayLookup = _never_holiday) -> datetime:
+    """The publish datetime for an article submitted at ``submit_dt``.
+
+    NOT the same as ``next_publish_time``: e.g. for a Sunday-morning
+    submission this returns Monday (Sunday's freeze already passed),
+    while ``next_publish_time(now=Sunday morning)`` returns Sunday
+    evening -- that's the next publish *run*, not the one this
+    submission's freeze feeds into.
+
+    Reference: lib/arXiv/Submit/Util.pm:63-76 (publish_time).
+    """
+    freeze = next_freeze_time(submit_dt, is_holiday=is_holiday)
+    return next_publish_time(freeze, is_holiday=is_holiday)
+
+
+def is_between_freeze_and_publish(now: datetime | None = None, *, is_holiday: HolidayLookup = _never_holiday) -> bool:
+    """Whether ``now`` falls between the most recent freeze and the
+    publish run it feeds into (inclusive, with a 1-minute buffer past
+    publish to avoid a race at the exact boundary).
+
+    True e.g. Friday 14:00 through Sunday 20:01 (Friday's freeze
+    publishes Sunday) -- submissions are frozen but not yet announced.
+
+    Reference: lib/arXiv/Submit/Util.pm:376-386 (is_between_freeze_and_publish).
+    """
+    if now is None:
+        now = datetime.now(BUSINESS_TZ)
+    else:
+        now = now.astimezone(BUSINESS_TZ)
+    last_freeze = last_freeze_time(now, is_holiday=is_holiday)
+    next_publish = next_publish_time(last_freeze, is_holiday=is_holiday) + timedelta(minutes=1)
+    return last_freeze <= now <= next_publish
+
+
+def compute_pub_yymmdd(now: datetime | None = None) -> str:
+    """YYMMDD of the publish day corresponding to the last freeze.
+
+    Mon-Thu freeze -> publish same day (20:00 BUSINESS_TZ).
+    Friday freeze -> publish Sunday (Saturday is not a publish day).
+
+    Reference: lib/arXiv/Submit/Util.pm:46-52 (pub_yymmdd).
+    """
+    freeze = last_freeze_time(now)
+    publish_day = freeze
+    if freeze.weekday() == 4:  # Friday -> Sunday
+        publish_day = freeze + timedelta(days=2)
+    publish_time = publish_day.replace(hour=20, minute=0, second=0, microsecond=0)
+    return publish_time.strftime("%y%m%d")

--- a/arxiv/schedule/holidays.py
+++ b/arxiv/schedule/holidays.py
@@ -1,0 +1,39 @@
+"""Shared read-only holiday lookup against ``arXiv_holidays``.
+
+One row per date in America/New_York on which no freeze and no
+announcement run; PK column ``freeze_skip_date``. Backed by the
+``Holiday`` model in ``arxiv.db.models`` and seeded by
+``arxiv_holidays_seed.sql``, kept in sync with the perl
+``Config/Holidays.pm`` array via dual-write until the perl side
+migrates.
+
+A single source of truth so every consumer of ``calendar.py``'s
+``is_holiday`` callable reads the same table the same way, instead of
+each growing its own copy.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.engine import Connection
+from sqlalchemy.orm import Session
+
+from arxiv.db.models import Holiday
+
+
+def is_holiday(conn: Connection | Session, d: date) -> bool:
+    """Whether ``d`` is a row in ``arXiv_holidays``.
+
+    ``conn`` accepts either an Engine ``Connection`` or an ORM ``Session``
+    -- both expose the same ``.execute(select(...))`` shape for this
+    single indexed point select, so a caller with either already open
+    can reuse this without opening a second connection.
+
+    No caching: callers here fire a handful of times per day and this is
+    a single indexed point select. A no-cache implementation makes ops
+    updates to the DB immediately authoritative.
+    """
+    stmt = select(Holiday.freeze_skip_date).where(Holiday.freeze_skip_date == d).limit(1)
+    return conn.execute(stmt).first() is not None

--- a/arxiv/schedule/tests/test_calendar.py
+++ b/arxiv/schedule/tests/test_calendar.py
@@ -1,0 +1,326 @@
+"""Tests for the holiday-aware calendar helpers.
+
+Mirrors the perl semantics in arxiv-lib.git/lib/arXiv/Submit/Util.pm
+(next_freeze_time, next_publish_time) and Holidays.pm (isPublishDay).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from arxiv.schedule.calendar import (
+    BUSINESS_TZ,
+    is_between_freeze_and_publish,
+    is_freeze_day,
+    is_publish_day,
+    last_freeze_time,
+    last_publish_time,
+    next_freeze_time,
+    next_publish_time,
+    publish_time,
+)
+
+ET = BUSINESS_TZ
+
+
+def _make_lookup(*holidays: str):
+    holiday_set = {date.fromisoformat(d) for d in holidays}
+    return lambda d: d in holiday_set
+
+
+# 2026-04-27 is a Monday, 2026-04-28 Tue, ..., 2026-05-01 Fri, 2026-05-02 Sat,
+# 2026-05-03 Sun.
+
+
+def test_is_freeze_day_weekday_no_holiday() -> None:
+    no_holidays = _make_lookup()
+    assert is_freeze_day(date(2026, 4, 27), is_holiday=no_holidays)  # Mon
+    assert is_freeze_day(date(2026, 5, 1), is_holiday=no_holidays)  # Fri
+
+
+def test_is_freeze_day_weekend() -> None:
+    no_holidays = _make_lookup()
+    assert not is_freeze_day(date(2026, 5, 2), is_holiday=no_holidays)  # Sat
+    assert not is_freeze_day(date(2026, 5, 3), is_holiday=no_holidays)  # Sun
+
+
+def test_is_freeze_day_holiday() -> None:
+    holidays = _make_lookup("2026-04-27")
+    assert not is_freeze_day(date(2026, 4, 27), is_holiday=holidays)
+
+
+def test_is_publish_day_mon_thu() -> None:
+    no_holidays = _make_lookup()
+    assert is_publish_day(date(2026, 4, 27), is_holiday=no_holidays)  # Mon
+    assert is_publish_day(date(2026, 4, 30), is_holiday=no_holidays)  # Thu
+
+
+def test_is_publish_day_friday_is_never() -> None:
+    """Friday's freeze publishes on Sunday; Friday itself is not a publish day."""
+    no_holidays = _make_lookup()
+    assert not is_publish_day(date(2026, 5, 1), is_holiday=no_holidays)
+
+
+def test_is_publish_day_saturday_is_never() -> None:
+    no_holidays = _make_lookup()
+    assert not is_publish_day(date(2026, 5, 2), is_holiday=no_holidays)
+
+
+def test_is_publish_day_sunday_after_non_holiday_friday() -> None:
+    no_holidays = _make_lookup()
+    assert is_publish_day(date(2026, 5, 3), is_holiday=no_holidays)
+
+
+def test_is_publish_day_sunday_after_holiday_friday() -> None:
+    """If Friday is a holiday, the Sunday slot is skipped (publishes Monday)."""
+    holidays = _make_lookup("2026-05-01")  # Fri holiday
+    assert not is_publish_day(date(2026, 5, 3), is_holiday=holidays)
+
+
+def test_is_publish_day_holiday_weekday() -> None:
+    holidays = _make_lookup("2026-04-27")
+    assert not is_publish_day(date(2026, 4, 27), is_holiday=holidays)
+
+
+# last_freeze_time --------------------------------------------------------------
+
+
+def test_last_freeze_at_cutoff_returns_today() -> None:
+    now = datetime(2026, 4, 27, 14, 0, tzinfo=ET)  # Mon exactly 14:00
+    out = last_freeze_time(now)
+    assert out == datetime(2026, 4, 27, 14, tzinfo=ET)
+
+
+def test_last_freeze_before_cutoff_walks_back_to_prior_day() -> None:
+    now = datetime(2026, 4, 27, 13, 59, tzinfo=ET)  # Mon before cutoff
+    out = last_freeze_time(now)
+    assert out == datetime(2026, 4, 24, 14, tzinfo=ET)  # prior Friday
+
+
+def test_last_freeze_skips_weekend() -> None:
+    now = datetime(2026, 5, 2, 10, 0, tzinfo=ET)  # Sat, before cutoff
+    out = last_freeze_time(now)
+    assert out == datetime(2026, 5, 1, 14, tzinfo=ET)  # Fri
+
+
+def test_last_freeze_default_ignores_holiday() -> None:
+    """Weekends-only walk-back by default -- matches the pre-existing
+    daily-listing caller, which doesn't pass ``is_holiday``."""
+    holidays = _make_lookup("2026-05-01")  # Fri holiday
+    now = datetime(2026, 5, 2, 10, 0, tzinfo=ET)  # Sat, before cutoff
+    out = last_freeze_time(now)  # no is_holiday passed
+    assert out == datetime(2026, 5, 1, 14, tzinfo=ET)  # still lands on the holiday Friday
+
+
+def test_last_freeze_skips_holiday_when_asked() -> None:
+    holidays = _make_lookup("2026-05-01")  # Fri holiday
+    now = datetime(2026, 5, 2, 10, 0, tzinfo=ET)  # Sat, before cutoff
+    out = last_freeze_time(now, is_holiday=holidays)
+    assert out == datetime(2026, 4, 30, 14, tzinfo=ET)  # prior Thu
+
+
+# next_freeze_time -------------------------------------------------------------
+
+
+def test_next_freeze_before_today_returns_today() -> None:
+    # Mon 2026-04-27 13:59 ET — still before 14:00 cutoff.
+    now = datetime(2026, 4, 27, 13, 59, 0, tzinfo=ET)
+    out = next_freeze_time(now)
+    assert out == datetime(2026, 4, 27, 14, tzinfo=ET)
+
+
+def test_next_freeze_at_cutoff_advances() -> None:
+    # Boundary: exactly 14:00 ET advances to the next freeze day.
+    # Matches perl `>= freeze_hour_policy`.
+    now = datetime(2026, 4, 27, 14, 0, 0, tzinfo=ET)
+    out = next_freeze_time(now)
+    assert out == datetime(2026, 4, 28, 14, tzinfo=ET)
+
+
+def test_next_freeze_skips_weekend() -> None:
+    # Fri 2026-05-01 15:00 ET → after cutoff → next freeze is Mon 2026-05-04.
+    now = datetime(2026, 5, 1, 15, tzinfo=ET)
+    out = next_freeze_time(now)
+    assert out == datetime(2026, 5, 4, 14, tzinfo=ET)
+
+
+def test_next_freeze_skips_holiday() -> None:
+    holidays = _make_lookup("2026-04-28")  # Tue holiday
+    # Mon after cutoff → would land Tue, but Tue is holiday → Wed.
+    now = datetime(2026, 4, 27, 15, tzinfo=ET)
+    out = next_freeze_time(now, is_holiday=holidays)
+    assert out == datetime(2026, 4, 29, 14, tzinfo=ET)
+
+
+def test_next_freeze_accepts_utc_input() -> None:
+    # 18:00 UTC == 14:00 EDT exact boundary → advances.
+    now_utc = datetime(2026, 4, 27, 18, 0, 0, tzinfo=UTC)
+    out = next_freeze_time(now_utc)
+    assert out.astimezone(ET) == datetime(2026, 4, 28, 14, tzinfo=ET)
+
+
+# next_publish_time ------------------------------------------------------------
+
+
+def test_next_publish_before_cutoff_returns_today() -> None:
+    # Mon 2026-04-27 19:59 ET — before 20:00 cutoff.
+    now = datetime(2026, 4, 27, 19, 59, tzinfo=ET)
+    out = next_publish_time(now)
+    assert out == datetime(2026, 4, 27, 20, tzinfo=ET)
+
+
+def test_next_publish_at_cutoff_advances() -> None:
+    now = datetime(2026, 4, 27, 20, 0, tzinfo=ET)
+    out = next_publish_time(now)
+    assert out == datetime(2026, 4, 28, 20, tzinfo=ET)
+
+
+def test_next_publish_friday_publishes_sunday() -> None:
+    # Fri 2026-05-01 21:00 ET. After cutoff → skip Fri (already past),
+    # but next_publish considers candidate Sat (not publish) and Sun
+    # which IS a publish day when Friday wasn't a holiday.
+    now = datetime(2026, 5, 1, 21, tzinfo=ET)
+    out = next_publish_time(now)
+    assert out == datetime(2026, 5, 3, 20, tzinfo=ET)
+
+
+def test_next_publish_friday_holiday_publishes_monday() -> None:
+    holidays = _make_lookup("2026-05-01")
+    now = datetime(2026, 5, 1, 21, tzinfo=ET)
+    out = next_publish_time(now, is_holiday=holidays)
+    assert out == datetime(2026, 5, 4, 20, tzinfo=ET)
+
+
+def test_next_publish_skips_multiday_holiday_stretch() -> None:
+    # Christmas week 2026: Fri 12-25, Tue 12-29, Thu 12-31 (per seed).
+    holidays = _make_lookup("2026-12-25", "2026-12-29", "2026-12-31")
+    # Mon 2026-12-28 21:00 ET → after cutoff → look forward.
+    # Tue 12-29 holiday → skip; Wed 12-30 is a publish day.
+    now = datetime(2026, 12, 28, 21, tzinfo=ET)
+    out = next_publish_time(now, is_holiday=holidays)
+    assert out == datetime(2026, 12, 30, 20, tzinfo=ET)
+
+
+# last_publish_time -------------------------------------------------------------
+
+
+def test_last_publish_at_cutoff_returns_today() -> None:
+    # Mon 2026-04-27 20:00 ET exactly — "at or after" includes the boundary.
+    now = datetime(2026, 4, 27, 20, 0, tzinfo=ET)
+    out = last_publish_time(now)
+    assert out == datetime(2026, 4, 27, 20, tzinfo=ET)
+
+
+def test_last_publish_after_cutoff_returns_today() -> None:
+    now = datetime(2026, 4, 27, 21, tzinfo=ET)
+    out = last_publish_time(now)
+    assert out == datetime(2026, 4, 27, 20, tzinfo=ET)
+
+
+def test_last_publish_before_cutoff_walks_back_to_sunday() -> None:
+    # Mon 2026-04-27 10:00 ET — before today's cutoff, so walk back. Sunday
+    # 2026-04-26 is a publish day (preceding Friday 4-24 not a holiday).
+    now = datetime(2026, 4, 27, 10, tzinfo=ET)
+    out = last_publish_time(now)
+    assert out == datetime(2026, 4, 26, 20, tzinfo=ET)
+
+
+def test_last_publish_skips_friday_saturday() -> None:
+    # Fri 2026-05-01 10:00 ET — before cutoff, walk back. Thursday 4-30 is
+    # the most recent publish day (Fri/Sat are never publish days).
+    now = datetime(2026, 5, 1, 10, tzinfo=ET)
+    out = last_publish_time(now)
+    assert out == datetime(2026, 4, 30, 20, tzinfo=ET)
+
+
+def test_last_publish_holiday_friday_skips_sunday_too() -> None:
+    # Friday 4-24 was a holiday, so Sunday 4-26 is also not a publish day
+    # (its own rule is "not is_holiday(preceding Friday)") -- must walk all
+    # the way back to Thursday 4-23.
+    holidays = _make_lookup("2026-04-24")
+    now = datetime(2026, 4, 27, 10, tzinfo=ET)
+    out = last_publish_time(now, is_holiday=holidays)
+    assert out == datetime(2026, 4, 23, 20, tzinfo=ET)
+
+
+# publish_time -------------------------------------------------------------------
+# Reference table from Util.pm:50-58 (Freeze => Publish): Mon-Thu => same day,
+# Fri => Sunday. A submission after today's freeze rolls to the *next* freeze
+# day first, so its publish day shifts accordingly.
+
+
+def test_publish_time_midweek_submission_same_day() -> None:
+    # Mon 2026-04-27 10:00, before freeze -> today's freeze -> today's publish.
+    now = datetime(2026, 4, 27, 10, tzinfo=ET)
+    out = publish_time(now)
+    assert out == datetime(2026, 4, 27, 20, tzinfo=ET)
+
+
+def test_publish_time_friday_submission_publishes_sunday() -> None:
+    # Fri 2026-05-01 10:00, before freeze -> Friday's freeze -> Sunday's publish.
+    now = datetime(2026, 5, 1, 10, tzinfo=ET)
+    out = publish_time(now)
+    assert out == datetime(2026, 5, 3, 20, tzinfo=ET)
+
+
+def test_publish_time_thursday_after_freeze_publishes_sunday() -> None:
+    # Thu 2026-04-30 21:00, after Thursday's freeze -> next freeze is Friday
+    # -> Friday's freeze publishes Sunday.
+    now = datetime(2026, 4, 30, 21, tzinfo=ET)
+    out = publish_time(now)
+    assert out == datetime(2026, 5, 3, 20, tzinfo=ET)
+
+
+def test_publish_time_saturday_submission_publishes_monday() -> None:
+    # Sat 2026-05-02 10:00 -> no freeze on weekends -> next freeze is Monday
+    # -> Monday's freeze publishes Monday.
+    now = datetime(2026, 5, 2, 10, tzinfo=ET)
+    out = publish_time(now)
+    assert out == datetime(2026, 5, 4, 20, tzinfo=ET)
+
+
+def test_publish_time_holiday_aware() -> None:
+    holidays = _make_lookup("2026-05-01")  # Fri holiday
+    # Thu 2026-04-30 21:00, after Thursday's freeze -> next freeze skips the
+    # holiday Friday -> lands on Monday -> Monday's freeze publishes Monday.
+    now = datetime(2026, 4, 30, 21, tzinfo=ET)
+    out = publish_time(now, is_holiday=holidays)
+    assert out == datetime(2026, 5, 4, 20, tzinfo=ET)
+
+
+# is_between_freeze_and_publish ---------------------------------------------------
+
+
+def test_is_between_true_at_exact_freeze_moment() -> None:
+    now = datetime(2026, 4, 27, 14, 0, tzinfo=ET)  # Mon, exactly freeze
+    assert is_between_freeze_and_publish(now) is True
+
+
+def test_is_between_false_before_freeze() -> None:
+    # Fri 2026-05-01 13:59, Friday's own freeze hasn't happened yet -- the
+    # last freeze was Thursday, whose publish (Thu 20:00) already passed.
+    now = datetime(2026, 5, 1, 13, 59, tzinfo=ET)
+    assert is_between_freeze_and_publish(now) is False
+
+
+def test_is_between_true_over_weekend_after_friday_freeze() -> None:
+    # Fri's freeze publishes Sunday, so Saturday sits inside the window.
+    now = datetime(2026, 5, 2, 10, 0, tzinfo=ET)
+    assert is_between_freeze_and_publish(now) is True
+
+
+def test_is_between_false_just_after_publish_buffer() -> None:
+    # Sunday's publish is 20:00; the 1-minute race buffer closes at 20:01.
+    now = datetime(2026, 5, 3, 20, 2, tzinfo=ET)
+    assert is_between_freeze_and_publish(now) is False
+
+
+def test_is_between_holiday_aware_diverges_from_default() -> None:
+    # With Friday a holiday, Friday's freeze never happens: the last real
+    # freeze was Thursday, and Thursday's publish (20:00 + buffer) is long
+    # past by Saturday morning -- so the holiday-aware answer is False even
+    # though the default (holiday-blind) answer for the same instant is True.
+    holidays = _make_lookup("2026-05-01")
+    now = datetime(2026, 5, 2, 10, 0, tzinfo=ET)
+    assert is_between_freeze_and_publish(now) is True
+    assert is_between_freeze_and_publish(now, is_holiday=holidays) is False

--- a/arxiv/schedule/tests/test_holidays.py
+++ b/arxiv/schedule/tests/test_holidays.py
@@ -1,0 +1,62 @@
+"""Tests for the shared holiday lookup.
+
+An in-memory SQLite ``arXiv_holidays`` table (created from the real
+``Holiday`` model, so schema drift would fail loud) stands in for the
+classic DB.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from arxiv.db.models import Base, Holiday
+from arxiv.schedule.holidays import is_holiday
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def _engine_with_holidays(*holidays: str):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[Holiday.__table__])
+    with engine.begin() as conn:
+        for d in holidays:
+            conn.execute(
+                Holiday.__table__.insert().values(
+                    freeze_skip_date=date.fromisoformat(d),
+                    created_by=1,
+                    created_at=datetime(2026, 1, 1),
+                )
+            )
+    return engine
+
+
+def test_is_holiday_true_for_seeded_date() -> None:
+    engine = _engine_with_holidays("2026-12-25")
+    with engine.connect() as conn:
+        assert is_holiday(conn, date(2026, 12, 25)) is True
+
+
+def test_is_holiday_false_for_other_date() -> None:
+    engine = _engine_with_holidays("2026-12-25")
+    with engine.connect() as conn:
+        assert is_holiday(conn, date(2026, 12, 24)) is False
+
+
+def test_is_holiday_false_with_no_rows() -> None:
+    engine = _engine_with_holidays()
+    with engine.connect() as conn:
+        assert is_holiday(conn, date(2026, 12, 25)) is False
+
+
+def test_is_holiday_accepts_a_session_not_just_a_connection() -> None:
+    """The whole point of accepting a Session as well as a Connection is
+    that a caller with an ORM session already open doesn't need a second
+    connection.
+    """
+    engine = _engine_with_holidays("2026-12-25")
+    session = sessionmaker(bind=engine)()
+    try:
+        assert is_holiday(session, date(2026, 12, 25)) is True
+        assert is_holiday(session, date(2026, 12, 26)) is False
+    finally:
+        session.close()


### PR DESCRIPTION
Ports the freeze/publish time and holiday-lookup logic from publish.git's arxiv-publish-shared package, so downstream consumers can share one source of truth instead of vendoring their own copy. Adds publish_time() and is_between_freeze_and_publish(), and extends last_freeze_time() with the same optional is_holiday awareness the other functions already have, since is_between_freeze_and_publish needs a holiday-correct answer for "most recent freeze".