### PR TITLE
Fix 26 typos in comments, docstrings and one tex2utf key

### DIFF
--- a/arxiv/auth/auth/__init__.py
+++ b/arxiv/auth/auth/__init__.py
@@ -24,7 +24,7 @@ class Auth(object):
 
     Set env var or `Flask.config` `ARXIV_AUTH_DEBUG` to True to get
     additional debugging in the logs. Only use this for short term debugging of
-    configs. This may be used in produciton but should not be left on in production.
+    configs. This may be used in production but should not be left on in production.
 
     Intended for use in a Flask application factory, for example:
 
@@ -38,7 +38,7 @@ class Auth(object):
        def create_web_app() -> Flask:
           app = Flask('someapp')
           app.config.from_pyfile('config.py')
-          Auth(app)   # Registers the before_reques auth check
+          Auth(app)   # Registers the before_request auth check
 
           @app.route("/hello")
           def hello():
@@ -116,7 +116,7 @@ class Auth(object):
 
         if app.config.get('ARXIV_AUTH_DEBUG') or os.getenv('ARXIV_AUTH_DEBUG'):
             self.auth_debug()
-            logger.debug("ARXIV_AUTH_DEBUG is set and auth debug messages to logging is turned on")
+            logger.debug("ARXIV_AUTH_DEBUG is set and auth debug messages to logging are turned on")
 
 
     def load_session(self) -> Optional[Response]:
@@ -132,11 +132,11 @@ class Auth(object):
         """
         # Check the WSGI request environ for the key, which is where the auth
         # middleware puts any unpacked auth information from the request OR any
-        # exceptions that need to be raised withing the request context.
+        # exceptions that need to be raised within the request context.
         req_auth: Optional[Union[domain.Session, Exception]] = \
             request.environ.get(self.auth_session_name)
 
-        # Middlware may raise exception, needs to be raised in to be handled correctly.
+        # Middleware may raise exception, needs to be raised in to be handled correctly.
         if isinstance(req_auth, Exception):
             logger.debug('Middleware passed an exception: %s', req_auth)
             raise req_auth
@@ -147,7 +147,7 @@ class Auth(object):
             else:
                 logger.warning('No legacy DB, will not check tapir auth.')
 
-        # Attach auth to the request so other can access easily. request.auth
+        # Attach auth to the request so others can access easily. request.auth
         setattr(request, self.auth_session_name, req_auth)
         return None
 
@@ -171,7 +171,7 @@ class Auth(object):
         cookies for both arxiv.org and sub.arxiv.org. If this is being
         served at sub.arxiv.org, there is no response that will cause
         the browser to alter its cookie store for arxiv.org. Duplicate
-        cookies must be handled gracefully to for the domain and
+        cookies must be handled gracefully for the domain and
         subdomain to coexist.
 
         The standard way to avoid this problem is to append part of

--- a/arxiv/config/__init__.py
+++ b/arxiv/config/__init__.py
@@ -157,12 +157,12 @@ class Settings(BaseSettings):
     LATEXML_DB_TRANSACTION_ISOLATION_LEVEL: Optional[IsolationLevel] = None
 
     LATEXML_DB_QUERY_TIMEOUT: int = 5
-    """Maximium seconds any query to the latxml DB can run.
+    """Maximum seconds any query to the latexml DB can run.
 
-    The statement will raise an excepton if it runs for longer than this
+    The statement will raise an exception if it runs for longer than this
     time.
 
-    This is intened to prevent a backed up latexml db from blocking arxiv-browse
+    This is intended to prevent a backed up latexml db from blocking arxiv-browse
     from serving pages. See ARXIVCE-2433.
 
     """

--- a/arxiv/db/__init__.py
+++ b/arxiv/db/__init__.py
@@ -79,9 +79,9 @@ try:
     from flask import has_app_context, Flask
     from flask.globals import app_ctx
     def _scope_id() -> int:
-        """Gets an ID used as a key to the sessions from the scopped_session registry.
-        `sqlalchemy.orm.Session` objects are NOT thread safe, but we are using `arxiv.db.session` as if were thread safe.
-        This works by `scopped_session` returning a proxy/registry that uses a different session based on
+        """Gets an ID used as a key to the sessions from the scoped_session registry.
+        `sqlalchemy.orm.Session` objects are NOT thread safe, but we are using `arxiv.db.session` as if it were thread safe.
+        This works by `scoped_session` returning a proxy/registry that uses a different session based on
         what thread is running.
         See https://docs.sqlalchemy.org/en/20/orm/contextual.html#thread-local-scope
         """

--- a/arxiv/integration/fastly/purge.py
+++ b/arxiv/integration/fastly/purge.py
@@ -35,7 +35,7 @@ def purge_cache_for_paper(paper_id:str, old_cats:Optional[str]=None) -> None:
 
 def _get_category_and_date(arxiv_id:Identifier)-> Tuple[str, Optional[date]]:
     """fetches the current categories for a paper as well as the last date it had announced changes to determine if it belongs in recent or new page
-        extra days were added to accomidate for weekends and holidays, 
+        extra days were added to accommodate for weekends and holidays, 
         these will occasionally purge new and recent papers more than is needed, but better to over clear than underclear
     """
     meta=aliased(Metadata)
@@ -60,7 +60,7 @@ def _get_category_and_date(arxiv_id:Identifier)-> Tuple[str, Optional[date]]:
         raise IdentifierException(f'paper id not found: {arxiv_id.id}')
 
     new_cats: str=result[0]
-    recent_date: Optional[date] = result[1]  #Papers that havent been changed since 2007 may not be in updates table
+    recent_date: Optional[date] = result[1]  #Papers that haven't been changed since 2007 may not be in updates table
 
     return new_cats, recent_date
 
@@ -68,7 +68,7 @@ def _purge_category_change(arxiv_id:Identifier, old_cats:Optional[str]=None )-> 
     """determines all list and year pages required for a category change to a paper
         returns list of all keys to purge
         does not include paths for the paper itself
-        assumes categories will be provided as string like from abs_categories feild, but could be improved if categories could be specified in a list
+        assumes categories will be provided as string like from abs_categories field, but could be improved if categories could be specified in a list
     """
     grp_physics=GROUPS['grp_physics']
     new_cats, recent_date= _get_category_and_date(arxiv_id)

--- a/arxiv/taxonomy/category.py
+++ b/arxiv/taxonomy/category.py
@@ -70,7 +70,7 @@ class Group(BaseTaxonomy):
     is_test: Optional[bool] = None
 
     def get_archives(self, include_inactive: bool = False) -> List['Archive'] :
-        """creates a list of all archives withing the group. By default only includes active archives"""
+        """creates a list of all archives within the group. By default only includes active archives"""
         from .definitions import ARCHIVES
         if include_inactive:
             return [archive for archive in ARCHIVES.values() if archive.in_group == self.id]
@@ -90,7 +90,7 @@ class Archive(BaseTaxonomy):
         return GROUPS[self.in_group]
 
     def get_categories(self, include_inactive: bool =False) -> List['Category'] :
-        """creates a list of all categories withing the group. By default only includes active categories"""
+        """creates a list of all categories within the group. By default only includes active categories"""
         from .definitions import CATEGORIES
         if include_inactive:
             return [category for category in CATEGORIES.values() if category.in_archive == self.id]
@@ -98,8 +98,8 @@ class Archive(BaseTaxonomy):
             return [category for category in CATEGORIES.values() if category.in_archive == self.id and category.is_active]
 
     def get_canonical(self) -> Union['Category', 'Archive']:
-        """returns the canonical version of an archive. The main purpose is transforming subsumed archives into their subsumign categories.
-        For most archives this returns the archive itself. In the case of archives that are also categories, it return the Archive version of the archive"""
+        """returns the canonical version of an archive. The main purpose is transforming subsumed archives into their subsuming categories.
+        For most archives this returns the archive itself. In the case of archives that are also categories, it returns the Archive version of the archive"""
         from .definitions import CATEGORIES
         if self.canonical_id!= self.id and self.canonical_id in CATEGORIES:
             return CATEGORIES[self.canonical_id]

--- a/arxiv/util/tex2utf.py
+++ b/arxiv/util/tex2utf.py
@@ -37,7 +37,7 @@ accents = {
     'cG': 0x0122, 'cK': 0x0136, 'cL': 0x013b, 'cN': 0x0145,
     'cR': 0x0156, 'cS': 0x015e, 'cT': 0x0162, 'cc': 0x00e7,
     'ce': 0x0229, 'cg': 0x0123, 'ck': 0x0137, 'cl': 0x013c,
-    # Commented out due ARXIVDEV-2322 (bug reported by PG)
+    # Commented out due to ARXIVDEV-2322 (bug reported by PG)
     # 'ci' : 'i\x{0327}' = chr(0x69).ch(0x327) # i with combining cedilla
     'cn': 0x0146, 'cr': 0x0157, 'cs': 0x015f, 'ct': 0x0163,
     'kA': 0x0104, 'kE': 0x0118, 'kI': 0x012e, 'kO': 0x01ea,
@@ -87,7 +87,7 @@ textgreek = {
     'kappa': 0x03ba, 'lambda': 0x03bb, 'mu': 0x03bc,
     'nu': 0x03bd, 'xi': 0x03be, 'omicron': 0x03bf,
     'pi': 0x03c0, 'rho': 0x03c1, 'varsigma': 0x03c2,
-    'sigma': 0x03c3, 'tau': 0x03c4, 'upsion': 0x03c5,
+    'sigma': 0x03c3, 'tau': 0x03c4, 'upsilon': 0x03c5,
     'varphi': 0x03C6,  # φ
     'phi':  0x03D5,  # ϕ
     'chi': 0x03c7, 'psi': 0x03c8, 'omega': 0x03c9,
@@ -128,7 +128,7 @@ def _textgreek_sub(match: Match) -> str:
 def texch2UTF(acc: str) -> str:
     """Convert single character TeX accents to UTF-8.
 
-    Strip non-whitepsace characters from any sequence not recognized
+    Strip non-whitespace characters from any sequence not recognized
     (hence could return an empty string if there are no word characters
     in the input string).
 
@@ -145,7 +145,7 @@ def tex2utf(tex: str, greek: bool = True) -> str:
 
     :param tex: Text to filter.
     :param greek: If False, do not convert greek letters or ligatures.
-        Greek symbols can cause problems. Ex. \phi is not suppose to
+        Greek symbols can cause problems. Ex. \phi is not supposed to
         look like φ. φ looks like \varphi. See ARXIVNG-1612
     :returns: string, possibly with some TeX replaced with UTF8
     """
@@ -175,7 +175,7 @@ def tex2utf(tex: str, greek: bool = True) -> str:
                  lambda m: texch2UTF(m.group(1) + m.group(2)), utf)
 
     # Accents which have a letter prefix in TeX
-    #  \u{x} u above (breve), \v{x}   v above (caron), \H{x}   double accute...
+    #  \u{x} u above (breve), \v{x}   v above (caron), \H{x}   double acute...
     utf = re.sub(r'\\([Hckoruv])\{([a-zA-Z])\}',
                  lambda m: texch2UTF(m.group(1) + m.group(2)), utf)
 


### PR DESCRIPTION
## Summary

Fix 26 typos across 6 files. All but one are in comments and docstrings.

**Target branch is `develop`**, per the arXiv CONTRIBUTING guide.

- **arxiv/util/tex2utf.py**: `double accute` -> `double acute`; `Commented out due ARXIVDEV-2322` -> `due to`; `non-whitepsace` -> `non-whitespace`; `is not suppose to` -> `is not supposed to`
- **arxiv/db/__init__.py**: `scopped_session` -> `scoped_session` (x2, docstring only - the code already uses the correct `scoped_session`); `as if were thread safe` -> `as if it were thread safe`
- **arxiv/auth/auth/__init__.py**: `produciton` -> `production`; `before_reques` -> `before_request`; `Middlware` -> `Middleware`; `withing` -> `within`; `so other can access` -> `so others can access`; `handled gracefully to for` -> `handled gracefully for`; and the `ARXIV_AUTH_DEBUG` debug log at line 119, `messages to logging is turned on` -> `are turned on`, which makes it identical to the same message already worded correctly at line 109
- **arxiv/integration/fastly/purge.py**: `accomidate` -> `accommodate`; `havent` -> `haven't`; `abs_categories feild` -> `abs_categories field`
- **arxiv/config/__init__.py**: `Maximium` -> `Maximum`; `latxml DB` -> `latexml DB`; `excepton` -> `exception`; `intened` -> `intended` (all in the `LATEXML_DB_QUERY_TIMEOUT` docstring)
- **arxiv/taxonomy/category.py**: `withing` -> `within` (x2); `subsumign` -> `subsuming`; `it return the Archive` -> `it returns the Archive`

## One change is not cosmetic - please review

`arxiv/util/tex2utf.py` line 90 maps TeX macro names to code points and had
`'upsion': 0x03c5`. U+03C5 is GREEK SMALL LETTER UPSILON, and there is no
`'upsilon'` key anywhere else in the table, so today `\upsilon` (the real TeX
macro) is not converted and `\upsion` (not a TeX macro) is. This PR renames the
key to `'upsilon'`. It changes behaviour: `\upsion` will stop resolving. Nothing
in the repository references either spelling apart from this line. Happy to drop
this hunk or add `'upsilon'` as a second key alongside the old one if you would
rather not change existing behaviour.

Everything else is comments/docstrings with no functional effect.


---

Your org-level `CONTRIBUTING.md` recommends working from a ticket. I did not open one first, since this is a documentation-only change of the "bite-sized" kind the same section asks for — happy to file a tracking issue if you would prefer one.